### PR TITLE
study: Canonicalize directional field + parallel transport, consolida…

### DIFF
--- a/experiments/studies/fim_identity_complex_structure.py
+++ b/experiments/studies/fim_identity_complex_structure.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""
+fim_identity_complex_structure.py
+
+Construct and test candidate almost-complex structure fields on the PAM manifold.
+
+Two candidate constructions are tested:
+
+1. response-frame J
+   Built from the local response principal direction rsp_theta
+
+2. identity-frame J
+   Built from the local identity / Fisher direction fim_theta
+
+For each candidate we compute:
+- J_xx, J_xy, J_yx, J_yy
+- J_squared_error
+- transport_J_error
+- alignment with obstruction / spin proxies (if present)
+
+Outputs
+-------
+outputs/fim_identity_complex_structure/
+  complex_structure_nodes.csv
+  complex_structure_summary.txt
+  complex_structure_panel.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from pam.geometry.directional_field import DirectionalField, wrap_angle
+from pam.geometry.parallel_transport import edge_parallel_transport_table
+
+
+@dataclass(frozen=True)
+class Config:
+    nodes_csv: str = "outputs/obs022_scene_bundle/scene_nodes.csv"
+    edges_csv: str = "outputs/obs022_scene_bundle/scene_edges.csv"
+    seam_csv: str = "outputs/obs022_scene_bundle/scene_seam.csv"
+    outdir: str = "outputs/fim_identity_complex_structure"
+    seam_threshold: float = 0.15
+    top_k_labels: int = 10
+
+
+def safe_corr(a: pd.Series, b: pd.Series) -> float:
+    aa = pd.to_numeric(a, errors="coerce")
+    bb = pd.to_numeric(b, errors="coerce")
+    mask = aa.notna() & bb.notna()
+    if int(mask.sum()) < 3:
+        return float("nan")
+    return float(np.corrcoef(aa[mask], bb[mask])[0, 1])
+
+
+def basis_from_theta(theta: float) -> tuple[np.ndarray, np.ndarray]:
+    e1 = np.array([np.cos(theta), np.sin(theta)], dtype=float)
+    e2 = np.array([-e1[1], e1[0]], dtype=float)
+    return e1, e2
+
+
+def J_from_theta(theta: float) -> np.ndarray:
+    """
+    Build J in global coordinates from a local orthonormal frame
+    whose first axis is angle theta.
+
+    J(e1) = e2
+    J(e2) = -e1
+    """
+    e1, e2 = basis_from_theta(theta)
+    # columns are J(e_x), J(e_y) in global basis after basis conversion
+    # equivalently R * J0 * R^{-1}; in 2D this reduces to the standard
+    # complex structure in any orthonormal frame, but we keep explicit construction.
+    R = np.column_stack([e1, e2])
+    J0 = np.array([[0.0, -1.0], [1.0, 0.0]], dtype=float)
+    return R @ J0 @ R.T
+
+
+def J_squared_error(J: np.ndarray) -> float:
+    I = np.eye(2, dtype=float)
+    err = J @ J + I
+    return float(np.linalg.norm(err, ord="fro"))
+
+
+def matrix_transport_error(J_src: np.ndarray, J_dst: np.ndarray, delta_conn: float) -> float:
+    """
+    Transport a (1,1)-tensor by conjugation with the edge rotation:
+        J' = R J R^{-1}
+    and compare with destination J.
+    """
+    c = float(np.cos(delta_conn))
+    s = float(np.sin(delta_conn))
+    R = np.array([[c, -s], [s, c]], dtype=float)
+    J_transported = R @ J_src @ R.T
+    return float(np.linalg.norm(J_transported - J_dst, ord="fro"))
+
+
+def build_node_table(field: DirectionalField) -> pd.DataFrame:
+    nodes = field.nodes.copy()
+
+    rows = []
+    for _, row in nodes.iterrows():
+        node_id = int(row["node_id"])
+        fim_theta = float(row["fim_theta"])
+        rsp_theta = float(row["rsp_theta"])
+
+        J_fim = J_from_theta(fim_theta)
+        J_rsp = J_from_theta(rsp_theta)
+
+        rows.append(
+            {
+                "node_id": node_id,
+                "J_fim_xx": J_fim[0, 0],
+                "J_fim_xy": J_fim[0, 1],
+                "J_fim_yx": J_fim[1, 0],
+                "J_fim_yy": J_fim[1, 1],
+                "J_rsp_xx": J_rsp[0, 0],
+                "J_rsp_xy": J_rsp[0, 1],
+                "J_rsp_yx": J_rsp[1, 0],
+                "J_rsp_yy": J_rsp[1, 1],
+                "J_fim_squared_error": J_squared_error(J_fim),
+                "J_rsp_squared_error": J_squared_error(J_rsp),
+            }
+        )
+
+    out = pd.DataFrame(rows)
+    return nodes.merge(out, on="node_id", how="left")
+
+
+def build_edge_transport_errors(field: DirectionalField) -> pd.DataFrame:
+    nodes = field.nodes.set_index("node_id", drop=False)
+    edge_pt = edge_parallel_transport_table(field)
+
+    rows = []
+    for _, row in edge_pt.iterrows():
+        src_id = int(row["src_id"])
+        dst_id = int(row["dst_id"])
+        delta_conn = np.radians(float(row["delta_connection_theta_deg"]))
+
+        src = nodes.loc[src_id]
+        dst = nodes.loc[dst_id]
+
+        J_fim_src = J_from_theta(float(src["fim_theta"]))
+        J_fim_dst = J_from_theta(float(dst["fim_theta"]))
+        J_rsp_src = J_from_theta(float(src["rsp_theta"]))
+        J_rsp_dst = J_from_theta(float(dst["rsp_theta"]))
+
+        rows.append(
+            {
+                "src_id": src_id,
+                "dst_id": dst_id,
+                "edge_distance_to_seam_mid": 0.5 * (
+                    float(src["distance_to_seam"]) + float(dst["distance_to_seam"])
+                ),
+                "J_fim_transport_error": matrix_transport_error(J_fim_src, J_fim_dst, delta_conn),
+                "J_rsp_transport_error": matrix_transport_error(J_rsp_src, J_rsp_dst, delta_conn),
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+def build_node_transport_summary(edge_df: pd.DataFrame) -> pd.DataFrame:
+    return (
+        edge_df.groupby("src_id", as_index=False)
+        .agg(
+            J_fim_transport_error_mean=("J_fim_transport_error", "mean"),
+            J_fim_transport_error_max=("J_fim_transport_error", "max"),
+            J_rsp_transport_error_mean=("J_rsp_transport_error", "mean"),
+            J_rsp_transport_error_max=("J_rsp_transport_error", "max"),
+        )
+        .rename(columns={"src_id": "node_id"})
+    )
+
+
+def build_summary(nodes: pd.DataFrame, seam_threshold: float) -> str:
+    seam_mask = pd.to_numeric(nodes["distance_to_seam"], errors="coerce") <= seam_threshold
+
+    lines = [
+        "=== FIM Identity Complex Structure Summary ===",
+        "",
+        f"n_nodes = {len(nodes)}",
+        f"seam_threshold = {seam_threshold:.4f}",
+        "",
+        "J^2 + I errors",
+        f"  mean J_fim_squared_error = {float(pd.to_numeric(nodes['J_fim_squared_error'], errors='coerce').mean()):.8f}",
+        f"  mean J_rsp_squared_error = {float(pd.to_numeric(nodes['J_rsp_squared_error'], errors='coerce').mean()):.8f}",
+        "",
+        "Transport consistency",
+        f"  mean J_fim_transport_error_mean = {float(pd.to_numeric(nodes['J_fim_transport_error_mean'], errors='coerce').mean()):.6f}",
+        f"  mean J_rsp_transport_error_mean = {float(pd.to_numeric(nodes['J_rsp_transport_error_mean'], errors='coerce').mean()):.6f}",
+        f"  seam-band mean J_fim_transport_error = {float(pd.to_numeric(nodes.loc[seam_mask, 'J_fim_transport_error_mean'], errors='coerce').mean()):.6f}",
+        f"  off-seam mean J_fim_transport_error  = {float(pd.to_numeric(nodes.loc[~seam_mask, 'J_fim_transport_error_mean'], errors='coerce').mean()):.6f}",
+        f"  seam-band mean J_rsp_transport_error = {float(pd.to_numeric(nodes.loc[seam_mask, 'J_rsp_transport_error_mean'], errors='coerce').mean()):.6f}",
+        f"  off-seam mean J_rsp_transport_error  = {float(pd.to_numeric(nodes.loc[~seam_mask, 'J_rsp_transport_error_mean'], errors='coerce').mean()):.6f}",
+        "",
+        "Correlations",
+        f"  corr(J_fim_transport_error, distance_to_seam) = {safe_corr(nodes['J_fim_transport_error_mean'], nodes['distance_to_seam']):.4f}",
+        f"  corr(J_rsp_transport_error, distance_to_seam) = {safe_corr(nodes['J_rsp_transport_error_mean'], nodes['distance_to_seam']):.4f}",
+        f"  corr(J_fim_transport_error, node_holonomy_proxy) = {safe_corr(nodes['J_fim_transport_error_mean'], nodes.get('node_holonomy_proxy', pd.Series(dtype=float))):.4f}",
+        f"  corr(J_rsp_transport_error, node_holonomy_proxy) = {safe_corr(nodes['J_rsp_transport_error_mean'], nodes.get('node_holonomy_proxy', pd.Series(dtype=float))):.4f}",
+    ]
+    return "\n".join(lines)
+
+
+def render_panel(cfg: Config, nodes: pd.DataFrame, seam: pd.DataFrame, outpath: Path) -> None:
+    seam_mask = pd.to_numeric(nodes["distance_to_seam"], errors="coerce") <= cfg.seam_threshold
+
+    fig = plt.figure(figsize=(16, 9), constrained_layout=True)
+    gs = fig.add_gridspec(2, 2, width_ratios=[3.0, 1.3], height_ratios=[1.0, 1.0])
+
+    ax_main = fig.add_subplot(gs[:, 0])
+    ax_bar = fig.add_subplot(gs[0, 1])
+    ax_sc = fig.add_subplot(gs[1, 1])
+
+    seam_draw = seam.dropna(subset=["mds1", "mds2"]).sort_values("mds1")
+    if len(seam_draw):
+        ax_main.plot(seam_draw["mds1"], seam_draw["mds2"], color="white", linewidth=6.0, alpha=0.65, zorder=1)
+        ax_main.plot(seam_draw["mds1"], seam_draw["mds2"], color="black", linewidth=2.8, alpha=0.96, zorder=2)
+
+    sc = ax_main.scatter(
+        nodes["mds1"],
+        nodes["mds2"],
+        c=pd.to_numeric(nodes["J_rsp_transport_error_mean"], errors="coerce"),
+        cmap="magma",
+        s=95,
+        alpha=0.96,
+        linewidths=0.35,
+        edgecolors="white",
+        zorder=3,
+    )
+
+    seam_nodes = nodes[seam_mask]
+    if len(seam_nodes):
+        ax_main.scatter(
+            seam_nodes["mds1"], seam_nodes["mds2"],
+            s=170, facecolors="none", edgecolors="black", linewidths=1.3, zorder=4
+        )
+
+    top = nodes.sort_values("J_rsp_transport_error_mean", ascending=False).head(cfg.top_k_labels)
+    for _, row in top.iterrows():
+        ax_main.scatter([row["mds1"]], [row["mds2"]], s=145, facecolors="none", edgecolors="#FFD166", linewidths=1.8, zorder=5)
+        ax_main.text(
+            float(row["mds1"]) + 0.05,
+            float(row["mds2"]) + 0.05,
+            f"{int(row['node_id'])}",
+            fontsize=8.5,
+            bbox=dict(boxstyle="round,pad=0.18", fc="white", ec="0.8", alpha=0.9),
+            zorder=6,
+        )
+
+    cbar = fig.colorbar(sc, ax=ax_main, fraction=0.038, pad=0.02)
+    cbar.set_label("J_rsp transport error")
+
+    ax_main.set_title("Candidate almost-complex field transport error", fontsize=17, pad=10)
+    ax_main.set_xlabel("MDS 1")
+    ax_main.set_ylabel("MDS 2")
+    ax_main.grid(alpha=0.08)
+    ax_main.set_aspect("equal", adjustable="box")
+
+    vals = [
+        float(pd.to_numeric(nodes.loc[seam_mask, "J_rsp_transport_error_mean"], errors="coerce").mean()),
+        float(pd.to_numeric(nodes.loc[~seam_mask, "J_rsp_transport_error_mean"], errors="coerce").mean()),
+    ]
+    ax_bar.bar(["seam-band", "off-seam"], vals, alpha=0.9)
+    ax_bar.set_ylabel("mean J_rsp transport error")
+    ax_bar.set_title("Seam localization", fontsize=14, pad=8)
+    ax_bar.grid(alpha=0.15, axis="y")
+
+    x = pd.to_numeric(nodes["distance_to_seam"], errors="coerce")
+    y = pd.to_numeric(nodes["J_rsp_transport_error_mean"], errors="coerce")
+    mask = x.notna() & y.notna()
+    ax_sc.scatter(x[mask], y[mask], s=38, alpha=0.88)
+    ax_sc.set_xlabel("distance to seam")
+    ax_sc.set_ylabel("J_rsp transport error")
+    ax_sc.set_title("Transport error vs seam distance", fontsize=14, pad=8)
+    ax_sc.grid(alpha=0.15)
+    ax_sc.text(
+        0.98, 0.05, f"corr = {safe_corr(y, x):.3f}",
+        transform=ax_sc.transAxes, ha="right", va="bottom", fontsize=10,
+        bbox=dict(boxstyle="round,pad=0.22", fc="white", ec="0.82", alpha=0.9),
+    )
+
+    fig.suptitle("PAM Observatory — Candidate Complex Structure Test", fontsize=21)
+    fig.savefig(outpath, dpi=220)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Test candidate almost-complex structure fields.")
+    parser.add_argument("--nodes-csv", default=Config.nodes_csv)
+    parser.add_argument("--edges-csv", default=Config.edges_csv)
+    parser.add_argument("--seam-csv", default=Config.seam_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--seam-threshold", type=float, default=Config.seam_threshold)
+    parser.add_argument("--top-k-labels", type=int, default=Config.top_k_labels)
+    args = parser.parse_args()
+
+    cfg = Config(
+        nodes_csv=args.nodes_csv,
+        edges_csv=args.edges_csv,
+        seam_csv=args.seam_csv,
+        outdir=args.outdir,
+        seam_threshold=args.seam_threshold,
+        top_k_labels=args.top_k_labels,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    field = DirectionalField.from_csv(
+        cfg.nodes_csv,
+        cfg.edges_csv,
+        connection_theta_col="fim_theta",
+        response_theta_col="rsp_theta",
+    )
+
+    seam = pd.read_csv(cfg.seam_csv)
+    for col in ["mds1", "mds2", "signed_phase", "distance_to_seam"]:
+        if col in seam.columns:
+            seam[col] = pd.to_numeric(seam[col], errors="coerce")
+
+    nodes = build_node_table(field)
+    edge_df = build_edge_transport_errors(field)
+    node_trn = build_node_transport_summary(edge_df)
+    nodes = nodes.merge(node_trn, on="node_id", how="left")
+
+    csv_path = outdir / "complex_structure_nodes.csv"
+    txt_path = outdir / "complex_structure_summary.txt"
+    png_path = outdir / "complex_structure_panel.png"
+
+    nodes.to_csv(csv_path, index=False)
+    txt_path.write_text(build_summary(nodes, cfg.seam_threshold), encoding="utf-8")
+    render_panel(cfg, nodes, seam, png_path)
+
+    print(csv_path)
+    print(txt_path)
+    print(png_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/studies/fim_response_complex_compatibility.py
+++ b/experiments/studies/fim_response_complex_compatibility.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""
+fim_response_complex_compatibility.py
+
+Test whether the local response operator T is compatible with a candidate
+almost-complex structure J on the PAM manifold.
+
+Core idea
+---------
+In 2D, a local almost-complex structure J is easy to define, so the interesting
+question is not whether J exists, but whether the response operator T respects it.
+
+We therefore measure, per node:
+
+    commutator_norm     = || T J - J T ||_F
+    anticommutator_norm = || T J + J T ||_F
+
+for two candidate J fields:
+
+1. J_fim : built from fim_theta
+2. J_rsp : built from rsp_theta
+
+Outputs
+-------
+outputs/fim_response_complex_compatibility/
+  response_complex_compatibility_nodes.csv
+  response_complex_compatibility_summary.txt
+  response_complex_compatibility_panel.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class Config:
+    nodes_csv: str = "outputs/obs022_scene_bundle/scene_nodes.csv"
+    seam_csv: str = "outputs/obs022_scene_bundle/scene_seam.csv"
+    outdir: str = "outputs/fim_response_complex_compatibility"
+    seam_threshold: float = 0.15
+    top_k_labels: int = 10
+
+
+def safe_corr(a: pd.Series, b: pd.Series) -> float:
+    aa = pd.to_numeric(a, errors="coerce")
+    bb = pd.to_numeric(b, errors="coerce")
+    mask = aa.notna() & bb.notna()
+    if int(mask.sum()) < 3:
+        return float("nan")
+    return float(np.corrcoef(aa[mask], bb[mask])[0, 1])
+
+
+def basis_from_theta(theta: float) -> tuple[np.ndarray, np.ndarray]:
+    e1 = np.array([np.cos(theta), np.sin(theta)], dtype=float)
+    e2 = np.array([-e1[1], e1[0]], dtype=float)
+    return e1, e2
+
+
+def J_from_theta(theta: float) -> np.ndarray:
+    """
+    Build the canonical 2D almost-complex structure in the local orthonormal frame
+    oriented by theta, then express it in global coordinates.
+
+    In 2D Euclidean coordinates this reduces to the standard J, but we keep the
+    construction explicit for clarity and future generalization.
+    """
+    e1, e2 = basis_from_theta(theta)
+    R = np.column_stack([e1, e2])
+    J0 = np.array([[0.0, -1.0], [1.0, 0.0]], dtype=float)
+    return R @ J0 @ R.T
+
+
+def fro_norm(M: np.ndarray) -> float:
+    return float(np.linalg.norm(M, ord="fro"))
+
+
+def commutator(A: np.ndarray, B: np.ndarray) -> np.ndarray:
+    return A @ B - B @ A
+
+
+def anticommutator(A: np.ndarray, B: np.ndarray) -> np.ndarray:
+    return A @ B + B @ A
+
+
+def response_matrix(row: pd.Series) -> np.ndarray | None:
+    cols = ["T_xx", "T_xy", "T_yx", "T_yy"]
+    if not all(c in row.index for c in cols):
+        return None
+    vals = [pd.to_numeric(row[c], errors="coerce") for c in cols]
+    if any(pd.isna(v) for v in vals):
+        return None
+    return np.array([[float(vals[0]), float(vals[1])], [float(vals[2]), float(vals[3])]], dtype=float)
+
+
+def build_node_table(nodes: pd.DataFrame) -> pd.DataFrame:
+    rows: list[dict] = []
+
+    for _, row in nodes.iterrows():
+        node_id = int(row["node_id"])
+        fim_theta = pd.to_numeric(row.get("fim_theta"), errors="coerce")
+        rsp_theta = pd.to_numeric(row.get("rsp_theta"), errors="coerce")
+        T = response_matrix(row)
+
+        out = {"node_id": node_id}
+
+        if pd.notna(fim_theta):
+            J_fim = J_from_theta(float(fim_theta))
+            out.update(
+                {
+                    "J_fim_xx": J_fim[0, 0],
+                    "J_fim_xy": J_fim[0, 1],
+                    "J_fim_yx": J_fim[1, 0],
+                    "J_fim_yy": J_fim[1, 1],
+                }
+            )
+        else:
+            J_fim = None
+            out.update(
+                {
+                    "J_fim_xx": np.nan,
+                    "J_fim_xy": np.nan,
+                    "J_fim_yx": np.nan,
+                    "J_fim_yy": np.nan,
+                }
+            )
+
+        if pd.notna(rsp_theta):
+            J_rsp = J_from_theta(float(rsp_theta))
+            out.update(
+                {
+                    "J_rsp_xx": J_rsp[0, 0],
+                    "J_rsp_xy": J_rsp[0, 1],
+                    "J_rsp_yx": J_rsp[1, 0],
+                    "J_rsp_yy": J_rsp[1, 1],
+                }
+            )
+        else:
+            J_rsp = None
+            out.update(
+                {
+                    "J_rsp_xx": np.nan,
+                    "J_rsp_xy": np.nan,
+                    "J_rsp_yx": np.nan,
+                    "J_rsp_yy": np.nan,
+                }
+            )
+
+        for prefix, J in [("fim", J_fim), ("rsp", J_rsp)]:
+            if T is None or J is None:
+                out[f"commutator_norm_{prefix}"] = np.nan
+                out[f"anticommutator_norm_{prefix}"] = np.nan
+                out[f"commutator_trace_{prefix}"] = np.nan
+                out[f"anticommutator_trace_{prefix}"] = np.nan
+            else:
+                C = commutator(T, J)
+                A = anticommutator(T, J)
+                out[f"commutator_norm_{prefix}"] = fro_norm(C)
+                out[f"anticommutator_norm_{prefix}"] = fro_norm(A)
+                out[f"commutator_trace_{prefix}"] = float(np.trace(C))
+                out[f"anticommutator_trace_{prefix}"] = float(np.trace(A))
+
+        rows.append(out)
+
+    compat = pd.DataFrame(rows)
+    return nodes.merge(compat, on="node_id", how="left")
+
+
+def build_summary(nodes: pd.DataFrame, seam_threshold: float) -> str:
+    seam_mask = pd.to_numeric(nodes["distance_to_seam"], errors="coerce") <= seam_threshold
+
+    lines = [
+        "=== FIM Response Complex Compatibility Summary ===",
+        "",
+        f"n_nodes = {len(nodes)}",
+        f"seam_threshold = {seam_threshold:.4f}",
+        "",
+        "Mean commutator norms",
+        f"  mean commutator_norm_fim = {float(pd.to_numeric(nodes['commutator_norm_fim'], errors='coerce').mean()):.6f}",
+        f"  mean commutator_norm_rsp = {float(pd.to_numeric(nodes['commutator_norm_rsp'], errors='coerce').mean()):.6f}",
+        "",
+        "Mean anticommutator norms",
+        f"  mean anticommutator_norm_fim = {float(pd.to_numeric(nodes['anticommutator_norm_fim'], errors='coerce').mean()):.6f}",
+        f"  mean anticommutator_norm_rsp = {float(pd.to_numeric(nodes['anticommutator_norm_rsp'], errors='coerce').mean()):.6f}",
+        "",
+        "Seam localization",
+        f"  seam-band mean commutator_norm_fim = {float(pd.to_numeric(nodes.loc[seam_mask, 'commutator_norm_fim'], errors='coerce').mean()):.6f}",
+        f"  off-seam mean commutator_norm_fim  = {float(pd.to_numeric(nodes.loc[~seam_mask, 'commutator_norm_fim'], errors='coerce').mean()):.6f}",
+        f"  seam-band mean commutator_norm_rsp = {float(pd.to_numeric(nodes.loc[seam_mask, 'commutator_norm_rsp'], errors='coerce').mean()):.6f}",
+        f"  off-seam mean commutator_norm_rsp  = {float(pd.to_numeric(nodes.loc[~seam_mask, 'commutator_norm_rsp'], errors='coerce').mean()):.6f}",
+        "",
+        "Correlations",
+        f"  corr(commutator_norm_fim, distance_to_seam) = {safe_corr(nodes['commutator_norm_fim'], nodes['distance_to_seam']):.4f}",
+        f"  corr(commutator_norm_rsp, distance_to_seam) = {safe_corr(nodes['commutator_norm_rsp'], nodes['distance_to_seam']):.4f}",
+        f"  corr(commutator_norm_fim, node_holonomy_proxy) = {safe_corr(nodes['commutator_norm_fim'], nodes.get('node_holonomy_proxy', pd.Series(dtype=float))):.4f}",
+        f"  corr(commutator_norm_rsp, node_holonomy_proxy) = {safe_corr(nodes['commutator_norm_rsp'], nodes.get('node_holonomy_proxy', pd.Series(dtype=float))):.4f}",
+        "",
+        "Top incompatibility nodes (rsp frame)",
+    ]
+
+    top = nodes.sort_values("commutator_norm_rsp", ascending=False).head(10)
+    for _, row in top.iterrows():
+        lines.append(
+            f"  node_id={int(row['node_id'])}, "
+            f"r={float(row['r']):.4f}, alpha={float(row['alpha']):.4f}, "
+            f"commutator_norm_rsp={float(row['commutator_norm_rsp']):.6f}, "
+            f"anticommutator_norm_rsp={float(row['anticommutator_norm_rsp']):.6f}, "
+            f"distance_to_seam={float(row['distance_to_seam']):.4f}"
+        )
+
+    return "\n".join(lines)
+
+
+def render_panel(cfg: Config, nodes: pd.DataFrame, seam: pd.DataFrame, outpath: Path) -> None:
+    seam_mask = pd.to_numeric(nodes["distance_to_seam"], errors="coerce") <= cfg.seam_threshold
+
+    fig = plt.figure(figsize=(16, 9), constrained_layout=True)
+    gs = fig.add_gridspec(2, 2, width_ratios=[3.0, 1.3], height_ratios=[1.0, 1.0])
+
+    ax_main = fig.add_subplot(gs[:, 0])
+    ax_bar = fig.add_subplot(gs[0, 1])
+    ax_sc = fig.add_subplot(gs[1, 1])
+
+    seam_draw = seam.dropna(subset=["mds1", "mds2"]).sort_values("mds1")
+    if len(seam_draw):
+        ax_main.plot(seam_draw["mds1"], seam_draw["mds2"], color="white", linewidth=6.0, alpha=0.65, zorder=1)
+        ax_main.plot(seam_draw["mds1"], seam_draw["mds2"], color="black", linewidth=2.8, alpha=0.96, zorder=2)
+
+    sc = ax_main.scatter(
+        nodes["mds1"],
+        nodes["mds2"],
+        c=pd.to_numeric(nodes["commutator_norm_rsp"], errors="coerce"),
+        cmap="magma",
+        s=95,
+        alpha=0.96,
+        linewidths=0.35,
+        edgecolors="white",
+        zorder=3,
+    )
+
+    seam_nodes = nodes[seam_mask]
+    if len(seam_nodes):
+        ax_main.scatter(
+            seam_nodes["mds1"],
+            seam_nodes["mds2"],
+            s=170,
+            facecolors="none",
+            edgecolors="black",
+            linewidths=1.3,
+            zorder=4,
+        )
+
+    top = nodes.sort_values("commutator_norm_rsp", ascending=False).head(cfg.top_k_labels)
+    for _, row in top.iterrows():
+        ax_main.scatter(
+            [row["mds1"]],
+            [row["mds2"]],
+            s=145,
+            facecolors="none",
+            edgecolors="#FFD166",
+            linewidths=1.8,
+            zorder=5,
+        )
+        ax_main.text(
+            float(row["mds1"]) + 0.05,
+            float(row["mds2"]) + 0.05,
+            f"{int(row['node_id'])}",
+            fontsize=8.5,
+            bbox=dict(boxstyle="round,pad=0.18", fc="white", ec="0.8", alpha=0.9),
+            zorder=6,
+        )
+
+    cbar = fig.colorbar(sc, ax=ax_main, fraction=0.038, pad=0.02)
+    cbar.set_label("||T J_rsp - J_rsp T||_F")
+
+    ax_main.set_title("Response / complex-structure incompatibility", fontsize=17, pad=10)
+    ax_main.set_xlabel("MDS 1")
+    ax_main.set_ylabel("MDS 2")
+    ax_main.grid(alpha=0.08)
+    ax_main.set_aspect("equal", adjustable="box")
+    ax_main.text(
+        0.02,
+        0.97,
+        "black seam = detected phase boundary\nblack rings = seam neighborhood\nyellow labels = highest incompatibility nodes",
+        transform=ax_main.transAxes,
+        va="top",
+        ha="left",
+        fontsize=9,
+        bbox=dict(boxstyle="round,pad=0.25", fc="white", ec="0.8", alpha=0.9),
+    )
+
+    vals = [
+        float(pd.to_numeric(nodes.loc[seam_mask, "commutator_norm_rsp"], errors="coerce").mean()),
+        float(pd.to_numeric(nodes.loc[~seam_mask, "commutator_norm_rsp"], errors="coerce").mean()),
+    ]
+    ax_bar.bar(["seam-band", "off-seam"], vals, alpha=0.9)
+    ax_bar.set_ylabel("mean commutator norm")
+    ax_bar.set_title("Seam localization", fontsize=14, pad=8)
+    ax_bar.grid(alpha=0.15, axis="y")
+
+    x = pd.to_numeric(nodes["distance_to_seam"], errors="coerce")
+    y = pd.to_numeric(nodes["commutator_norm_rsp"], errors="coerce")
+    mask = x.notna() & y.notna()
+    ax_sc.scatter(x[mask], y[mask], s=38, alpha=0.88)
+    ax_sc.set_xlabel("distance to seam")
+    ax_sc.set_ylabel("commutator norm")
+    ax_sc.set_title("Incompatibility vs seam distance", fontsize=14, pad=8)
+    ax_sc.grid(alpha=0.15)
+    ax_sc.text(
+        0.98,
+        0.05,
+        f"corr = {safe_corr(y, x):.3f}",
+        transform=ax_sc.transAxes,
+        ha="right",
+        va="bottom",
+        fontsize=10,
+        bbox=dict(boxstyle="round,pad=0.22", fc="white", ec="0.82", alpha=0.9),
+    )
+
+    fig.suptitle("PAM Observatory — Response / Complex Compatibility", fontsize=21)
+    fig.savefig(outpath, dpi=220)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Test response-operator compatibility with candidate complex structures.")
+    parser.add_argument("--nodes-csv", default=Config.nodes_csv)
+    parser.add_argument("--seam-csv", default=Config.seam_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--seam-threshold", type=float, default=Config.seam_threshold)
+    parser.add_argument("--top-k-labels", type=int, default=Config.top_k_labels)
+    args = parser.parse_args()
+
+    cfg = Config(
+        nodes_csv=args.nodes_csv,
+        seam_csv=args.seam_csv,
+        outdir=args.outdir,
+        seam_threshold=args.seam_threshold,
+        top_k_labels=args.top_k_labels,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    nodes = pd.read_csv(cfg.nodes_csv)
+    for col in nodes.columns:
+        if col not in {"path_id", "path_family"}:
+            try:
+                nodes[col] = pd.to_numeric(nodes[col], errors="coerce")
+            except Exception:
+                pass
+
+    seam = pd.read_csv(cfg.seam_csv)
+    for col in ["mds1", "mds2", "signed_phase", "distance_to_seam"]:
+        if col in seam.columns:
+            seam[col] = pd.to_numeric(seam[col], errors="coerce")
+
+    nodes = build_node_table(nodes)
+
+    csv_path = outdir / "response_complex_compatibility_nodes.csv"
+    txt_path = outdir / "response_complex_compatibility_summary.txt"
+    png_path = outdir / "response_complex_compatibility_panel.png"
+
+    nodes.to_csv(csv_path, index=False)
+    txt_path.write_text(build_summary(nodes, cfg.seam_threshold), encoding="utf-8")
+    render_panel(cfg, nodes, seam, png_path)
+
+    print(csv_path)
+    print(txt_path)
+    print(png_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/studies/fim_response_operator_decomposition.py
+++ b/experiments/studies/fim_response_operator_decomposition.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""
+fim_response_operator_decomposition.py
+
+Decompose the local response operator T into canonical 2x2 parts and test
+which component drives complex-compatibility failure near the seam.
+
+For each node, decompose:
+
+    T = scalar_part + symmetric_traceless_part + antisymmetric_part
+
+where:
+- scalar_part            = (tr(T)/2) I
+- symmetric_traceless    = 0.5 * (T + T^T) - (tr(T)/2) I
+- antisymmetric_part     = 0.5 * (T - T^T)
+
+We compute:
+- Frobenius norm of each part
+- commutator norm with canonical complex structure J
+- seam localization summaries
+- correlations with seam distance, holonomy proxy, and transport mismatch
+
+Inputs
+------
+outputs/obs022_scene_bundle/scene_nodes.csv
+outputs/obs023_transport_misalignment/obs023_transport_misalignment_nodes.csv
+outputs/fim_response_complex_compatibility/response_complex_compatibility_nodes.csv
+outputs/obs022_scene_bundle/scene_seam.csv
+
+Outputs
+-------
+outputs/fim_response_operator_decomposition/
+  response_operator_decomposition_nodes.csv
+  response_operator_decomposition_summary.txt
+  response_operator_decomposition_panel.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class Config:
+    nodes_csv: str = "outputs/obs022_scene_bundle/scene_nodes.csv"
+    transport_nodes_csv: str = "outputs/obs023_transport_misalignment/obs023_transport_misalignment_nodes.csv"
+    compatibility_nodes_csv: str = "outputs/fim_response_complex_compatibility/response_complex_compatibility_nodes.csv"
+    seam_csv: str = "outputs/obs022_scene_bundle/scene_seam.csv"
+    outdir: str = "outputs/fim_response_operator_decomposition"
+    seam_threshold: float = 0.15
+    top_k_labels: int = 10
+
+
+def safe_corr(a: pd.Series, b: pd.Series) -> float:
+    aa = pd.to_numeric(a, errors="coerce")
+    bb = pd.to_numeric(b, errors="coerce")
+    mask = aa.notna() & bb.notna()
+    if int(mask.sum()) < 3:
+        return float("nan")
+    return float(np.corrcoef(aa[mask], bb[mask])[0, 1])
+
+
+def fro_norm(M: np.ndarray) -> float:
+    return float(np.linalg.norm(M, ord="fro"))
+
+
+def canonical_J() -> np.ndarray:
+    return np.array([[0.0, -1.0], [1.0, 0.0]], dtype=float)
+
+
+def commutator(A: np.ndarray, B: np.ndarray) -> np.ndarray:
+    return A @ B - B @ A
+
+
+def response_matrix(row: pd.Series) -> np.ndarray | None:
+    cols = ["T_xx", "T_xy", "T_yx", "T_yy"]
+    if not all(c in row.index for c in cols):
+        return None
+    vals = [pd.to_numeric(row[c], errors="coerce") for c in cols]
+    if any(pd.isna(v) for v in vals):
+        return None
+    return np.array([[float(vals[0]), float(vals[1])], [float(vals[2]), float(vals[3])]], dtype=float)
+
+
+def load_inputs(cfg: Config) -> tuple[pd.DataFrame, pd.DataFrame]:
+    nodes = pd.read_csv(cfg.nodes_csv)
+    transport = pd.read_csv(cfg.transport_nodes_csv)
+    compat = pd.read_csv(cfg.compatibility_nodes_csv)
+    seam = pd.read_csv(cfg.seam_csv)
+
+    for df in (nodes, transport, compat, seam):
+        for col in df.columns:
+            if col not in {"path_id", "path_family"}:
+                try:
+                    df[col] = pd.to_numeric(df[col], errors="coerce")
+                except Exception:
+                    pass
+
+    keep_transport = [c for c in ["node_id", "transport_align_mean_deg", "transport_align_max_deg"] if c in transport.columns]
+    keep_compat = [c for c in ["node_id", "commutator_norm_rsp", "anticommutator_norm_rsp"] if c in compat.columns]
+
+    merged = nodes.merge(transport[keep_transport], on="node_id", how="left")
+    merged = merged.merge(compat[keep_compat], on="node_id", how="left")
+
+    return merged, seam
+
+
+def decompose_nodes(nodes: pd.DataFrame) -> pd.DataFrame:
+    J = canonical_J()
+    rows: list[dict] = []
+
+    for _, row in nodes.iterrows():
+        node_id = int(row["node_id"])
+        T = response_matrix(row)
+
+        out = {"node_id": node_id}
+
+        if T is None:
+            out.update(
+                {
+                    "scalar_norm": np.nan,
+                    "sym_traceless_norm": np.nan,
+                    "antisymmetric_norm": np.nan,
+                    "total_norm": np.nan,
+                    "scalar_trace_coeff": np.nan,
+                    "anisotropy_ratio": np.nan,
+                    "scalar_commutator_norm": np.nan,
+                    "sym_traceless_commutator_norm": np.nan,
+                    "antisymmetric_commutator_norm": np.nan,
+                    "dominant_component": np.nan,
+                }
+            )
+            rows.append(out)
+            continue
+
+        tr = float(np.trace(T))
+        I = np.eye(2, dtype=float)
+
+        scalar = 0.5 * tr * I
+        sym = 0.5 * (T + T.T)
+        antisym = 0.5 * (T - T.T)
+        sym_traceless = sym - scalar
+
+        scalar_norm = fro_norm(scalar)
+        sym_traceless_norm = fro_norm(sym_traceless)
+        antisymmetric_norm = fro_norm(antisym)
+        total_norm = fro_norm(T)
+
+        comp_map = {
+            "scalar": scalar_norm,
+            "sym_traceless": sym_traceless_norm,
+            "antisymmetric": antisymmetric_norm,
+        }
+        dominant_component = max(comp_map, key=comp_map.get)
+
+        out.update(
+            {
+                "scalar_norm": scalar_norm,
+                "sym_traceless_norm": sym_traceless_norm,
+                "antisymmetric_norm": antisymmetric_norm,
+                "total_norm": total_norm,
+                "scalar_trace_coeff": 0.5 * tr,
+                "anisotropy_ratio": sym_traceless_norm / total_norm if total_norm > 1e-12 else np.nan,
+                "scalar_commutator_norm": fro_norm(commutator(scalar, J)),
+                "sym_traceless_commutator_norm": fro_norm(commutator(sym_traceless, J)),
+                "antisymmetric_commutator_norm": fro_norm(commutator(antisym, J)),
+                "dominant_component": dominant_component,
+            }
+        )
+        rows.append(out)
+
+    return nodes.merge(pd.DataFrame(rows), on="node_id", how="left")
+
+
+def build_summary(nodes: pd.DataFrame, seam_threshold: float) -> str:
+    seam_mask = pd.to_numeric(nodes["distance_to_seam"], errors="coerce") <= seam_threshold
+
+    components = [
+        ("scalar_norm", "scalar"),
+        ("sym_traceless_norm", "sym_traceless"),
+        ("antisymmetric_norm", "antisymmetric"),
+    ]
+
+    lines = [
+        "=== FIM Response Operator Decomposition Summary ===",
+        "",
+        f"n_nodes = {len(nodes)}",
+        f"seam_threshold = {seam_threshold:.4f}",
+        "",
+        "Mean component norms",
+    ]
+    for col, label in components:
+        lines.append(f"  mean {label} = {float(pd.to_numeric(nodes[col], errors='coerce').mean()):.6f}")
+
+    lines.extend(
+        [
+            "",
+            "Seam localization",
+            f"  seam-band mean scalar_norm         = {float(pd.to_numeric(nodes.loc[seam_mask, 'scalar_norm'], errors='coerce').mean()):.6f}",
+            f"  off-seam mean scalar_norm          = {float(pd.to_numeric(nodes.loc[~seam_mask, 'scalar_norm'], errors='coerce').mean()):.6f}",
+            f"  seam-band mean sym_traceless_norm  = {float(pd.to_numeric(nodes.loc[seam_mask, 'sym_traceless_norm'], errors='coerce').mean()):.6f}",
+            f"  off-seam mean sym_traceless_norm   = {float(pd.to_numeric(nodes.loc[~seam_mask, 'sym_traceless_norm'], errors='coerce').mean()):.6f}",
+            f"  seam-band mean antisymmetric_norm  = {float(pd.to_numeric(nodes.loc[seam_mask, 'antisymmetric_norm'], errors='coerce').mean()):.6f}",
+            f"  off-seam mean antisymmetric_norm   = {float(pd.to_numeric(nodes.loc[~seam_mask, 'antisymmetric_norm'], errors='coerce').mean()):.6f}",
+            "",
+            "Commutator decomposition",
+            f"  mean scalar_commutator_norm        = {float(pd.to_numeric(nodes['scalar_commutator_norm'], errors='coerce').mean()):.6f}",
+            f"  mean sym_traceless_commutator_norm = {float(pd.to_numeric(nodes['sym_traceless_commutator_norm'], errors='coerce').mean()):.6f}",
+            f"  mean antisymmetric_commutator_norm = {float(pd.to_numeric(nodes['antisymmetric_commutator_norm'], errors='coerce').mean()):.6f}",
+            "",
+            "Correlations with response / seam observables",
+            f"  corr(sym_traceless_norm, commutator_norm_rsp)   = {safe_corr(nodes['sym_traceless_norm'], nodes['commutator_norm_rsp']):.4f}",
+            f"  corr(antisymmetric_norm, commutator_norm_rsp)   = {safe_corr(nodes['antisymmetric_norm'], nodes['commutator_norm_rsp']):.4f}",
+            f"  corr(scalar_norm, commutator_norm_rsp)          = {safe_corr(nodes['scalar_norm'], nodes['commutator_norm_rsp']):.4f}",
+            f"  corr(sym_traceless_norm, transport_align_mean)  = {safe_corr(nodes['sym_traceless_norm'], nodes['transport_align_mean_deg']):.4f}",
+            f"  corr(antisymmetric_norm, transport_align_mean)  = {safe_corr(nodes['antisymmetric_norm'], nodes['transport_align_mean_deg']):.4f}",
+            f"  corr(sym_traceless_norm, distance_to_seam)      = {safe_corr(nodes['sym_traceless_norm'], nodes['distance_to_seam']):.4f}",
+            f"  corr(antisymmetric_norm, distance_to_seam)      = {safe_corr(nodes['antisymmetric_norm'], nodes['distance_to_seam']):.4f}",
+            "",
+            "Dominant components",
+        ]
+    )
+
+    dom_counts = nodes["dominant_component"].value_counts(dropna=False)
+    for k, v in dom_counts.items():
+        lines.append(f"  {k}: {int(v)}")
+
+    lines.extend(["", "Top anisotropy / incompatibility nodes"])
+    top = nodes.sort_values(["sym_traceless_norm", "commutator_norm_rsp"], ascending=False).head(10)
+    for _, row in top.iterrows():
+        lines.append(
+            f"  node_id={int(row['node_id'])}, "
+            f"r={float(row['r']):.4f}, alpha={float(row['alpha']):.4f}, "
+            f"sym_traceless_norm={float(row['sym_traceless_norm']):.6f}, "
+            f"antisymmetric_norm={float(row['antisymmetric_norm']):.6f}, "
+            f"commutator_norm_rsp={float(row['commutator_norm_rsp']):.6f}, "
+            f"distance_to_seam={float(row['distance_to_seam']):.4f}"
+        )
+
+    return "\n".join(lines)
+
+
+def render_panel(cfg: Config, nodes: pd.DataFrame, seam: pd.DataFrame, outpath: Path) -> None:
+    seam_mask = pd.to_numeric(nodes["distance_to_seam"], errors="coerce") <= cfg.seam_threshold
+
+    fig = plt.figure(figsize=(16, 9), constrained_layout=True)
+    gs = fig.add_gridspec(2, 2, width_ratios=[3.0, 1.3], height_ratios=[1.0, 1.0])
+
+    ax_main = fig.add_subplot(gs[:, 0])
+    ax_bar = fig.add_subplot(gs[0, 1])
+    ax_sc = fig.add_subplot(gs[1, 1])
+
+    seam_draw = seam.dropna(subset=["mds1", "mds2"]).sort_values("mds1")
+    if len(seam_draw):
+        ax_main.plot(seam_draw["mds1"], seam_draw["mds2"], color="white", linewidth=6.0, alpha=0.65, zorder=1)
+        ax_main.plot(seam_draw["mds1"], seam_draw["mds2"], color="black", linewidth=2.8, alpha=0.96, zorder=2)
+
+    sc = ax_main.scatter(
+        nodes["mds1"],
+        nodes["mds2"],
+        c=pd.to_numeric(nodes["sym_traceless_norm"], errors="coerce"),
+        cmap="viridis",
+        s=95,
+        alpha=0.96,
+        linewidths=0.35,
+        edgecolors="white",
+        zorder=3,
+    )
+
+    seam_nodes = nodes[seam_mask]
+    if len(seam_nodes):
+        ax_main.scatter(
+            seam_nodes["mds1"],
+            seam_nodes["mds2"],
+            s=170,
+            facecolors="none",
+            edgecolors="black",
+            linewidths=1.3,
+            zorder=4,
+        )
+
+    top = nodes.sort_values(["sym_traceless_norm", "commutator_norm_rsp"], ascending=False).head(cfg.top_k_labels)
+    for _, row in top.iterrows():
+        ax_main.scatter(
+            [row["mds1"]],
+            [row["mds2"]],
+            s=145,
+            facecolors="none",
+            edgecolors="#FFD166",
+            linewidths=1.8,
+            zorder=5,
+        )
+        ax_main.text(
+            float(row["mds1"]) + 0.05,
+            float(row["mds2"]) + 0.05,
+            f"{int(row['node_id'])}",
+            fontsize=8.5,
+            bbox=dict(boxstyle="round,pad=0.18", fc="white", ec="0.8", alpha=0.9),
+            zorder=6,
+        )
+
+    cbar = fig.colorbar(sc, ax=ax_main, fraction=0.038, pad=0.02)
+    cbar.set_label("symmetric traceless norm")
+
+    ax_main.set_title("Response anisotropy on the phase manifold", fontsize=17, pad=10)
+    ax_main.set_xlabel("MDS 1")
+    ax_main.set_ylabel("MDS 2")
+    ax_main.grid(alpha=0.08)
+    ax_main.set_aspect("equal", adjustable="box")
+    ax_main.text(
+        0.02,
+        0.97,
+        "black seam = detected phase boundary\nblack rings = seam neighborhood\nyellow labels = top anisotropy / incompatibility nodes",
+        transform=ax_main.transAxes,
+        va="top",
+        ha="left",
+        fontsize=9,
+        bbox=dict(boxstyle="round,pad=0.25", fc="white", ec="0.8", alpha=0.9),
+    )
+
+    vals = [
+        float(pd.to_numeric(nodes.loc[seam_mask, "sym_traceless_norm"], errors="coerce").mean()),
+        float(pd.to_numeric(nodes.loc[~seam_mask, "sym_traceless_norm"], errors="coerce").mean()),
+    ]
+    ax_bar.bar(["seam-band", "off-seam"], vals, alpha=0.9)
+    ax_bar.set_ylabel("mean symmetric traceless norm")
+    ax_bar.set_title("Seam localization", fontsize=14, pad=8)
+    ax_bar.grid(alpha=0.15, axis="y")
+
+    x = pd.to_numeric(nodes["sym_traceless_norm"], errors="coerce")
+    y = pd.to_numeric(nodes["commutator_norm_rsp"], errors="coerce")
+    mask = x.notna() & y.notna()
+    ax_sc.scatter(x[mask], y[mask], s=38, alpha=0.88)
+    ax_sc.set_xlabel("symmetric traceless norm")
+    ax_sc.set_ylabel("commutator norm")
+    ax_sc.set_title("Anisotropy vs incompatibility", fontsize=14, pad=8)
+    ax_sc.grid(alpha=0.15)
+    ax_sc.text(
+        0.98,
+        0.05,
+        f"corr = {safe_corr(x, y):.3f}",
+        transform=ax_sc.transAxes,
+        ha="right",
+        va="bottom",
+        fontsize=10,
+        bbox=dict(boxstyle="round,pad=0.22", fc="white", ec="0.82", alpha=0.9),
+    )
+
+    fig.suptitle("PAM Observatory — Response Operator Decomposition", fontsize=21)
+    fig.savefig(outpath, dpi=220)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Decompose response operator and test seam incompatibility drivers.")
+    parser.add_argument("--nodes-csv", default=Config.nodes_csv)
+    parser.add_argument("--transport-nodes-csv", default=Config.transport_nodes_csv)
+    parser.add_argument("--compatibility-nodes-csv", default=Config.compatibility_nodes_csv)
+    parser.add_argument("--seam-csv", default=Config.seam_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--seam-threshold", type=float, default=Config.seam_threshold)
+    parser.add_argument("--top-k-labels", type=int, default=Config.top_k_labels)
+    args = parser.parse_args()
+
+    cfg = Config(
+        nodes_csv=args.nodes_csv,
+        transport_nodes_csv=args.transport_nodes_csv,
+        compatibility_nodes_csv=args.compatibility_nodes_csv,
+        seam_csv=args.seam_csv,
+        outdir=args.outdir,
+        seam_threshold=args.seam_threshold,
+        top_k_labels=args.top_k_labels,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    nodes, seam = load_inputs(cfg)
+    nodes = decompose_nodes(nodes)
+
+    csv_path = outdir / "response_operator_decomposition_nodes.csv"
+    txt_path = outdir / "response_operator_decomposition_summary.txt"
+    png_path = outdir / "response_operator_decomposition_panel.png"
+
+    nodes.to_csv(csv_path, index=False)
+    txt_path.write_text(build_summary(nodes, cfg.seam_threshold), encoding="utf-8")
+    render_panel(cfg, nodes, seam, png_path)
+
+    print(csv_path)
+    print(txt_path)
+    print(png_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/studies/obs025_anisotropy_vs_relational_obstruction.py
+++ b/experiments/studies/obs025_anisotropy_vs_relational_obstruction.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""
+OBS-025 — Response anisotropy vs relational obstruction.
+
+Unify two seam-side structural fields:
+
+1. response anisotropy
+   -> symmetric traceless norm of the local response tensor
+
+2. relational obstruction
+   -> neighbor-level directional mismatch / transport-aware relational field
+
+This script compares:
+- seam localization of both fields
+- global correlation
+- hotspot overlap
+- family of top nodes shared by both fields
+
+Inputs
+------
+outputs/fim_response_operator_decomposition/response_operator_decomposition_nodes.csv
+outputs/obs023_local_direction_mismatch/local_direction_mismatch_nodes.csv
+outputs/obs022_scene_bundle/scene_seam.csv
+
+Outputs
+-------
+outputs/obs025_anisotropy_vs_relational_obstruction/
+  obs025_anisotropy_vs_relational_obstruction_nodes.csv
+  obs025_anisotropy_vs_relational_obstruction_summary.txt
+  obs025_anisotropy_vs_relational_obstruction_figure.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class Config:
+    anisotropy_csv: str = "outputs/fim_response_operator_decomposition/response_operator_decomposition_nodes.csv"
+    mismatch_csv: str = "outputs/obs023_local_direction_mismatch/local_direction_mismatch_nodes.csv"
+    seam_csv: str = "outputs/obs022_scene_bundle/scene_seam.csv"
+    outdir: str = "outputs/obs025_anisotropy_vs_relational_obstruction"
+    seam_threshold: float = 0.15
+    hotspot_quantile: float = 0.85
+    top_k_overlap: int = 10
+    top_k_labels: int = 8
+
+
+def safe_corr(a: pd.Series, b: pd.Series) -> float:
+    aa = pd.to_numeric(a, errors="coerce")
+    bb = pd.to_numeric(b, errors="coerce")
+    mask = aa.notna() & bb.notna()
+    if int(mask.sum()) < 3:
+        return float("nan")
+    return float(np.corrcoef(aa[mask], bb[mask])[0, 1])
+
+
+def safe_mean(s: pd.Series) -> float:
+    s = pd.to_numeric(s, errors="coerce")
+    return float(s.mean()) if s.notna().any() else float("nan")
+
+
+def load_inputs(cfg: Config) -> tuple[pd.DataFrame, pd.DataFrame]:
+    aniso = pd.read_csv(cfg.anisotropy_csv)
+    mm = pd.read_csv(cfg.mismatch_csv)
+    seam = pd.read_csv(cfg.seam_csv)
+
+    for df in (aniso, mm, seam):
+        for col in df.columns:
+            if col not in {"path_id", "path_family"}:
+                try:
+                    df[col] = pd.to_numeric(df[col], errors="coerce")
+                except Exception:
+                    pass
+
+    keep_aniso = [
+        c
+        for c in [
+            "node_id",
+            "r",
+            "alpha",
+            "mds1",
+            "mds2",
+            "signed_phase",
+            "distance_to_seam",
+            "node_holonomy_proxy",
+            "sym_traceless_norm",
+            "antisymmetric_norm",
+            "scalar_norm",
+            "commutator_norm_rsp",
+        ]
+        if c in aniso.columns
+    ]
+    keep_mm = [
+        c
+        for c in [
+            "node_id",
+            "neighbor_direction_mismatch_mean",
+            "local_direction_mismatch_deg",
+            "transport_align_mean_deg",
+        ]
+        if c in mm.columns
+    ]
+
+    nodes = aniso[keep_aniso].merge(mm[keep_mm], on="node_id", how="left")
+    return nodes, seam
+
+
+def add_hotspots(nodes: pd.DataFrame, quantile: float) -> pd.DataFrame:
+    out = nodes.copy()
+
+    aniso_thr = float(pd.to_numeric(out["sym_traceless_norm"], errors="coerce").quantile(quantile))
+    rel_thr = float(pd.to_numeric(out["neighbor_direction_mismatch_mean"], errors="coerce").quantile(quantile))
+
+    out["anisotropy_hotspot"] = (
+        pd.to_numeric(out["sym_traceless_norm"], errors="coerce") >= aniso_thr
+    ).astype(int)
+    out["relational_hotspot"] = (
+        pd.to_numeric(out["neighbor_direction_mismatch_mean"], errors="coerce") >= rel_thr
+    ).astype(int)
+    out["shared_hotspot"] = ((out["anisotropy_hotspot"] == 1) & (out["relational_hotspot"] == 1)).astype(int)
+
+    out.attrs["anisotropy_threshold"] = aniso_thr
+    out.attrs["relational_threshold"] = rel_thr
+    return out
+
+
+def build_summary(nodes: pd.DataFrame, cfg: Config) -> str:
+    seam_mask = pd.to_numeric(nodes["distance_to_seam"], errors="coerce") <= cfg.seam_threshold
+    transport_col = "transport_align_mean_deg" if "transport_align_mean_deg" in nodes.columns else "neighbor_direction_mismatch_mean"
+
+    top_aniso = set(
+        nodes.sort_values("sym_traceless_norm", ascending=False)
+        .head(cfg.top_k_overlap)["node_id"]
+        .dropna()
+        .astype(int)
+        .tolist()
+    )
+    top_rel = set(
+        nodes.sort_values("neighbor_direction_mismatch_mean", ascending=False)
+        .head(cfg.top_k_overlap)["node_id"]
+        .dropna()
+        .astype(int)
+        .tolist()
+    )
+    overlap = len(top_aniso & top_rel)
+
+    lines = [
+        "=== OBS-025 Anisotropy vs Relational Obstruction Summary ===",
+        "",
+        f"n_nodes = {len(nodes)}",
+        f"seam_threshold = {cfg.seam_threshold:.4f}",
+        f"hotspot_quantile = {cfg.hotspot_quantile:.4f}",
+        f"anisotropy_threshold = {float(nodes.attrs['anisotropy_threshold']):.6f}",
+        f"relational_threshold = {float(nodes.attrs['relational_threshold']):.6f}",
+        "",
+        "Field means",
+        f"  mean sym_traceless_norm              = {safe_mean(nodes['sym_traceless_norm']):.6f}",
+        f"  mean neighbor_direction_mismatch     = {safe_mean(nodes['neighbor_direction_mismatch_mean']):.6f}",
+        "",
+        "Seam localization",
+        f"  seam-band mean sym_traceless_norm    = {safe_mean(nodes.loc[seam_mask, 'sym_traceless_norm']):.6f}",
+        f"  off-seam mean sym_traceless_norm     = {safe_mean(nodes.loc[~seam_mask, 'sym_traceless_norm']):.6f}",
+        f"  seam-band mean relational mismatch   = {safe_mean(nodes.loc[seam_mask, 'neighbor_direction_mismatch_mean']):.6f}",
+        f"  off-seam mean relational mismatch    = {safe_mean(nodes.loc[~seam_mask, 'neighbor_direction_mismatch_mean']):.6f}",
+        "",
+        "Correlations",
+        f"  corr(sym_traceless_norm, relational mismatch) = {safe_corr(nodes['sym_traceless_norm'], nodes['neighbor_direction_mismatch_mean']):.4f}",
+        f"  corr(sym_traceless_norm, {transport_col})     = {safe_corr(nodes['sym_traceless_norm'], nodes[transport_col]):.4f}",
+        f"  corr(sym_traceless_norm, distance_to_seam)    = {safe_corr(nodes['sym_traceless_norm'], nodes['distance_to_seam']):.4f}",
+        f"  corr(relational mismatch, distance_to_seam)   = {safe_corr(nodes['neighbor_direction_mismatch_mean'], nodes['distance_to_seam']):.4f}",
+        f"  corr(sym_traceless_norm, node_holonomy_proxy) = {safe_corr(nodes['sym_traceless_norm'], nodes.get('node_holonomy_proxy', pd.Series(dtype=float))):.4f}",
+        f"  corr(relational mismatch, node_holonomy_proxy)= {safe_corr(nodes['neighbor_direction_mismatch_mean'], nodes.get('node_holonomy_proxy', pd.Series(dtype=float))):.4f}",
+        "",
+        "Hotspot overlap",
+        f"  n_anisotropy_hotspots = {int(nodes['anisotropy_hotspot'].sum())}",
+        f"  n_relational_hotspots = {int(nodes['relational_hotspot'].sum())}",
+        f"  n_shared_hotspots     = {int(nodes['shared_hotspot'].sum())}",
+        f"  top_{cfg.top_k_overlap}_overlap     = {overlap}",
+        "",
+        "Top shared hotspots",
+    ]
+
+    top_shared = nodes[nodes["shared_hotspot"] == 1].copy()
+    top_shared = top_shared.sort_values(
+        ["sym_traceless_norm", "neighbor_direction_mismatch_mean"],
+        ascending=False,
+    ).head(10)
+
+    for _, row in top_shared.iterrows():
+        lines.append(
+            f"  node_id={int(row['node_id'])}, "
+            f"r={float(row['r']):.4f}, alpha={float(row['alpha']):.4f}, "
+            f"sym_traceless_norm={float(row['sym_traceless_norm']):.6f}, "
+            f"neighbor_direction_mismatch_mean={float(row['neighbor_direction_mismatch_mean']):.6f}, "
+            f"distance_to_seam={float(row['distance_to_seam']):.4f}"
+        )
+
+    return "\n".join(lines)
+
+
+def render_figure(cfg: Config, nodes: pd.DataFrame, seam: pd.DataFrame, outpath: Path) -> None:
+    seam_mask = pd.to_numeric(nodes["distance_to_seam"], errors="coerce") <= cfg.seam_threshold
+
+    fig = plt.figure(figsize=(16, 9.5), constrained_layout=True)
+    gs = fig.add_gridspec(2, 3, width_ratios=[1.5, 1.5, 1.15], height_ratios=[1.0, 1.0])
+
+    ax_a = fig.add_subplot(gs[0, 0])
+    ax_b = fig.add_subplot(gs[0, 1])
+    ax_sc = fig.add_subplot(gs[0, 2])
+    ax_bar = fig.add_subplot(gs[1, 0])
+    ax_overlap = fig.add_subplot(gs[1, 1])
+    ax_diag = fig.add_subplot(gs[1, 2])
+
+    seam_draw = seam.dropna(subset=["mds1", "mds2"]).sort_values("mds1")
+
+    # anisotropy field
+    if len(seam_draw):
+        ax_a.plot(seam_draw["mds1"], seam_draw["mds2"], color="white", linewidth=5.5, alpha=0.65, zorder=1)
+        ax_a.plot(seam_draw["mds1"], seam_draw["mds2"], color="black", linewidth=2.6, alpha=0.96, zorder=2)
+
+    sc_a = ax_a.scatter(
+        nodes["mds1"],
+        nodes["mds2"],
+        c=pd.to_numeric(nodes["sym_traceless_norm"], errors="coerce"),
+        cmap="viridis",
+        s=92,
+        alpha=0.96,
+        linewidths=0.35,
+        edgecolors="white",
+        zorder=3,
+    )
+    ax_a.scatter(
+        nodes.loc[nodes["anisotropy_hotspot"] == 1, "mds1"],
+        nodes.loc[nodes["anisotropy_hotspot"] == 1, "mds2"],
+        s=150,
+        facecolors="none",
+        edgecolors="black",
+        linewidths=1.2,
+        zorder=4,
+    )
+    cbar_a = fig.colorbar(sc_a, ax=ax_a, fraction=0.046, pad=0.02)
+    cbar_a.set_label("sym. traceless norm")
+    ax_a.set_title("Response anisotropy", fontsize=15, pad=8)
+    ax_a.set_xlabel("MDS 1")
+    ax_a.set_ylabel("MDS 2")
+    ax_a.grid(alpha=0.08)
+    ax_a.set_aspect("equal", adjustable="box")
+
+    # relational field
+    if len(seam_draw):
+        ax_b.plot(seam_draw["mds1"], seam_draw["mds2"], color="white", linewidth=5.5, alpha=0.65, zorder=1)
+        ax_b.plot(seam_draw["mds1"], seam_draw["mds2"], color="black", linewidth=2.6, alpha=0.96, zorder=2)
+
+    sc_b = ax_b.scatter(
+        nodes["mds1"],
+        nodes["mds2"],
+        c=pd.to_numeric(nodes["neighbor_direction_mismatch_mean"], errors="coerce"),
+        cmap="magma",
+        s=92,
+        alpha=0.96,
+        linewidths=0.35,
+        edgecolors="white",
+        zorder=3,
+    )
+    ax_b.scatter(
+        nodes.loc[nodes["relational_hotspot"] == 1, "mds1"],
+        nodes.loc[nodes["relational_hotspot"] == 1, "mds2"],
+        s=150,
+        facecolors="none",
+        edgecolors="black",
+        linewidths=1.2,
+        zorder=4,
+    )
+    cbar_b = fig.colorbar(sc_b, ax=ax_b, fraction=0.046, pad=0.02)
+    cbar_b.set_label("relational mismatch (deg)")
+    ax_b.set_title("Relational obstruction", fontsize=15, pad=8)
+    ax_b.set_xlabel("MDS 1")
+    ax_b.set_ylabel("MDS 2")
+    ax_b.grid(alpha=0.08)
+    ax_b.set_aspect("equal", adjustable="box")
+
+    # scatter relation
+    x = pd.to_numeric(nodes["sym_traceless_norm"], errors="coerce")
+    y = pd.to_numeric(nodes["neighbor_direction_mismatch_mean"], errors="coerce")
+    mask = x.notna() & y.notna()
+    ax_sc.scatter(x[mask], y[mask], s=38, alpha=0.86)
+    ax_sc.set_xlabel("sym. traceless norm")
+    ax_sc.set_ylabel("relational mismatch (deg)")
+    ax_sc.set_title("Field correspondence", fontsize=14, pad=8)
+    ax_sc.grid(alpha=0.15)
+    ax_sc.text(
+        0.98,
+        0.05,
+        f"corr = {safe_corr(x, y):.3f}",
+        transform=ax_sc.transAxes,
+        ha="right",
+        va="bottom",
+        fontsize=10,
+        bbox=dict(boxstyle="round,pad=0.22", fc="white", ec="0.82", alpha=0.9),
+    )
+
+    # seam/off-seam bars
+    bar_labels = ["anisotropy", "relational"]
+    seam_vals = [
+        safe_mean(nodes.loc[seam_mask, "sym_traceless_norm"]),
+        safe_mean(nodes.loc[seam_mask, "neighbor_direction_mismatch_mean"]),
+    ]
+    off_vals = [
+        safe_mean(nodes.loc[~seam_mask, "sym_traceless_norm"]),
+        safe_mean(nodes.loc[~seam_mask, "neighbor_direction_mismatch_mean"]),
+    ]
+    xx = np.arange(len(bar_labels))
+    width = 0.34
+    ax_bar.bar(xx - width / 2, seam_vals, width, label="seam-band", alpha=0.9)
+    ax_bar.bar(xx + width / 2, off_vals, width, label="off-seam", alpha=0.9)
+    ax_bar.set_xticks(xx)
+    ax_bar.set_xticklabels(bar_labels)
+    ax_bar.set_title("Seam localization", fontsize=14, pad=8)
+    ax_bar.grid(alpha=0.15, axis="y")
+    ax_bar.legend()
+
+    # hotspot overlap map
+    if len(seam_draw):
+        ax_overlap.plot(seam_draw["mds1"], seam_draw["mds2"], color="white", linewidth=5.5, alpha=0.65, zorder=1)
+        ax_overlap.plot(seam_draw["mds1"], seam_draw["mds2"], color="black", linewidth=2.6, alpha=0.96, zorder=2)
+
+    base = nodes.copy()
+    ax_overlap.scatter(base["mds1"], base["mds2"], s=48, c="lightgray", alpha=0.55, linewidths=0, zorder=2.5)
+    aniso_only = base[(base["anisotropy_hotspot"] == 1) & (base["shared_hotspot"] == 0)]
+    rel_only = base[(base["relational_hotspot"] == 1) & (base["shared_hotspot"] == 0)]
+    shared = base[base["shared_hotspot"] == 1]
+
+    if len(aniso_only):
+        ax_overlap.scatter(aniso_only["mds1"], aniso_only["mds2"], s=120, c="#2A9D8F", alpha=0.95, zorder=3)
+    if len(rel_only):
+        ax_overlap.scatter(rel_only["mds1"], rel_only["mds2"], s=120, c="#B23A48", alpha=0.95, zorder=3.2)
+    if len(shared):
+        ax_overlap.scatter(shared["mds1"], shared["mds2"], s=155, c="#FFD166", edgecolors="black", linewidths=1.0, alpha=0.98, zorder=4)
+
+    top_shared = shared.sort_values(
+        ["sym_traceless_norm", "neighbor_direction_mismatch_mean"], ascending=False
+    ).head(cfg.top_k_labels)
+    for _, row in top_shared.iterrows():
+        ax_overlap.text(
+            float(row["mds1"]) + 0.05,
+            float(row["mds2"]) + 0.05,
+            f"{int(row['node_id'])}",
+            fontsize=8.5,
+            bbox=dict(boxstyle="round,pad=0.18", fc="white", ec="0.8", alpha=0.9),
+            zorder=5,
+        )
+
+    ax_overlap.set_title("Hotspot overlap", fontsize=14, pad=8)
+    ax_overlap.set_xlabel("MDS 1")
+    ax_overlap.set_ylabel("MDS 2")
+    ax_overlap.grid(alpha=0.08)
+    ax_overlap.set_aspect("equal", adjustable="box")
+
+    # diagnostics box
+    ax_diag.axis("off")
+    transport_col = "transport_align_mean_deg" if "transport_align_mean_deg" in nodes.columns else "neighbor_direction_mismatch_mean"
+
+    text = (
+        "OBS-025 diagnostics\n\n"
+        f"n anisotropy hotspots: {int(nodes['anisotropy_hotspot'].sum())}\n"
+        f"n relational hotspots: {int(nodes['relational_hotspot'].sum())}\n"
+        f"n shared hotspots: {int(nodes['shared_hotspot'].sum())}\n\n"
+        f"corr(aniso, relational): {safe_corr(nodes['sym_traceless_norm'], nodes['neighbor_direction_mismatch_mean']):.3f}\n"
+        f"corr(aniso, {transport_col}): {safe_corr(nodes['sym_traceless_norm'], nodes[transport_col]):.3f}\n\n"
+        "cyan   = anisotropy-only hotspot\n"
+        "crimson= relational-only hotspot\n"
+        "gold   = shared hotspot"
+    )
+    ax_diag.text(
+        0.02,
+        0.98,
+        text,
+        va="top",
+        ha="left",
+        fontsize=10,
+        family="monospace",
+        bbox=dict(boxstyle="round,pad=0.35", fc="white", ec="0.85", alpha=0.95),
+    )
+
+    fig.suptitle("PAM Observatory — OBS-025 anisotropy vs relational obstruction", fontsize=20)
+    fig.savefig(outpath, dpi=220)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compare response anisotropy against relational obstruction.")
+    parser.add_argument("--anisotropy-csv", default=Config.anisotropy_csv)
+    parser.add_argument("--mismatch-csv", default=Config.mismatch_csv)
+    parser.add_argument("--seam-csv", default=Config.seam_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--seam-threshold", type=float, default=Config.seam_threshold)
+    parser.add_argument("--hotspot-quantile", type=float, default=Config.hotspot_quantile)
+    parser.add_argument("--top-k-overlap", type=int, default=Config.top_k_overlap)
+    parser.add_argument("--top-k-labels", type=int, default=Config.top_k_labels)
+    args = parser.parse_args()
+
+    cfg = Config(
+        anisotropy_csv=args.anisotropy_csv,
+        mismatch_csv=args.mismatch_csv,
+        seam_csv=args.seam_csv,
+        outdir=args.outdir,
+        seam_threshold=args.seam_threshold,
+        hotspot_quantile=args.hotspot_quantile,
+        top_k_overlap=args.top_k_overlap,
+        top_k_labels=args.top_k_labels,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    nodes, seam = load_inputs(cfg)
+    nodes = add_hotspots(nodes, cfg.hotspot_quantile)
+
+    csv_path = outdir / "obs025_anisotropy_vs_relational_obstruction_nodes.csv"
+    txt_path = outdir / "obs025_anisotropy_vs_relational_obstruction_summary.txt"
+    png_path = outdir / "obs025_anisotropy_vs_relational_obstruction_figure.png"
+
+    nodes.to_csv(csv_path, index=False)
+    txt_path.write_text(build_summary(nodes, cfg), encoding="utf-8")
+    render_figure(cfg, nodes, seam, png_path)
+
+    print(csv_path)
+    print(txt_path)
+    print(png_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/studies/obs025_two_field_seam_panel.py
+++ b/experiments/studies/obs025_two_field_seam_panel.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""
+OBS-025 — Two-field seam panel.
+
+Present the seam as a multi-field regime by comparing:
+
+1. response anisotropy
+   -> symmetric traceless norm of the response tensor
+
+2. relational obstruction
+   -> neighbor-level directional mismatch
+
+and their hotspot overlap structure.
+
+Inputs
+------
+outputs/obs025_anisotropy_vs_relational_obstruction/obs025_anisotropy_vs_relational_obstruction_nodes.csv
+outputs/obs022_scene_bundle/scene_seam.csv
+
+Outputs
+-------
+outputs/obs025_two_field_seam_panel/
+  obs025_two_field_seam_panel_summary.txt
+  obs025_two_field_seam_panel.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class Config:
+    nodes_csv: str = "outputs/obs025_anisotropy_vs_relational_obstruction/obs025_anisotropy_vs_relational_obstruction_nodes.csv"
+    seam_csv: str = "outputs/obs022_scene_bundle/scene_seam.csv"
+    outdir: str = "outputs/obs025_two_field_seam_panel"
+    seam_threshold: float = 0.15
+    top_k_labels: int = 4
+
+
+def safe_corr(a: pd.Series, b: pd.Series) -> float:
+    aa = pd.to_numeric(a, errors="coerce")
+    bb = pd.to_numeric(b, errors="coerce")
+    mask = aa.notna() & bb.notna()
+    if int(mask.sum()) < 3:
+        return float("nan")
+    return float(np.corrcoef(aa[mask], bb[mask])[0, 1])
+
+
+def safe_mean(s: pd.Series) -> float:
+    s = pd.to_numeric(s, errors="coerce")
+    return float(s.mean()) if s.notna().any() else float("nan")
+
+
+def load_inputs(cfg: Config) -> tuple[pd.DataFrame, pd.DataFrame]:
+    nodes = pd.read_csv(cfg.nodes_csv)
+    seam = pd.read_csv(cfg.seam_csv)
+
+    for df in (nodes, seam):
+        for col in df.columns:
+            if col not in {"path_id", "path_family", "dominant_component"}:
+                try:
+                    df[col] = pd.to_numeric(df[col], errors="coerce")
+                except Exception:
+                    pass
+
+    required = [
+        "node_id",
+        "mds1",
+        "mds2",
+        "distance_to_seam",
+        "sym_traceless_norm",
+        "neighbor_direction_mismatch_mean",
+        "anisotropy_hotspot",
+        "relational_hotspot",
+        "shared_hotspot",
+    ]
+    missing = [c for c in required if c not in nodes.columns]
+    if missing:
+        raise ValueError(f"Missing required node columns: {missing}")
+
+    return nodes, seam
+
+
+def build_summary(nodes: pd.DataFrame, seam_threshold: float) -> str:
+    seam_mask = pd.to_numeric(nodes["distance_to_seam"], errors="coerce") <= seam_threshold
+
+    aniso_only = (nodes["anisotropy_hotspot"] == 1) & (nodes["shared_hotspot"] == 0)
+    rel_only = (nodes["relational_hotspot"] == 1) & (nodes["shared_hotspot"] == 0)
+    shared = nodes["shared_hotspot"] == 1
+
+    lines = [
+        "=== OBS-025 Two-Field Seam Panel Summary ===",
+        "",
+        f"n_nodes = {len(nodes)}",
+        f"seam_threshold = {seam_threshold:.4f}",
+        "",
+        "Field summary",
+        f"  mean sym_traceless_norm          = {safe_mean(nodes['sym_traceless_norm']):.6f}",
+        f"  mean relational mismatch         = {safe_mean(nodes['neighbor_direction_mismatch_mean']):.6f}",
+        f"  corr(anisotropy, relational)     = {safe_corr(nodes['sym_traceless_norm'], nodes['neighbor_direction_mismatch_mean']):.4f}",
+        "",
+        "Seam localization",
+        f"  seam-band mean anisotropy        = {safe_mean(nodes.loc[seam_mask, 'sym_traceless_norm']):.6f}",
+        f"  off-seam mean anisotropy         = {safe_mean(nodes.loc[~seam_mask, 'sym_traceless_norm']):.6f}",
+        f"  seam-band mean relational        = {safe_mean(nodes.loc[seam_mask, 'neighbor_direction_mismatch_mean']):.6f}",
+        f"  off-seam mean relational         = {safe_mean(nodes.loc[~seam_mask, 'neighbor_direction_mismatch_mean']):.6f}",
+        "",
+        "Hotspot structure",
+        f"  anisotropy-only hotspots         = {int(aniso_only.sum())}",
+        f"  relational-only hotspots         = {int(rel_only.sum())}",
+        f"  shared hotspots                  = {int(shared.sum())}",
+        "",
+        "Interpretation",
+        "- both fields are seam-biased",
+        "- anisotropy and relational obstruction only weakly align pointwise",
+        "- the seam therefore behaves as a multi-field structural regime",
+    ]
+    return "\n".join(lines)
+
+
+def render_panel(cfg: Config, nodes: pd.DataFrame, seam: pd.DataFrame, outpath: Path) -> None:
+    seam_mask = pd.to_numeric(nodes["distance_to_seam"], errors="coerce") <= cfg.seam_threshold
+    aniso_only = nodes[(nodes["anisotropy_hotspot"] == 1) & (nodes["shared_hotspot"] == 0)].copy()
+    rel_only = nodes[(nodes["relational_hotspot"] == 1) & (nodes["shared_hotspot"] == 0)].copy()
+    shared = nodes[nodes["shared_hotspot"] == 1].copy()
+
+    fig = plt.figure(figsize=(16.5, 9.5), constrained_layout=True)
+    gs = fig.add_gridspec(2, 3, width_ratios=[1.35, 1.35, 1.05], height_ratios=[1.0, 1.0])
+
+    ax_a = fig.add_subplot(gs[0, 0])
+    ax_b = fig.add_subplot(gs[0, 1])
+    ax_overlap = fig.add_subplot(gs[0, 2])
+    ax_sc = fig.add_subplot(gs[1, 0])
+    ax_bar = fig.add_subplot(gs[1, 1])
+    ax_diag = fig.add_subplot(gs[1, 2])
+
+    seam_draw = seam.dropna(subset=["mds1", "mds2"]).sort_values("mds1")
+
+    def draw_seam(ax):
+        if len(seam_draw):
+            ax.plot(seam_draw["mds1"], seam_draw["mds2"], color="white", linewidth=5.5, alpha=0.65, zorder=1)
+            ax.plot(seam_draw["mds1"], seam_draw["mds2"], color="black", linewidth=2.6, alpha=0.96, zorder=2)
+
+    # Panel A: anisotropy field
+    draw_seam(ax_a)
+    sc_a = ax_a.scatter(
+        nodes["mds1"],
+        nodes["mds2"],
+        c=pd.to_numeric(nodes["sym_traceless_norm"], errors="coerce"),
+        cmap="viridis",
+        s=92,
+        alpha=0.96,
+        linewidths=0.35,
+        edgecolors="white",
+        zorder=3,
+    )
+    ax_a.scatter(
+        nodes.loc[seam_mask, "mds1"],
+        nodes.loc[seam_mask, "mds2"],
+        s=160,
+        facecolors="none",
+        edgecolors="black",
+        linewidths=1.0,
+        zorder=4,
+    )
+    cbar_a = fig.colorbar(sc_a, ax=ax_a, fraction=0.046, pad=0.02)
+    cbar_a.set_label("sym. traceless norm")
+    ax_a.set_title("Field A — response anisotropy", fontsize=15, pad=8)
+    ax_a.set_xlabel("MDS 1")
+    ax_a.set_ylabel("MDS 2")
+    ax_a.grid(alpha=0.08)
+    ax_a.set_aspect("equal", adjustable="box")
+
+    # Panel B: relational field
+    draw_seam(ax_b)
+    sc_b = ax_b.scatter(
+        nodes["mds1"],
+        nodes["mds2"],
+        c=pd.to_numeric(nodes["neighbor_direction_mismatch_mean"], errors="coerce"),
+        cmap="magma",
+        s=92,
+        alpha=0.96,
+        linewidths=0.35,
+        edgecolors="white",
+        zorder=3,
+    )
+    ax_b.scatter(
+        nodes.loc[seam_mask, "mds1"],
+        nodes.loc[seam_mask, "mds2"],
+        s=160,
+        facecolors="none",
+        edgecolors="black",
+        linewidths=1.0,
+        zorder=4,
+    )
+    cbar_b = fig.colorbar(sc_b, ax=ax_b, fraction=0.046, pad=0.02)
+    cbar_b.set_label("relational mismatch (deg)")
+    ax_b.set_title("Field B — relational obstruction", fontsize=15, pad=8)
+    ax_b.set_xlabel("MDS 1")
+    ax_b.set_ylabel("MDS 2")
+    ax_b.grid(alpha=0.08)
+    ax_b.set_aspect("equal", adjustable="box")
+
+    # Panel C: overlap structure
+    draw_seam(ax_overlap)
+    ax_overlap.scatter(nodes["mds1"], nodes["mds2"], s=42, c="lightgray", alpha=0.55, linewidths=0, zorder=2.5)
+
+    if len(aniso_only):
+        ax_overlap.scatter(aniso_only["mds1"], aniso_only["mds2"], s=120, c="#2A9D8F", alpha=0.95, zorder=3)
+    if len(rel_only):
+        ax_overlap.scatter(rel_only["mds1"], rel_only["mds2"], s=120, c="#B23A48", alpha=0.95, zorder=3.2)
+    if len(shared):
+        ax_overlap.scatter(shared["mds1"], shared["mds2"], s=155, c="#FFD166", edgecolors="black", linewidths=1.0, alpha=0.98, zorder=4)
+
+    top_shared = shared.sort_values(
+        ["sym_traceless_norm", "neighbor_direction_mismatch_mean"],
+        ascending=False,
+    ).head(cfg.top_k_labels)
+    for _, row in top_shared.iterrows():
+        ax_overlap.text(
+            float(row["mds1"]) + 0.05,
+            float(row["mds2"]) + 0.05,
+            f"{int(row['node_id'])}",
+            fontsize=8.5,
+            bbox=dict(boxstyle="round,pad=0.18", fc="white", ec="0.8", alpha=0.9),
+            zorder=5,
+        )
+
+    ax_overlap.set_title("Hotspot overlap structure", fontsize=15, pad=8)
+    ax_overlap.set_xlabel("MDS 1")
+    ax_overlap.set_ylabel("MDS 2")
+    ax_overlap.grid(alpha=0.08)
+    ax_overlap.set_aspect("equal", adjustable="box")
+
+    # Panel D: field correspondence scatter
+    x = pd.to_numeric(nodes["sym_traceless_norm"], errors="coerce")
+    y = pd.to_numeric(nodes["neighbor_direction_mismatch_mean"], errors="coerce")
+    mask = x.notna() & y.notna()
+    ax_sc.scatter(x[mask], y[mask], s=38, alpha=0.86)
+    ax_sc.set_xlabel("sym. traceless norm")
+    ax_sc.set_ylabel("relational mismatch (deg)")
+    ax_sc.set_title("Anisotropy vs relational obstruction", fontsize=14, pad=8)
+    ax_sc.grid(alpha=0.15)
+    ax_sc.text(
+        0.98,
+        0.05,
+        f"corr = {safe_corr(x, y):.3f}",
+        transform=ax_sc.transAxes,
+        ha="right",
+        va="bottom",
+        fontsize=10,
+        bbox=dict(boxstyle="round,pad=0.22", fc="white", ec="0.82", alpha=0.9),
+    )
+
+    # Panel E: normalized seam enrichment
+    aniso_seam = safe_mean(nodes.loc[seam_mask, "sym_traceless_norm"])
+    aniso_off = safe_mean(nodes.loc[~seam_mask, "sym_traceless_norm"])
+    rel_seam = safe_mean(nodes.loc[seam_mask, "neighbor_direction_mismatch_mean"])
+    rel_off = safe_mean(nodes.loc[~seam_mask, "neighbor_direction_mismatch_mean"])
+
+    aniso_ratio = aniso_seam / aniso_off if np.isfinite(aniso_off) and abs(aniso_off) > 1e-12 else np.nan
+    rel_ratio = rel_seam / rel_off if np.isfinite(rel_off) and abs(rel_off) > 1e-12 else np.nan
+
+    labels = ["anisotropy", "relational"]
+    vals = [aniso_ratio, rel_ratio]
+
+    ax_bar.bar(labels, vals, alpha=0.9)
+    ax_bar.axhline(1.0, color="black", linewidth=1.2, alpha=0.8)
+    ax_bar.set_ylabel("seam / off-seam ratio")
+    ax_bar.set_title("Normalized seam enrichment", fontsize=14, pad=8)
+    ax_bar.grid(alpha=0.15, axis="y")
+
+    for i, v in enumerate(vals):
+        if np.isfinite(v):
+            ax_bar.text(
+                i,
+                v + 0.02 * max(vals),
+                f"{v:.2f}×",
+                ha="center",
+                va="bottom",
+                fontsize=10,
+            )
+
+    # Panel F: interpretation box
+    transport_text = (
+        "OBS-025 synthesis\n\n"
+        f"corr(aniso, relational): {safe_corr(nodes['sym_traceless_norm'], nodes['neighbor_direction_mismatch_mean']):.3f}\n\n"
+        f"anisotropy-only hotspots: {len(aniso_only)}\n"
+        f"relational-only hotspots: {len(rel_only)}\n"
+        f"shared hotspots: {len(shared)}\n\n"
+        "cyan    = anisotropy-only\n"
+        "crimson = relational-only\n"
+        "gold    = shared\n\n"
+        "Conclusion:\n"
+        "both fields are seam-enriched,\n"
+        "but only weakly aligned\n"
+        "node-by-node."
+    )
+    ax_diag.text(
+        0.02,
+        0.98,
+        transport_text,
+        va="top",
+        ha="left",
+        fontsize=10.2,
+        family="monospace",
+        bbox=dict(boxstyle="round,pad=0.35", fc="white", ec="0.85", alpha=0.95),
+    )
+
+    fig.suptitle("PAM Observatory — OBS-025 two-field seam panel", fontsize=21)
+    fig.savefig(outpath, dpi=220)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Render OBS-025 two-field seam panel.")
+    parser.add_argument("--nodes-csv", default=Config.nodes_csv)
+    parser.add_argument("--seam-csv", default=Config.seam_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--seam-threshold", type=float, default=Config.seam_threshold)
+    parser.add_argument("--top-k-labels", type=int, default=Config.top_k_labels)
+    args = parser.parse_args()
+
+    cfg = Config(
+        nodes_csv=args.nodes_csv,
+        seam_csv=args.seam_csv,
+        outdir=args.outdir,
+        seam_threshold=args.seam_threshold,
+        top_k_labels=args.top_k_labels,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    nodes, seam = load_inputs(cfg)
+
+    txt_path = outdir / "obs025_two_field_seam_panel_summary.txt"
+    png_path = outdir / "obs025_two_field_seam_panel.png"
+
+    txt_path.write_text(build_summary(nodes, cfg.seam_threshold), encoding="utf-8")
+    render_panel(cfg, nodes, seam, png_path)
+
+    print(txt_path)
+    print(png_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Motivation

This PR consolidates the recent observatory work around:
	•	transport-aware directional mismatch
	•	relational seam obstruction
	•	branch-exit relaxation
	•	family-specific hotspot usage
	•	response anisotropy as a second seam-side structural field

The main goal is to move this stack from exploratory experiment code into a more canonical geometry layer, while preserving numerical behavior and upgrading the observatory figures accordingly.

This turns the seam-obstruction arc into a stable architectural slice:
	•	coherent directional field object
	•	reusable parallel transport module
	•	validated refactor
	•	upgraded 2D/3D observatory renderers
	•	OBS-023/024 analyses aligned to the same core logic
	•	OBS-025 synthesis of seam as a multi-field regime

⸻

Main contributions

1. Canonical directional-field layer
Adds a reusable geometry object for manifold-direction structure:
	•	src/pam/geometry/directional_field.py

This module packages:
	•	node geometry / coordinates
	•	graph edges
	•	Fisher connection proxy (fim_theta)
	•	response principal direction (rsp_theta)
	•	local pointwise mismatch
	•	neighbor / relational mismatch

This replaces scattered directional logic with one coherent field representation.

2. Canonical parallel-transport layer
Adds a reusable transport module:
	•	src/pam/geometry/parallel_transport.py

This module provides:
	•	edgewise parallel transport
	•	node transport summaries
	•	pathwise transport diagnostics
	•	loop transport residuals
	•	transported response vectors

This promotes transport from ad hoc experiment logic into a stable geometry-layer API.

3. Numerical refactor validation
The transport refactor was validated against the earlier toy implementation.

Validation result:
	•	transport_align_mean_deg: exact match
	•	transport_align_max_deg: exact match
	•	distance_to_seam: exact match

So the new canonical implementation is cleaner while remaining numerically faithful.

⸻

Observability / experiment changes

4. Refactored transport-alignment toy
Updated:
	•	experiments/toy/identity_transport_alignment_toy.py

Now uses:
	•	DirectionalField
	•	parallel_transport

This keeps the toy as a diagnostic sandbox while aligning it with the canonical geometry layer.

5. Refactored OBS-023
Updated:
	•	experiments/toy/obs023_transport_misalignment_figure.py
	•	experiments/toy/obs023_local_direction_mismatch.py

These now compute:
	•	transport-aware seam misalignment
	•	pointwise vs relational mismatch

directly from the canonical field object and transport module.

6. Refactored OBS-024 path analyses
Updated:
	•	experiments/toy/obs024_branch_exit_phase_profile.py
	•	experiments/toy/obs024_family_phase_profile_comparison.py

These now include phasewise path-transport diagnostics using the canonical transport API.

⸻

Figure / rendering upgrades

7. Upgraded 2D observatory plate
Updated:
	•	experiments/toy/render_scene_bundle_observatory_plate_obs024.py

Scientific visual grammar now distinguishes:
	•	phase substrate
	•	seam organizer
	•	route families
	•	routing hubs
	•	relational obstruction hotspots

This makes the 2D plate show not only where the seam is, but where transport coherence breaks.

8. Upgraded 3D PyVista scene
Updated:
	•	experiments/toy/render_scene_bundle_obs024_pyvista.py

Key upgrades:
	•	interactive mode restored
	•	seam rendered as structural organizer
	•	family routes layered more clearly
	•	hubs and obstruction hotspots visually separated
	•	obstruction hotspots rendered as charcoal cores with warm accent shells
	•	background substrate demoted so the seam-core obstruction ridge reads clearly

This makes the 3D scene scientifically legible rather than merely atmospheric.

⸻

Scientific results consolidated in this PR

OBS-023
Transport-aware response-field misalignment localizes strongly at the seam.

Interpretation:
	•	the seam is a directional incompatibility zone, not merely a scalar boundary

OBS-024
Pointwise and relational directional mismatch were separated.

Key result:
	•	relational mismatch localizes strongly at the seam
	•	pointwise mismatch localizes only weakly

Interpretation:
	•	seam obstruction is fundamentally relational, not pointwise

Branch-exit phase profiling
Branch-exit paths were segmented into:
	•	pre-contact
	•	seam-contact
	•	post-exit

Key result:
	•	relational mismatch remains high before and during seam contact
	•	then drops sharply after sustained exit

Interpretation:
	•	sustained exit relaxes seam obstruction

Family comparison
Compared:
	•	branch_exit
	•	stable_seam_corridor
	•	reorganization_heavy

Interpretation:
	•	branch-exit paths relax after departure
	•	corridor paths remain elevated
	•	reorganization-heavy paths redistribute stress more fragmentarily

Hotspot occupancy
High relational-mismatch nodes were treated as seam obstruction hotspots.

Interpretation:
	•	corridor paths reside on seam-core hotspots
	•	reorganization-heavy paths recycle a narrower stressed subset
	•	branch-exit paths touch and leave

⸻

New synthesis added in this PR: OBS-025

9. Response / complex compatibility
Added:
	•	experiments/studies/fim_response_complex_compatibility.py

This tested whether the local response operator T is compatible with a candidate local complex-rotation operator J via:
	•	||T J - J T||

Result:
	•	response / complex incompatibility is elevated near the seam

Interpretation:
	•	the seam is also a region where response dynamics are less compatible with local rotational symmetry

10. Response operator decomposition
Added:
	•	experiments/studies/fim_response_operator_decomposition.py

This decomposes the response tensor into:
	•	scalar part
	•	symmetric traceless part
	•	antisymmetric part

Key result:
	•	seam-side incompatibility is driven entirely by the symmetric traceless anisotropic part
	•	scalar and antisymmetric parts do not contribute to the commutator with J

Interpretation:
	•	seam incompatibility is specifically an anisotropy phenomenon

11. Two-field seam synthesis
Added:
	•	experiments/studies/obs025_anisotropy_vs_relational_obstruction.py
	•	experiments/studies/obs025_two_field_seam_panel.py

OBS-025 compares:
	•	response anisotropy (sym_traceless_norm)
	•	relational obstruction (neighbor_direction_mismatch_mean)

Key result:
	•	both fields are seam-enriched
	•	but they align only weakly node-by-node
	•	hotspot overlap is small

Interpretation:
	•	the seam is best understood as a multi-field structural regime, not a single stress field

This is the main conceptual synthesis added in this PR.

⸻

Architectural outcome

Before:
	•	directional logic distributed across toy scripts
	•	transport logic mostly local to experiments
	•	observatory figures only partially aligned with the seam-obstruction interpretation

After:
	•	coherent directional field object
	•	reusable parallel transport module
	•	validated transport refactor
	•	OBS-023/024 analyses aligned to the same core logic
	•	upgraded 2D/3D figures with consistent scientific grammar
	•	OBS-025 synthesis showing seam as a two-field regime:
	•	relational obstruction
	•	response anisotropy

⸻

Files / areas touched

New geometry-layer modules
	•	src/pam/geometry/directional_field.py
	•	src/pam/geometry/parallel_transport.py

Refactored / upgraded experiments
	•	experiments/toy/identity_transport_alignment_toy.py
	•	experiments/toy/obs023_transport_misalignment_figure.py
	•	experiments/toy/obs023_local_direction_mismatch.py
	•	experiments/toy/obs024_branch_exit_phase_profile.py
	•	experiments/toy/obs024_family_phase_profile_comparison.py
	•	experiments/toy/render_scene_bundle_observatory_plate_obs024.py
	•	experiments/toy/render_scene_bundle_obs024_pyvista.py
	•	experiments/toy/validate_directional_field_refactor.py

New study scripts
	•	experiments/studies/fim_identity_complex_structure.py
	•	experiments/studies/fim_response_complex_compatibility.py
	•	experiments/studies/fim_response_operator_decomposition.py
	•	experiments/studies/obs025_anisotropy_vs_relational_obstruction.py
	•	experiments/studies/obs025_two_field_seam_panel.py

⸻

Outputs affected

Representative outputs include:
	•	outputs/toy_identity_transport_alignment/
	•	outputs/obs023_transport_misalignment/
	•	outputs/obs023_local_direction_mismatch/
	•	outputs/obs024_branch_exit_phase_profile/
	•	outputs/obs024_family_phase_profile_comparison/
	•	outputs/obs022_scene_bundle_plate_obs024/
	•	outputs/obs022_scene_bundle_obs024_pyvista/
	•	outputs/validate_directional_field_refactor/
	•	outputs/fim_response_complex_compatibility/
	•	outputs/fim_response_operator_decomposition/
	•	outputs/obs025_anisotropy_vs_relational_obstruction/
	•	outputs/obs025_two_field_seam_panel/

⸻

Why this matters

This PR makes a conceptual shift explicit in code and figures:

the seam is no longer treated only as a scalar divider on a phase surface.

It is now modeled and rendered as:
	•	a relational obstruction regime
	•	defined by transport-aware directional incompatibility
	•	modulated by residency vs exit
	•	structured by family-specific hotspot usage
	•	accompanied by a distinct response anisotropy field
	•	best interpreted as a multi-field seam regime
