### PR TITLE
Add seam occupancy and canonical seam bundle studies

### DIFF
--- a/experiments/studies/obs026_family_two_field_occupancy.py
+++ b/experiments/studies/obs026_family_two_field_occupancy.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""
+OBS-026 — Family occupancy on the two-field seam structure.
+
+Compare realized route classes against three hotspot regimes:
+
+1. anisotropy-only hotspots
+2. relational-only hotspots
+3. shared hotspots
+
+This bridges:
+- OBS-024 family dynamics
+- OBS-025 two-field seam structure
+
+Inputs
+------
+outputs/obs025_anisotropy_vs_relational_obstruction/obs025_anisotropy_vs_relational_obstruction_nodes.csv
+outputs/obs022_scene_bundle/scene_routes.csv
+
+Outputs
+-------
+outputs/obs026_family_two_field_occupancy/
+  family_two_field_node_usage.csv
+  family_two_field_class_summary.csv
+  obs026_family_two_field_occupancy_summary.txt
+  obs026_family_two_field_occupancy_figure.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class Config:
+    nodes_csv: str = "outputs/obs025_anisotropy_vs_relational_obstruction/obs025_anisotropy_vs_relational_obstruction_nodes.csv"
+    routes_csv: str = "outputs/obs022_scene_bundle/scene_routes.csv"
+    outdir: str = "outputs/obs026_family_two_field_occupancy"
+    include_other: bool = False
+
+
+CLASS_ORDER = [
+    "branch_exit",
+    "stable_seam_corridor",
+    "reorganization_heavy",
+]
+
+HOTSPOT_ORDER = [
+    "anisotropy_only",
+    "relational_only",
+    "shared",
+    "non_hotspot",
+]
+
+
+def safe_mean(s: pd.Series) -> float:
+    s = pd.to_numeric(s, errors="coerce")
+    return float(s.mean()) if s.notna().any() else float("nan")
+
+
+def entropy_from_counts(counts: np.ndarray) -> float:
+    counts = np.asarray(counts, dtype=float)
+    total = counts.sum()
+    if total <= 0:
+        return float("nan")
+    p = counts / total
+    p = p[p > 0]
+    return float(-(p * np.log(p)).sum())
+
+
+def herfindahl_from_counts(counts: np.ndarray) -> float:
+    counts = np.asarray(counts, dtype=float)
+    total = counts.sum()
+    if total <= 0:
+        return float("nan")
+    p = counts / total
+    return float((p ** 2).sum())
+
+
+def classify_routes(routes: pd.DataFrame) -> pd.DataFrame:
+    out = routes.copy()
+    out["route_class"] = np.select(
+        [
+            pd.to_numeric(out.get("is_branch_away", 0), errors="coerce").fillna(0).eq(1),
+            (
+                pd.to_numeric(out.get("is_representative", 0), errors="coerce").fillna(0).eq(1)
+                & out.get("path_family", pd.Series(index=out.index, dtype=object)).eq("stable_seam_corridor")
+            ),
+            (
+                pd.to_numeric(out.get("is_representative", 0), errors="coerce").fillna(0).eq(1)
+                & out.get("path_family", pd.Series(index=out.index, dtype=object)).eq("reorganization_heavy")
+            ),
+        ],
+        [
+            "branch_exit",
+            "stable_seam_corridor",
+            "reorganization_heavy",
+        ],
+        default="other",
+    )
+    return out
+
+
+def assign_hotspot_class(nodes: pd.DataFrame) -> pd.DataFrame:
+    out = nodes.copy()
+
+    aniso = pd.to_numeric(out["anisotropy_hotspot"], errors="coerce").fillna(0).astype(int)
+    rel = pd.to_numeric(out["relational_hotspot"], errors="coerce").fillna(0).astype(int)
+    shared = pd.to_numeric(out["shared_hotspot"], errors="coerce").fillna(0).astype(int)
+
+    hotspot_class = np.full(len(out), "non_hotspot", dtype=object)
+    hotspot_class[(aniso == 1) & (shared == 0)] = "anisotropy_only"
+    hotspot_class[(rel == 1) & (shared == 0)] = "relational_only"
+    hotspot_class[shared == 1] = "shared"
+
+    out["hotspot_class"] = hotspot_class
+    return out
+
+
+def load_inputs(cfg: Config) -> tuple[pd.DataFrame, pd.DataFrame]:
+    nodes = pd.read_csv(cfg.nodes_csv)
+    routes = pd.read_csv(cfg.routes_csv)
+
+    for df in (nodes, routes):
+        for col in df.columns:
+            if col not in {"path_id", "path_family", "route_class", "hotspot_class"}:
+                try:
+                    df[col] = pd.to_numeric(df[col], errors="coerce")
+                except Exception:
+                    pass
+
+    nodes = assign_hotspot_class(nodes)
+    routes = classify_routes(routes)
+
+    keep_node_cols = [
+        c
+        for c in [
+            "node_id",
+            "r",
+            "alpha",
+            "distance_to_seam",
+            "sym_traceless_norm",
+            "neighbor_direction_mismatch_mean",
+            "anisotropy_hotspot",
+            "relational_hotspot",
+            "shared_hotspot",
+            "hotspot_class",
+        ]
+        if c in nodes.columns
+    ]
+
+    routes = routes.merge(
+        nodes[keep_node_cols].drop_duplicates(subset=["node_id"]),
+        on="node_id",
+        how="left",
+        suffixes=("", "_node"),
+    )
+
+    for base_col in [
+        "r",
+        "alpha",
+        "distance_to_seam",
+        "sym_traceless_norm",
+        "neighbor_direction_mismatch_mean",
+        "anisotropy_hotspot",
+        "relational_hotspot",
+        "shared_hotspot",
+        "hotspot_class",
+    ]:
+        node_col = f"{base_col}_node"
+        if base_col not in routes.columns and node_col in routes.columns:
+            routes[base_col] = routes[node_col]
+        elif base_col in routes.columns and node_col in routes.columns:
+            routes[base_col] = routes[base_col].where(routes[base_col].notna(), routes[node_col])
+
+    drop_cols = [c for c in routes.columns if c.endswith("_node")]
+    if drop_cols:
+        routes = routes.drop(columns=drop_cols)
+
+    return nodes, routes
+
+
+def compute_node_usage(routes: pd.DataFrame, include_other: bool) -> pd.DataFrame:
+    work = routes.copy()
+    if not include_other:
+        work = work[work["route_class"].isin(CLASS_ORDER)].copy()
+
+    usage = (
+        work.groupby(["route_class", "node_id", "hotspot_class"], as_index=False)
+        .agg(
+            n_rows=("path_id", "size"),
+            n_paths=("path_id", "nunique"),
+            mean_distance_to_seam=("distance_to_seam", "mean"),
+            mean_anisotropy=("sym_traceless_norm", "mean"),
+            mean_relational=("neighbor_direction_mismatch_mean", "mean"),
+        )
+    )
+    return usage.sort_values(["route_class", "n_rows"], ascending=[True, False]).reset_index(drop=True)
+
+
+def compute_class_summary(routes: pd.DataFrame, include_other: bool) -> pd.DataFrame:
+    work = routes.copy()
+    if not include_other:
+        work = work[work["route_class"].isin(CLASS_ORDER)].copy()
+
+    # path-level hotspot touch summary
+    path_touch = (
+        work.groupby(["route_class", "path_id"], as_index=False)
+        .agg(
+            touches_anisotropy_only=("hotspot_class", lambda s: int((s == "anisotropy_only").any())),
+            touches_relational_only=("hotspot_class", lambda s: int((s == "relational_only").any())),
+            touches_shared=("hotspot_class", lambda s: int((s == "shared").any())),
+            touches_any_hotspot=("hotspot_class", lambda s: int((s != "non_hotspot").any())),
+        )
+    )
+
+    rows = []
+    for cls, grp in work.groupby("route_class", sort=False):
+        total_rows = len(grp)
+        total_paths = int(grp["path_id"].nunique())
+        counts = grp["hotspot_class"].value_counts()
+
+        row = {
+            "route_class": cls,
+            "n_rows": total_rows,
+            "n_paths": total_paths,
+            "row_share_anisotropy_only": counts.get("anisotropy_only", 0) / max(total_rows, 1),
+            "row_share_relational_only": counts.get("relational_only", 0) / max(total_rows, 1),
+            "row_share_shared": counts.get("shared", 0) / max(total_rows, 1),
+            "row_share_non_hotspot": counts.get("non_hotspot", 0) / max(total_rows, 1),
+            "mean_distance_to_seam": safe_mean(grp["distance_to_seam"]),
+            "mean_anisotropy": safe_mean(grp["sym_traceless_norm"]),
+            "mean_relational": safe_mean(grp["neighbor_direction_mismatch_mean"]),
+        }
+
+        touch = path_touch[path_touch["route_class"] == cls]
+        row["path_touch_anisotropy_only"] = safe_mean(touch["touches_anisotropy_only"])
+        row["path_touch_relational_only"] = safe_mean(touch["touches_relational_only"])
+        row["path_touch_shared"] = safe_mean(touch["touches_shared"])
+        row["path_touch_any_hotspot"] = safe_mean(touch["touches_any_hotspot"])
+
+        hotspot_counts = np.array(
+            [
+                counts.get("anisotropy_only", 0),
+                counts.get("relational_only", 0),
+                counts.get("shared", 0),
+            ],
+            dtype=float,
+        )
+        row["hotspot_entropy"] = entropy_from_counts(hotspot_counts)
+        row["hotspot_herfindahl"] = herfindahl_from_counts(hotspot_counts)
+
+        rows.append(row)
+
+    out = pd.DataFrame(rows)
+    order = {k: i for i, k in enumerate(CLASS_ORDER)}
+    out["order"] = out["route_class"].map(lambda x: order.get(x, 999))
+    return out.sort_values("order").drop(columns="order").reset_index(drop=True)
+
+
+def build_summary(summary_df: pd.DataFrame) -> str:
+    lines = [
+        "=== OBS-026 Family Two-Field Occupancy Summary ===",
+        "",
+    ]
+
+    for _, row in summary_df.iterrows():
+        lines.extend(
+            [
+                f"{row['route_class']} (n_paths={int(row['n_paths'])}, n_rows={int(row['n_rows'])})",
+                f"  row_share_anisotropy_only = {float(row['row_share_anisotropy_only']):.4f}",
+                f"  row_share_relational_only = {float(row['row_share_relational_only']):.4f}",
+                f"  row_share_shared          = {float(row['row_share_shared']):.4f}",
+                f"  row_share_non_hotspot     = {float(row['row_share_non_hotspot']):.4f}",
+                f"  path_touch_anisotropy_only= {float(row['path_touch_anisotropy_only']):.4f}",
+                f"  path_touch_relational_only= {float(row['path_touch_relational_only']):.4f}",
+                f"  path_touch_shared         = {float(row['path_touch_shared']):.4f}",
+                f"  path_touch_any_hotspot    = {float(row['path_touch_any_hotspot']):.4f}",
+                f"  mean_distance_to_seam     = {float(row['mean_distance_to_seam']):.4f}",
+                f"  mean_anisotropy           = {float(row['mean_anisotropy']):.6f}",
+                f"  mean_relational           = {float(row['mean_relational']):.6f}",
+                f"  hotspot_entropy           = {float(row['hotspot_entropy']):.4f}",
+                f"  hotspot_herfindahl        = {float(row['hotspot_herfindahl']):.4f}",
+                "",
+            ]
+        )
+
+    lines.extend(
+        [
+            "Interpretive guide",
+            "- anisotropy-only occupancy indicates preference for response-side symmetry-breaking regions",
+            "- relational-only occupancy indicates preference for transport-obstruction regions",
+            "- shared occupancy indicates convergence on the seam-core where both fields intensify",
+            "- entropy/herfindahl summarize whether hotspot usage is distributed or concentrated",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def render_figure(summary_df: pd.DataFrame, outpath: Path) -> None:
+    fig, axes = plt.subplots(2, 2, figsize=(14.5, 9.5), constrained_layout=True)
+
+    classes = summary_df["route_class"].tolist()
+    x = np.arange(len(classes))
+    width = 0.24
+
+    # Row-share composition
+    ax = axes[0, 0]
+    ax.bar(x - width, summary_df["row_share_anisotropy_only"], width, label="anisotropy-only")
+    ax.bar(x, summary_df["row_share_relational_only"], width, label="relational-only")
+    ax.bar(x + width, summary_df["row_share_shared"], width, label="shared")
+    ax.set_xticks(x)
+    ax.set_xticklabels(classes, rotation=12)
+    ax.set_ylabel("row share")
+    ax.set_title("Hotspot regime occupancy", fontsize=14, pad=8)
+    ax.grid(alpha=0.15, axis="y")
+    ax.legend()
+
+    # Path-touch summary
+    ax = axes[0, 1]
+    ax.bar(x - width, summary_df["path_touch_anisotropy_only"], width, label="anisotropy-only")
+    ax.bar(x, summary_df["path_touch_relational_only"], width, label="relational-only")
+    ax.bar(x + width, summary_df["path_touch_shared"], width, label="shared")
+    ax.set_xticks(x)
+    ax.set_xticklabels(classes, rotation=12)
+    ax.set_ylabel("fraction of paths touching class")
+    ax.set_title("Path-touch profile", fontsize=14, pad=8)
+    ax.grid(alpha=0.15, axis="y")
+
+    # Mean field values
+    ax = axes[1, 0]
+    ax.bar(x - width / 2, summary_df["mean_anisotropy"], width, label="mean anisotropy")
+    ax.bar(x + width / 2, summary_df["mean_relational"], width, label="mean relational")
+    ax.set_xticks(x)
+    ax.set_xticklabels(classes, rotation=12)
+    ax.set_title("Mean field exposure", fontsize=14, pad=8)
+    ax.grid(alpha=0.15, axis="y")
+    ax.legend()
+
+    # Concentration / spread
+    ax = axes[1, 1]
+    ax.bar(x - width / 2, summary_df["hotspot_entropy"], width, label="entropy")
+    ax.bar(x + width / 2, summary_df["hotspot_herfindahl"], width, label="herfindahl")
+    ax.set_xticks(x)
+    ax.set_xticklabels(classes, rotation=12)
+    ax.set_title("Hotspot usage structure", fontsize=14, pad=8)
+    ax.grid(alpha=0.15, axis="y")
+    ax.legend()
+
+    fig.suptitle("PAM Observatory — OBS-026 family occupancy on two-field seam structure", fontsize=18)
+    fig.savefig(outpath, dpi=220)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compare family occupancy on the two-field seam structure.")
+    parser.add_argument("--nodes-csv", default=Config.nodes_csv)
+    parser.add_argument("--routes-csv", default=Config.routes_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--include-other", action="store_true")
+    args = parser.parse_args()
+
+    cfg = Config(
+        nodes_csv=args.nodes_csv,
+        routes_csv=args.routes_csv,
+        outdir=args.outdir,
+        include_other=args.include_other,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    _, routes = load_inputs(cfg)
+    node_usage = compute_node_usage(routes, cfg.include_other)
+    summary_df = compute_class_summary(routes, cfg.include_other)
+
+    node_csv = outdir / "family_two_field_node_usage.csv"
+    class_csv = outdir / "family_two_field_class_summary.csv"
+    txt_path = outdir / "obs026_family_two_field_occupancy_summary.txt"
+    png_path = outdir / "obs026_family_two_field_occupancy_figure.png"
+
+    node_usage.to_csv(node_csv, index=False)
+    summary_df.to_csv(class_csv, index=False)
+    txt_path.write_text(build_summary(summary_df), encoding="utf-8")
+    render_figure(summary_df, png_path)
+
+    print(node_csv)
+    print(class_csv)
+    print(txt_path)
+    print(png_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/studies/obs027_seam_regime_synthesis.py
+++ b/experiments/studies/obs027_seam_regime_synthesis.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""
+OBS-027 — Seam-regime synthesis.
+
+Unify OBS-023 through OBS-026 into one canonical seam figure.
+
+Panels
+------
+A. Relational obstruction field
+B. Response anisotropy field
+C. Two-field hotspot overlap
+D. Family two-field occupancy summary
+E. Seam-regime synthesis text box
+
+Inputs
+------
+outputs/obs025_anisotropy_vs_relational_obstruction/obs025_anisotropy_vs_relational_obstruction_nodes.csv
+outputs/obs026_family_two_field_occupancy/family_two_field_class_summary.csv
+outputs/obs022_scene_bundle/scene_seam.csv
+
+Outputs
+-------
+outputs/obs027_seam_regime_synthesis/
+  obs027_seam_regime_synthesis_summary.txt
+  obs027_seam_regime_synthesis.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class Config:
+    nodes_csv: str = "outputs/obs025_anisotropy_vs_relational_obstruction/obs025_anisotropy_vs_relational_obstruction_nodes.csv"
+    family_summary_csv: str = "outputs/obs026_family_two_field_occupancy/family_two_field_class_summary.csv"
+    seam_csv: str = "outputs/obs022_scene_bundle/scene_seam.csv"
+    outdir: str = "outputs/obs027_seam_regime_synthesis"
+    seam_threshold: float = 0.15
+    top_k_shared_labels: int = 4
+
+
+CLASS_ORDER = [
+    "branch_exit",
+    "stable_seam_corridor",
+    "reorganization_heavy",
+]
+
+
+def safe_corr(a: pd.Series, b: pd.Series) -> float:
+    aa = pd.to_numeric(a, errors="coerce")
+    bb = pd.to_numeric(b, errors="coerce")
+    mask = aa.notna() & bb.notna()
+    if int(mask.sum()) < 3:
+        return float("nan")
+    return float(np.corrcoef(aa[mask], bb[mask])[0, 1])
+
+
+def safe_mean(s: pd.Series) -> float:
+    s = pd.to_numeric(s, errors="coerce")
+    return float(s.mean()) if s.notna().any() else float("nan")
+
+
+def load_inputs(cfg: Config) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    nodes = pd.read_csv(cfg.nodes_csv)
+    fam = pd.read_csv(cfg.family_summary_csv)
+    seam = pd.read_csv(cfg.seam_csv)
+
+    for df in (nodes, fam, seam):
+        for col in df.columns:
+            if col not in {"path_id", "path_family", "route_class", "hotspot_class", "dominant_component"}:
+                try:
+                    df[col] = pd.to_numeric(df[col], errors="coerce")
+                except Exception:
+                    pass
+
+    required_nodes = [
+        "node_id", "mds1", "mds2", "distance_to_seam",
+        "sym_traceless_norm", "neighbor_direction_mismatch_mean",
+        "anisotropy_hotspot", "relational_hotspot", "shared_hotspot",
+    ]
+    missing = [c for c in required_nodes if c not in nodes.columns]
+    if missing:
+        raise ValueError(f"Missing required node columns: {missing}")
+
+    if "route_class" in fam.columns:
+        order = {k: i for i, k in enumerate(CLASS_ORDER)}
+        fam["order"] = fam["route_class"].map(lambda x: order.get(x, 999))
+        fam = fam.sort_values("order").drop(columns="order").reset_index(drop=True)
+
+    return nodes, fam, seam
+
+
+def build_summary(nodes: pd.DataFrame, fam: pd.DataFrame, seam_threshold: float) -> str:
+    seam_mask = pd.to_numeric(nodes["distance_to_seam"], errors="coerce") <= seam_threshold
+
+    aniso_only = ((nodes["anisotropy_hotspot"] == 1) & (nodes["shared_hotspot"] == 0)).sum()
+    rel_only = ((nodes["relational_hotspot"] == 1) & (nodes["shared_hotspot"] == 0)).sum()
+    shared = (nodes["shared_hotspot"] == 1).sum()
+
+    lines = [
+        "=== OBS-027 Seam Regime Synthesis Summary ===",
+        "",
+        f"n_nodes = {len(nodes)}",
+        f"seam_threshold = {seam_threshold:.4f}",
+        "",
+        "Field synthesis",
+        f"  mean anisotropy                = {safe_mean(nodes['sym_traceless_norm']):.6f}",
+        f"  mean relational obstruction    = {safe_mean(nodes['neighbor_direction_mismatch_mean']):.6f}",
+        f"  corr(aniso, relational)        = {safe_corr(nodes['sym_traceless_norm'], nodes['neighbor_direction_mismatch_mean']):.4f}",
+        f"  seam-band mean anisotropy      = {safe_mean(nodes.loc[seam_mask, 'sym_traceless_norm']):.6f}",
+        f"  off-seam mean anisotropy       = {safe_mean(nodes.loc[~seam_mask, 'sym_traceless_norm']):.6f}",
+        f"  seam-band mean relational      = {safe_mean(nodes.loc[seam_mask, 'neighbor_direction_mismatch_mean']):.6f}",
+        f"  off-seam mean relational       = {safe_mean(nodes.loc[~seam_mask, 'neighbor_direction_mismatch_mean']):.6f}",
+        "",
+        "Hotspot structure",
+        f"  anisotropy-only hotspots       = {int(aniso_only)}",
+        f"  relational-only hotspots       = {int(rel_only)}",
+        f"  shared hotspots                = {int(shared)}",
+        "",
+        "Family occupancy synthesis",
+    ]
+
+    for _, row in fam.iterrows():
+        lines.append(
+            f"  {row['route_class']}: "
+            f"row(aniso-only)={float(row['row_share_anisotropy_only']):.4f}, "
+            f"row(rel-only)={float(row['row_share_relational_only']):.4f}, "
+            f"row(shared)={float(row['row_share_shared']):.4f}, "
+            f"touch(shared)={float(row['path_touch_shared']):.4f}, "
+            f"mean_d2s={float(row['mean_distance_to_seam']):.4f}"
+        )
+
+    lines.extend(
+        [
+            "",
+            "Canonical interpretation",
+            "- the seam is a multi-field structural regime",
+            "- relational obstruction is the stronger seam discriminator",
+            "- response anisotropy is a distinct seam-side field",
+            "- hotspot overlap is small, so the fields are not reducible to one another",
+            "- families differ by residency pattern within this two-field regime",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def render_figure(cfg: Config, nodes: pd.DataFrame, fam: pd.DataFrame, seam: pd.DataFrame, outpath: Path) -> None:
+    seam_mask = pd.to_numeric(nodes["distance_to_seam"], errors="coerce") <= cfg.seam_threshold
+    aniso_only = nodes[(nodes["anisotropy_hotspot"] == 1) & (nodes["shared_hotspot"] == 0)].copy()
+    rel_only = nodes[(nodes["relational_hotspot"] == 1) & (nodes["shared_hotspot"] == 0)].copy()
+    shared = nodes[nodes["shared_hotspot"] == 1].copy()
+
+    fig = plt.figure(figsize=(16.5, 10), constrained_layout=True)
+    gs = fig.add_gridspec(2, 3, width_ratios=[1.35, 1.35, 1.15], height_ratios=[1.0, 1.0])
+
+    ax_rel = fig.add_subplot(gs[0, 0])
+    ax_aniso = fig.add_subplot(gs[0, 1])
+    ax_overlap = fig.add_subplot(gs[0, 2])
+    ax_occ = fig.add_subplot(gs[1, 0:2])
+    ax_diag = fig.add_subplot(gs[1, 2])
+
+    seam_draw = seam.dropna(subset=["mds1", "mds2"]).sort_values("mds1")
+
+    def draw_seam(ax):
+        if len(seam_draw):
+            ax.plot(seam_draw["mds1"], seam_draw["mds2"], color="white", linewidth=5.5, alpha=0.65, zorder=1)
+            ax.plot(seam_draw["mds1"], seam_draw["mds2"], color="black", linewidth=2.6, alpha=0.96, zorder=2)
+
+    # A relational
+    draw_seam(ax_rel)
+    sc_rel = ax_rel.scatter(
+        nodes["mds1"], nodes["mds2"],
+        c=pd.to_numeric(nodes["neighbor_direction_mismatch_mean"], errors="coerce"),
+        cmap="magma", s=92, alpha=0.96, linewidths=0.35, edgecolors="white", zorder=3
+    )
+    ax_rel.scatter(
+        nodes.loc[seam_mask, "mds1"], nodes.loc[seam_mask, "mds2"],
+        s=160, facecolors="none", edgecolors="black", linewidths=1.0, zorder=4
+    )
+    cbar_rel = fig.colorbar(sc_rel, ax=ax_rel, fraction=0.046, pad=0.02)
+    cbar_rel.set_label("relational mismatch (deg)")
+    ax_rel.set_title("A — relational obstruction", fontsize=15, pad=8)
+    ax_rel.set_xlabel("MDS 1")
+    ax_rel.set_ylabel("MDS 2")
+    ax_rel.grid(alpha=0.08)
+    ax_rel.set_aspect("equal", adjustable="box")
+
+    # B anisotropy
+    draw_seam(ax_aniso)
+    sc_aniso = ax_aniso.scatter(
+        nodes["mds1"], nodes["mds2"],
+        c=pd.to_numeric(nodes["sym_traceless_norm"], errors="coerce"),
+        cmap="viridis", s=92, alpha=0.96, linewidths=0.35, edgecolors="white", zorder=3
+    )
+    ax_aniso.scatter(
+        nodes.loc[seam_mask, "mds1"], nodes.loc[seam_mask, "mds2"],
+        s=160, facecolors="none", edgecolors="black", linewidths=1.0, zorder=4
+    )
+    cbar_aniso = fig.colorbar(sc_aniso, ax=ax_aniso, fraction=0.046, pad=0.02)
+    cbar_aniso.set_label("sym. traceless norm")
+    ax_aniso.set_title("B — response anisotropy", fontsize=15, pad=8)
+    ax_aniso.set_xlabel("MDS 1")
+    ax_aniso.set_ylabel("MDS 2")
+    ax_aniso.grid(alpha=0.08)
+    ax_aniso.set_aspect("equal", adjustable="box")
+
+    # C overlap
+    draw_seam(ax_overlap)
+    ax_overlap.scatter(nodes["mds1"], nodes["mds2"], s=42, c="lightgray", alpha=0.55, linewidths=0, zorder=2.5)
+    if len(aniso_only):
+        ax_overlap.scatter(aniso_only["mds1"], aniso_only["mds2"], s=120, c="#2A9D8F", alpha=0.95, zorder=3)
+    if len(rel_only):
+        ax_overlap.scatter(rel_only["mds1"], rel_only["mds2"], s=120, c="#B23A48", alpha=0.95, zorder=3.2)
+    if len(shared):
+        ax_overlap.scatter(shared["mds1"], shared["mds2"], s=155, c="#FFD166",
+                           edgecolors="black", linewidths=1.0, alpha=0.98, zorder=4)
+
+    top_shared = shared.sort_values(
+        ["sym_traceless_norm", "neighbor_direction_mismatch_mean"],
+        ascending=False,
+    ).head(cfg.top_k_shared_labels)
+    for _, row in top_shared.iterrows():
+        ax_overlap.text(
+            float(row["mds1"]) + 0.05,
+            float(row["mds2"]) + 0.05,
+            f"{int(row['node_id'])}",
+            fontsize=8.5,
+            bbox=dict(boxstyle="round,pad=0.18", fc="white", ec="0.8", alpha=0.9),
+            zorder=5,
+        )
+
+    ax_overlap.set_title("C — two-field hotspot overlap", fontsize=15, pad=8)
+    ax_overlap.set_xlabel("MDS 1")
+    ax_overlap.set_ylabel("MDS 2")
+    ax_overlap.grid(alpha=0.08)
+    ax_overlap.set_aspect("equal", adjustable="box")
+
+    # D family occupancy
+    classes = fam["route_class"].tolist()
+    x = np.arange(len(classes))
+    width = 0.24
+
+    ax_occ.bar(x - width, fam["row_share_anisotropy_only"], width, label="anisotropy-only")
+    ax_occ.bar(x, fam["row_share_relational_only"], width, label="relational-only")
+    ax_occ.bar(x + width, fam["row_share_shared"], width, label="shared")
+    ax_occ.set_xticks(x)
+    ax_occ.set_xticklabels(classes, rotation=12)
+    ax_occ.set_ylabel("row share")
+    ax_occ.set_title("D — family occupancy on seam fields", fontsize=15, pad=8)
+    ax_occ.grid(alpha=0.15, axis="y")
+    ax_occ.legend()
+
+    # E synthesis box
+    ax_diag.axis("off")
+
+    aniso_ratio = (
+        safe_mean(nodes.loc[seam_mask, "sym_traceless_norm"])
+        / safe_mean(nodes.loc[~seam_mask, "sym_traceless_norm"])
+    )
+    rel_ratio = (
+        safe_mean(nodes.loc[seam_mask, "neighbor_direction_mismatch_mean"])
+        / safe_mean(nodes.loc[~seam_mask, "neighbor_direction_mismatch_mean"])
+    )
+
+    text = (
+        "OBS-027 synthesis\n\n"
+        f"corr(aniso, relational): {safe_corr(nodes['sym_traceless_norm'], nodes['neighbor_direction_mismatch_mean']):.3f}\n"
+        f"aniso seam enrichment: {aniso_ratio:.2f}×\n"
+        f"rel seam enrichment: {rel_ratio:.2f}×\n\n"
+        f"aniso-only hotspots: {len(aniso_only)}\n"
+        f"rel-only hotspots: {len(rel_only)}\n"
+        f"shared hotspots: {len(shared)}\n\n"
+        "stable corridor:\nstrongest two-field resident\n\n"
+        "reorg-heavy:\nbalanced but more diffuse\n\n"
+        "branch-exit:\ntouch-and-leave class\n\n"
+        "Conclusion:\n"
+        "the seam is a multi-field,\n"
+        "family-selective residency\n"
+        "landscape."
+    )
+    ax_diag.text(
+        0.02, 0.98, text,
+        va="top", ha="left", fontsize=10.2, family="monospace",
+        bbox=dict(boxstyle="round,pad=0.35", fc="white", ec="0.85", alpha=0.95),
+    )
+
+    fig.suptitle("PAM Observatory — OBS-027 seam-regime synthesis", fontsize=21)
+    fig.savefig(outpath, dpi=220)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Render OBS-027 seam-regime synthesis.")
+    parser.add_argument("--nodes-csv", default=Config.nodes_csv)
+    parser.add_argument("--family-summary-csv", default=Config.family_summary_csv)
+    parser.add_argument("--seam-csv", default=Config.seam_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--seam-threshold", type=float, default=Config.seam_threshold)
+    parser.add_argument("--top-k-shared-labels", type=int, default=Config.top_k_shared_labels)
+    args = parser.parse_args()
+
+    cfg = Config(
+        nodes_csv=args.nodes_csv,
+        family_summary_csv=args.family_summary_csv,
+        seam_csv=args.seam_csv,
+        outdir=args.outdir,
+        seam_threshold=args.seam_threshold,
+        top_k_shared_labels=args.top_k_shared_labels,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    nodes, fam, seam = load_inputs(cfg)
+
+    txt_path = outdir / "obs027_seam_regime_synthesis_summary.txt"
+    png_path = outdir / "obs027_seam_regime_synthesis.png"
+
+    txt_path.write_text(build_summary(nodes, fam, cfg.seam_threshold), encoding="utf-8")
+    render_figure(cfg, nodes, fam, seam, png_path)
+
+    print(txt_path)
+    print(png_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/studies/obs028_embedding_comparison.py
+++ b/experiments/studies/obs028_embedding_comparison.py
@@ -1,0 +1,558 @@
+#!/usr/bin/env python3
+"""
+OBS-028 — Embedding comparison for the PAM observatory.
+
+Compare multiple low-dimensional embeddings built from the observatory graph:
+
+1. MDS                  (distance-faithful baseline)
+2. Isomap               (graph-geodesic manifold embedding)
+3. Laplacian Eigenmaps  (local graph structure / boundary-sensitive)
+4. Diffusion coordinates (slow connectivity modes)
+5. UMAP                 (optional exploratory view, if installed)
+
+Evaluation is observatory-specific, not purely visual.
+
+We report for each embedding:
+- seam-band separation score
+- family centroid separation score
+- hotspot compactness score
+- trustworthiness-like nearest-neighbor retention score
+
+Inputs
+------
+outputs/obs022_scene_bundle/scene_nodes.csv
+outputs/obs022_scene_bundle/scene_edges.csv
+outputs/obs022_scene_bundle/scene_routes.csv
+
+Outputs
+-------
+outputs/obs028_embedding_comparison/
+  embedding_scores.csv
+  embedding_nodes_mds.csv
+  embedding_nodes_isomap.csv
+  embedding_nodes_laplacian.csv
+  embedding_nodes_diffusion.csv
+  embedding_nodes_umap.csv          (if UMAP available)
+  obs028_embedding_comparison_summary.txt
+  obs028_embedding_comparison.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from sklearn.manifold import Isomap, MDS, trustworthiness
+from sklearn.neighbors import NearestNeighbors
+
+try:
+    from sklearn.manifold import SpectralEmbedding
+except Exception:
+    SpectralEmbedding = None
+
+try:
+    import umap  # type: ignore
+except Exception:
+    umap = None
+
+
+@dataclass(frozen=True)
+class Config:
+    nodes_csv: str = "outputs/obs022_scene_bundle/scene_nodes.csv"
+    edges_csv: str = "outputs/obs022_scene_bundle/scene_edges.csv"
+    routes_csv: str = "outputs/obs022_scene_bundle/scene_routes.csv"
+    outdir: str = "outputs/obs028_embedding_comparison"
+    seam_threshold: float = 0.15
+    hotspot_quantile: float = 0.85
+    n_neighbors: int = 8
+    random_state: int = 42
+    include_umap: bool = True
+
+
+CLASS_ORDER = [
+    "branch_exit",
+    "stable_seam_corridor",
+    "reorganization_heavy",
+]
+
+
+def safe_mean(s: pd.Series) -> float:
+    s = pd.to_numeric(s, errors="coerce")
+    return float(s.mean()) if s.notna().any() else float("nan")
+
+
+def pairwise_dist(X: np.ndarray) -> np.ndarray:
+    diffs = X[:, None, :] - X[None, :, :]
+    return np.sqrt(np.sum(diffs * diffs, axis=2))
+
+
+def load_inputs(cfg: Config) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    nodes = pd.read_csv(cfg.nodes_csv)
+    edges = pd.read_csv(cfg.edges_csv)
+    routes = pd.read_csv(cfg.routes_csv)
+
+    for df in (nodes, edges, routes):
+        for col in df.columns:
+            if col not in {"path_id", "path_family"}:
+                try:
+                    df[col] = pd.to_numeric(df[col], errors="coerce")
+                except Exception:
+                    pass
+
+    if "is_branch_away" not in routes.columns:
+        routes["is_branch_away"] = 0
+    if "is_representative" not in routes.columns:
+        routes["is_representative"] = 0
+
+    return nodes, edges, routes
+
+
+def classify_routes(routes: pd.DataFrame) -> pd.DataFrame:
+    out = routes.copy()
+    fam = out.get("path_family", pd.Series(index=out.index, dtype=object))
+    out["route_class"] = np.select(
+        [
+            pd.to_numeric(out["is_branch_away"], errors="coerce").fillna(0).eq(1),
+            pd.to_numeric(out["is_representative"], errors="coerce").fillna(0).eq(1) & fam.eq("stable_seam_corridor"),
+            pd.to_numeric(out["is_representative"], errors="coerce").fillna(0).eq(1) & fam.eq("reorganization_heavy"),
+        ],
+        [
+            "branch_exit",
+            "stable_seam_corridor",
+            "reorganization_heavy",
+        ],
+        default="other",
+    )
+    return out
+
+
+def build_feature_table(nodes: pd.DataFrame, routes: pd.DataFrame, cfg: Config) -> pd.DataFrame:
+    routes = classify_routes(routes)
+
+    family_touch = (
+        routes[routes["route_class"].isin(CLASS_ORDER)]
+        .groupby(["node_id", "route_class"], as_index=False)
+        .agg(n_rows=("path_id", "size"), n_paths=("path_id", "nunique"))
+    )
+
+    pivot_rows = (
+        family_touch.pivot(index="node_id", columns="route_class", values="n_rows")
+        .fillna(0.0)
+        .reset_index()
+    )
+    pivot_rows.columns.name = None
+    for cls in CLASS_ORDER:
+        if cls not in pivot_rows.columns:
+            pivot_rows[cls] = 0.0
+
+    out = nodes.merge(pivot_rows, on="node_id", how="left")
+    for cls in CLASS_ORDER:
+        out[cls] = pd.to_numeric(out[cls], errors="coerce").fillna(0.0)
+
+    # hotspot labels if available, otherwise derive from existing fields
+    if "shared_hotspot" not in out.columns:
+        if "sym_traceless_norm" in out.columns:
+            thr_a = float(pd.to_numeric(out["sym_traceless_norm"], errors="coerce").quantile(cfg.hotspot_quantile))
+            out["anisotropy_hotspot"] = (pd.to_numeric(out["sym_traceless_norm"], errors="coerce") >= thr_a).astype(int)
+        else:
+            out["anisotropy_hotspot"] = 0
+        if "neighbor_direction_mismatch_mean" in out.columns:
+            thr_r = float(pd.to_numeric(out["neighbor_direction_mismatch_mean"], errors="coerce").quantile(cfg.hotspot_quantile))
+            out["relational_hotspot"] = (pd.to_numeric(out["neighbor_direction_mismatch_mean"], errors="coerce") >= thr_r).astype(int)
+        else:
+            out["relational_hotspot"] = 0
+        out["shared_hotspot"] = (
+            (pd.to_numeric(out["anisotropy_hotspot"], errors="coerce").fillna(0) == 1)
+            & (pd.to_numeric(out["relational_hotspot"], errors="coerce").fillna(0) == 1)
+        ).astype(int)
+
+    feature_cols = [
+        c for c in [
+            "signed_phase",
+            "distance_to_seam",
+            "lazarus_score",
+            "response_strength",
+            "sym_traceless_norm",
+            "neighbor_direction_mismatch_mean",
+            "node_holonomy_proxy",
+            "stable_seam_corridor",
+            "reorganization_heavy",
+            "branch_exit",
+        ] if c in out.columns
+    ]
+
+    for c in feature_cols:
+        out[c] = pd.to_numeric(out[c], errors="coerce").fillna(0.0)
+
+    # standardize
+    X = out[feature_cols].to_numpy(dtype=float)
+    mu = X.mean(axis=0, keepdims=True)
+    sigma = X.std(axis=0, keepdims=True)
+    sigma[sigma < 1e-12] = 1.0
+    Xz = (X - mu) / sigma
+
+    out.attrs["feature_cols"] = feature_cols
+    out.attrs["Xz"] = Xz
+    return out
+
+
+def compute_graph_distance(nodes: pd.DataFrame, edges: pd.DataFrame) -> np.ndarray:
+    node_ids = pd.to_numeric(nodes["node_id"], errors="coerce").astype(int).tolist()
+    idx = {nid: i for i, nid in enumerate(node_ids)}
+    n = len(node_ids)
+    D = np.full((n, n), np.inf, dtype=float)
+    np.fill_diagonal(D, 0.0)
+
+    for _, row in edges.iterrows():
+        try:
+            u = idx[int(row["src_id"])]
+            v = idx[int(row["dst_id"])]
+        except Exception:
+            continue
+
+        if "edge_cost" in edges.columns and pd.notna(row.get("edge_cost", np.nan)):
+            w = float(row["edge_cost"])
+        else:
+            # fallback to Euclidean in MDS plane if edge_cost absent
+            try:
+                x1, y1 = float(row["src_mds1"]), float(row["src_mds2"])
+                x2, y2 = float(row["dst_mds1"]), float(row["dst_mds2"])
+                w = float(np.hypot(x2 - x1, y2 - y1))
+            except Exception:
+                w = 1.0
+
+        if not np.isfinite(w):
+            continue
+
+        D[u, v] = min(D[u, v], w)
+        D[v, u] = min(D[v, u], w)
+
+    # Floyd-Warshall is fine for n=75
+    for k in range(n):
+        D = np.minimum(D, D[:, [k]] + D[[k], :])
+
+    # fill any disconnected pairs with max finite distance
+    finite = D[np.isfinite(D)]
+    max_finite = float(finite.max()) if finite.size else 1.0
+    D[~np.isfinite(D)] = max_finite
+    return D
+
+
+def embed_mds(D: np.ndarray, cfg: Config) -> np.ndarray:
+    model = MDS(
+        n_components=2,
+        dissimilarity="precomputed",
+        random_state=cfg.random_state,
+        normalized_stress="auto",
+    )
+    return model.fit_transform(D)
+
+
+def embed_isomap(D: np.ndarray, cfg: Config) -> np.ndarray:
+    model = Isomap(n_components=2, metric="precomputed", n_neighbors=cfg.n_neighbors)
+    return model.fit_transform(D)
+
+
+def embed_laplacian(D: np.ndarray, cfg: Config) -> np.ndarray:
+    if SpectralEmbedding is None:
+        raise RuntimeError("SpectralEmbedding unavailable")
+    sigma = np.median(D[D > 0])
+    if not np.isfinite(sigma) or sigma <= 0:
+        sigma = 1.0
+    A = np.exp(-(D ** 2) / (2 * sigma ** 2))
+    np.fill_diagonal(A, 0.0)
+    model = SpectralEmbedding(
+        n_components=2,
+        affinity="precomputed",
+        random_state=cfg.random_state,
+    )
+    return model.fit_transform(A)
+
+
+def embed_diffusion(D: np.ndarray, cfg: Config) -> np.ndarray:
+    sigma = np.median(D[D > 0])
+    if not np.isfinite(sigma) or sigma <= 0:
+        sigma = 1.0
+    K = np.exp(-(D ** 2) / (2 * sigma ** 2))
+    np.fill_diagonal(K, 0.0)
+
+    row_sum = K.sum(axis=1, keepdims=True)
+    row_sum[row_sum <= 1e-12] = 1.0
+    P = K / row_sum
+
+    vals, vecs = np.linalg.eig(P)
+    vals = np.real(vals)
+    vecs = np.real(vecs)
+
+    order = np.argsort(vals)[::-1]
+    vals = vals[order]
+    vecs = vecs[:, order]
+
+    # skip trivial first eigenvector
+    coords = vecs[:, 1:3] * vals[1:3]
+    return coords
+
+
+def embed_umap_from_features(Xz: np.ndarray, cfg: Config) -> np.ndarray:
+    if umap is None:
+        raise RuntimeError("UMAP unavailable")
+    model = umap.UMAP(
+        n_components=2,
+        n_neighbors=cfg.n_neighbors,
+        random_state=cfg.random_state,
+        min_dist=0.15,
+    )
+    return model.fit_transform(Xz)
+
+
+def seam_separation_score(df: pd.DataFrame, seam_threshold: float) -> float:
+    seam = pd.to_numeric(df["distance_to_seam"], errors="coerce") <= seam_threshold
+    A = df.loc[seam, ["emb1", "emb2"]].to_numpy(dtype=float)
+    B = df.loc[~seam, ["emb1", "emb2"]].to_numpy(dtype=float)
+    if len(A) < 2 or len(B) < 2:
+        return float("nan")
+    muA = A.mean(axis=0)
+    muB = B.mean(axis=0)
+    varA = float(np.mean(np.sum((A - muA) ** 2, axis=1)))
+    varB = float(np.mean(np.sum((B - muB) ** 2, axis=1)))
+    denom = np.sqrt(max(varA + varB, 1e-12))
+    return float(np.linalg.norm(muA - muB) / denom)
+
+
+def family_centroid_score(df: pd.DataFrame) -> float:
+    rows = []
+    for cls in CLASS_ORDER:
+        weight = pd.to_numeric(df.get(cls, 0), errors="coerce").fillna(0.0)
+        if float(weight.sum()) <= 0:
+            continue
+        X = df[["emb1", "emb2"]].to_numpy(dtype=float)
+        mu = (X * weight.to_numpy()[:, None]).sum(axis=0) / float(weight.sum())
+        rows.append(mu)
+    if len(rows) < 2:
+        return float("nan")
+    rows = np.vstack(rows)
+    d = pairwise_dist(rows)
+    iu = np.triu_indices_from(d, k=1)
+    return float(np.mean(d[iu]))
+
+
+def hotspot_compactness_score(df: pd.DataFrame) -> float:
+    shared = pd.to_numeric(df.get("shared_hotspot", 0), errors="coerce").fillna(0) == 1
+    Xs = df.loc[shared, ["emb1", "emb2"]].to_numpy(dtype=float)
+    if len(Xs) < 2:
+        return float("nan")
+    mu = Xs.mean(axis=0)
+    return float(np.mean(np.sqrt(np.sum((Xs - mu) ** 2, axis=1))))
+
+
+def nn_retention_score(Xref: np.ndarray, Y: np.ndarray, k: int = 8) -> float:
+    nn_ref = NearestNeighbors(n_neighbors=min(k + 1, len(Xref))).fit(Xref)
+    nn_emb = NearestNeighbors(n_neighbors=min(k + 1, len(Y))).fit(Y)
+
+    idx_ref = nn_ref.kneighbors(return_distance=False)[:, 1:]
+    idx_emb = nn_emb.kneighbors(return_distance=False)[:, 1:]
+
+    overlaps = []
+    for a, b in zip(idx_ref, idx_emb):
+        overlaps.append(len(set(map(int, a)) & set(map(int, b))) / max(len(a), 1))
+    return float(np.mean(overlaps))
+
+
+def score_embedding(df: pd.DataFrame, Xref: np.ndarray, cfg: Config) -> dict[str, float]:
+    Y = df[["emb1", "emb2"]].to_numpy(dtype=float)
+    return {
+        "seam_separation": seam_separation_score(df, cfg.seam_threshold),
+        "family_centroid_separation": family_centroid_score(df),
+        "shared_hotspot_compactness": hotspot_compactness_score(df),
+        "trustworthiness": float(trustworthiness(Xref, Y, n_neighbors=min(cfg.n_neighbors, len(df) - 1))),
+        "nn_retention": nn_retention_score(Xref, Y, k=cfg.n_neighbors),
+    }
+
+
+def render_panel(embed_tables: dict[str, pd.DataFrame], scores: pd.DataFrame, outpath: Path) -> None:
+    names = list(embed_tables.keys())
+    n = len(names)
+    fig = plt.figure(figsize=(5.4 * n, 9), constrained_layout=True)
+    gs = fig.add_gridspec(2, n)
+
+    for i, name in enumerate(names):
+        df = embed_tables[name]
+
+        ax1 = fig.add_subplot(gs[0, i])
+        sc = ax1.scatter(
+            df["emb1"], df["emb2"],
+            c=pd.to_numeric(df["distance_to_seam"], errors="coerce"),
+            cmap="magma_r",
+            s=70, alpha=0.95, linewidths=0.35, edgecolors="white",
+        )
+        ax1.set_title(f"{name} — seam distance", fontsize=14, pad=8)
+        ax1.set_xlabel("dim 1")
+        ax1.set_ylabel("dim 2")
+        ax1.grid(alpha=0.12)
+        ax1.set_aspect("equal", adjustable="box")
+        fig.colorbar(sc, ax=ax1, fraction=0.046, pad=0.02)
+
+        ax2 = fig.add_subplot(gs[1, i])
+        base = df.copy()
+        ax2.scatter(base["emb1"], base["emb2"], s=40, c="lightgray", alpha=0.55, linewidths=0)
+        aniso_only = base[(pd.to_numeric(base["anisotropy_hotspot"], errors="coerce").fillna(0) == 1)
+                          & (pd.to_numeric(base["shared_hotspot"], errors="coerce").fillna(0) == 0)]
+        rel_only = base[(pd.to_numeric(base["relational_hotspot"], errors="coerce").fillna(0) == 1)
+                        & (pd.to_numeric(base["shared_hotspot"], errors="coerce").fillna(0) == 0)]
+        shared = base[pd.to_numeric(base["shared_hotspot"], errors="coerce").fillna(0) == 1]
+
+        if len(aniso_only):
+            ax2.scatter(aniso_only["emb1"], aniso_only["emb2"], s=90, c="#2A9D8F", alpha=0.95)
+        if len(rel_only):
+            ax2.scatter(rel_only["emb1"], rel_only["emb2"], s=90, c="#B23A48", alpha=0.95)
+        if len(shared):
+            ax2.scatter(shared["emb1"], shared["emb2"], s=120, c="#FFD166", edgecolors="black", linewidths=1.0, alpha=0.98)
+
+        ax2.set_title(f"{name} — hotspot structure", fontsize=14, pad=8)
+        ax2.set_xlabel("dim 1")
+        ax2.set_ylabel("dim 2")
+        ax2.grid(alpha=0.12)
+        ax2.set_aspect("equal", adjustable="box")
+
+        row = scores[scores["embedding"] == name].iloc[0]
+        txt = (
+            f"seam sep: {row['seam_separation']:.2f}\n"
+            f"family sep: {row['family_centroid_separation']:.2f}\n"
+            f"shared compact: {row['shared_hotspot_compactness']:.2f}\n"
+            f"trust: {row['trustworthiness']:.2f}\n"
+            f"nn keep: {row['nn_retention']:.2f}"
+        )
+        ax2.text(
+            0.98, 0.02, txt,
+            transform=ax2.transAxes,
+            ha="right", va="bottom", fontsize=9,
+            bbox=dict(boxstyle="round,pad=0.25", fc="white", ec="0.82", alpha=0.9),
+        )
+
+    fig.suptitle("PAM Observatory — OBS-028 embedding comparison", fontsize=20)
+    fig.savefig(outpath, dpi=220)
+    plt.close(fig)
+
+
+def build_summary(scores: pd.DataFrame, feature_cols: list[str]) -> str:
+    lines = [
+        "=== OBS-028 Embedding Comparison Summary ===",
+        "",
+        "Features used",
+        f"  {', '.join(feature_cols)}",
+        "",
+        "Scores",
+    ]
+    for _, row in scores.iterrows():
+        lines.append(
+            f"  {row['embedding']}: "
+            f"seam_separation={row['seam_separation']:.4f}, "
+            f"family_centroid_separation={row['family_centroid_separation']:.4f}, "
+            f"shared_hotspot_compactness={row['shared_hotspot_compactness']:.4f}, "
+            f"trustworthiness={row['trustworthiness']:.4f}, "
+            f"nn_retention={row['nn_retention']:.4f}"
+        )
+
+    best_seam = scores.sort_values("seam_separation", ascending=False).iloc[0]["embedding"]
+    best_family = scores.sort_values("family_centroid_separation", ascending=False).iloc[0]["embedding"]
+    best_trust = scores.sort_values("trustworthiness", ascending=False).iloc[0]["embedding"]
+
+    lines.extend(
+        [
+            "",
+            "Best-by-metric",
+            f"  seam separation: {best_seam}",
+            f"  family separation: {best_family}",
+            f"  trustworthiness: {best_trust}",
+            "",
+            "Interpretive guide",
+            "- MDS is the distance-faithful baseline",
+            "- Isomap emphasizes intrinsic graph-geodesic structure",
+            "- Laplacian / diffusion coordinates emphasize connectivity modes",
+            "- UMAP is exploratory and should not automatically replace geometry-faithful embeddings",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compare MDS against alternative observatory embeddings.")
+    parser.add_argument("--nodes-csv", default=Config.nodes_csv)
+    parser.add_argument("--edges-csv", default=Config.edges_csv)
+    parser.add_argument("--routes-csv", default=Config.routes_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--seam-threshold", type=float, default=Config.seam_threshold)
+    parser.add_argument("--hotspot-quantile", type=float, default=Config.hotspot_quantile)
+    parser.add_argument("--n-neighbors", type=int, default=Config.n_neighbors)
+    parser.add_argument("--random-state", type=int, default=Config.random_state)
+    parser.add_argument("--no-umap", action="store_true")
+    args = parser.parse_args()
+
+    cfg = Config(
+        nodes_csv=args.nodes_csv,
+        edges_csv=args.edges_csv,
+        routes_csv=args.routes_csv,
+        outdir=args.outdir,
+        seam_threshold=args.seam_threshold,
+        hotspot_quantile=args.hotspot_quantile,
+        n_neighbors=args.n_neighbors,
+        random_state=args.random_state,
+        include_umap=not args.no_umap,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    nodes, edges, routes = load_inputs(cfg)
+    feat_df = build_feature_table(nodes, routes, cfg)
+    Xz = feat_df.attrs["Xz"]
+    feature_cols = feat_df.attrs["feature_cols"]
+
+    D = compute_graph_distance(feat_df, edges)
+
+    embeddings: dict[str, np.ndarray] = {}
+    embeddings["mds"] = embed_mds(D, cfg)
+    embeddings["isomap"] = embed_isomap(D, cfg)
+    embeddings["laplacian"] = embed_laplacian(D, cfg)
+    embeddings["diffusion"] = embed_diffusion(D, cfg)
+
+    if cfg.include_umap and umap is not None:
+        embeddings["umap"] = embed_umap_from_features(Xz, cfg)
+
+    embed_tables: dict[str, pd.DataFrame] = {}
+    score_rows: list[dict[str, float | str]] = []
+
+    for name, Y in embeddings.items():
+        df = feat_df.copy()
+        df["emb1"] = Y[:, 0]
+        df["emb2"] = Y[:, 1]
+        embed_tables[name] = df
+
+        df.to_csv(outdir / f"embedding_nodes_{name}.csv", index=False)
+
+        sc = score_embedding(df, Xz, cfg)
+        sc["embedding"] = name
+        score_rows.append(sc)
+
+    scores = pd.DataFrame(score_rows)
+    score_cols = ["embedding", "seam_separation", "family_centroid_separation", "shared_hotspot_compactness", "trustworthiness", "nn_retention"]
+    scores = scores[score_cols].sort_values("embedding").reset_index(drop=True)
+    scores.to_csv(outdir / "embedding_scores.csv", index=False)
+
+    summary = build_summary(scores, feature_cols)
+    (outdir / "obs028_embedding_comparison_summary.txt").write_text(summary, encoding="utf-8")
+
+    render_panel(embed_tables, scores, outdir / "obs028_embedding_comparison.png")
+
+    print(outdir / "embedding_scores.csv")
+    print(outdir / "obs028_embedding_comparison_summary.txt")
+    print(outdir / "obs028_embedding_comparison.png")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/studies/obs028b_diffusion_mode_analysis.py
+++ b/experiments/studies/obs028b_diffusion_mode_analysis.py
@@ -1,0 +1,564 @@
+#!/usr/bin/env python3
+"""
+OBS-028b — Diffusion mode analysis for the PAM observatory.
+
+Purpose
+-------
+Give diffusion coordinates a fair, diffusion-native evaluation.
+
+Rather than scoring diffusion maps mainly on local-neighborhood retention or
+class separation alone, this study asks whether the leading diffusion modes
+capture:
+
+1. seam distance
+2. branch-exit tendency
+3. corridor residency tendency
+4. hotspot / bottleneck concentration
+5. multiscale behavior across diffusion time t
+
+Inputs
+------
+outputs/obs022_scene_bundle/scene_nodes.csv
+outputs/obs022_scene_bundle/scene_edges.csv
+outputs/obs022_scene_bundle/scene_routes.csv
+
+Outputs
+-------
+outputs/obs028b_diffusion_mode_analysis/
+  diffusion_modes_nodes.csv
+  diffusion_mode_scores.csv
+  obs028b_diffusion_mode_analysis_summary.txt
+  obs028b_diffusion_mode_analysis.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class Config:
+    nodes_csv: str = "outputs/obs022_scene_bundle/scene_nodes.csv"
+    edges_csv: str = "outputs/obs022_scene_bundle/scene_edges.csv"
+    routes_csv: str = "outputs/obs022_scene_bundle/scene_routes.csv"
+    outdir: str = "outputs/obs028b_diffusion_mode_analysis"
+    seam_threshold: float = 0.15
+    hotspot_quantile: float = 0.85
+    diffusion_times: tuple[int, ...] = (1, 2, 4, 8)
+    kernel_scale: str = "median"  # {"median", "mean"}
+    top_k_labels: int = 8
+
+
+CLASS_ORDER = [
+    "branch_exit",
+    "stable_seam_corridor",
+    "reorganization_heavy",
+]
+
+
+def safe_corr(a: pd.Series | np.ndarray, b: pd.Series | np.ndarray) -> float:
+    aa = pd.to_numeric(pd.Series(a), errors="coerce")
+    bb = pd.to_numeric(pd.Series(b), errors="coerce")
+    mask = aa.notna() & bb.notna()
+    if int(mask.sum()) < 3:
+        return float("nan")
+    return float(np.corrcoef(aa[mask], bb[mask])[0, 1])
+
+
+def safe_mean(s: pd.Series | np.ndarray) -> float:
+    ss = pd.to_numeric(pd.Series(s), errors="coerce")
+    return float(ss.mean()) if ss.notna().any() else float("nan")
+
+
+def classify_routes(routes: pd.DataFrame) -> pd.DataFrame:
+    out = routes.copy()
+    fam = out.get("path_family", pd.Series(index=out.index, dtype=object))
+    is_branch = pd.to_numeric(out.get("is_branch_away", 0), errors="coerce").fillna(0).eq(1)
+    is_rep = pd.to_numeric(out.get("is_representative", 0), errors="coerce").fillna(0).eq(1)
+
+    out["route_class"] = np.select(
+        [
+            is_branch,
+            is_rep & fam.eq("stable_seam_corridor"),
+            is_rep & fam.eq("reorganization_heavy"),
+        ],
+        [
+            "branch_exit",
+            "stable_seam_corridor",
+            "reorganization_heavy",
+        ],
+        default="other",
+    )
+    return out
+
+
+def load_inputs(cfg: Config) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    nodes = pd.read_csv(cfg.nodes_csv)
+    edges = pd.read_csv(cfg.edges_csv)
+    routes = pd.read_csv(cfg.routes_csv)
+
+    for df in (nodes, edges, routes):
+        for col in df.columns:
+            if col not in {"path_id", "path_family", "route_class", "hotspot_class"}:
+                try:
+                    df[col] = pd.to_numeric(df[col], errors="coerce")
+                except Exception:
+                    pass
+
+    if "is_branch_away" not in routes.columns:
+        routes["is_branch_away"] = 0
+    if "is_representative" not in routes.columns:
+        routes["is_representative"] = 0
+
+    routes = classify_routes(routes)
+    return nodes, edges, routes
+
+
+def build_node_augmented_table(nodes: pd.DataFrame, routes: pd.DataFrame, cfg: Config) -> pd.DataFrame:
+    out = nodes.copy()
+
+    # Family occupancy fields
+    family_touch = (
+        routes[routes["route_class"].isin(CLASS_ORDER)]
+        .groupby(["node_id", "route_class"], as_index=False)
+        .agg(n_rows=("path_id", "size"), n_paths=("path_id", "nunique"))
+    )
+
+    pivot = (
+        family_touch.pivot(index="node_id", columns="route_class", values="n_rows")
+        .fillna(0.0)
+        .reset_index()
+    )
+    pivot.columns.name = None
+    for cls in CLASS_ORDER:
+        if cls not in pivot.columns:
+            pivot[cls] = 0.0
+
+    out = out.merge(pivot, on="node_id", how="left")
+    for cls in CLASS_ORDER:
+        out[cls] = pd.to_numeric(out[cls], errors="coerce").fillna(0.0)
+
+    # Hotspots from available seam-side fields if not already present
+    if "anisotropy_hotspot" not in out.columns and "sym_traceless_norm" in out.columns:
+        thr_a = float(pd.to_numeric(out["sym_traceless_norm"], errors="coerce").quantile(cfg.hotspot_quantile))
+        out["anisotropy_hotspot"] = (
+            pd.to_numeric(out["sym_traceless_norm"], errors="coerce") >= thr_a
+        ).astype(int)
+    elif "anisotropy_hotspot" not in out.columns:
+        out["anisotropy_hotspot"] = 0
+
+    if "relational_hotspot" not in out.columns and "neighbor_direction_mismatch_mean" in out.columns:
+        thr_r = float(
+            pd.to_numeric(out["neighbor_direction_mismatch_mean"], errors="coerce").quantile(cfg.hotspot_quantile)
+        )
+        out["relational_hotspot"] = (
+            pd.to_numeric(out["neighbor_direction_mismatch_mean"], errors="coerce") >= thr_r
+        ).astype(int)
+    elif "relational_hotspot" not in out.columns:
+        out["relational_hotspot"] = 0
+
+    if "shared_hotspot" not in out.columns:
+        out["shared_hotspot"] = (
+            (pd.to_numeric(out["anisotropy_hotspot"], errors="coerce").fillna(0) == 1)
+            & (pd.to_numeric(out["relational_hotspot"], errors="coerce").fillna(0) == 1)
+        ).astype(int)
+
+    return out
+
+
+def compute_graph_distance(nodes: pd.DataFrame, edges: pd.DataFrame) -> np.ndarray:
+    node_ids = pd.to_numeric(nodes["node_id"], errors="coerce").astype(int).tolist()
+    idx = {nid: i for i, nid in enumerate(node_ids)}
+    n = len(node_ids)
+    D = np.full((n, n), np.inf, dtype=float)
+    np.fill_diagonal(D, 0.0)
+
+    for _, row in edges.iterrows():
+        try:
+            u = idx[int(row["src_id"])]
+            v = idx[int(row["dst_id"])]
+        except Exception:
+            continue
+
+        w = np.nan
+        if "edge_cost" in edges.columns and pd.notna(row.get("edge_cost", np.nan)):
+            w = float(row["edge_cost"])
+        elif all(c in edges.columns for c in ["src_mds1", "src_mds2", "dst_mds1", "dst_mds2"]):
+            try:
+                w = float(np.hypot(float(row["dst_mds1"]) - float(row["src_mds1"]),
+                                  float(row["dst_mds2"]) - float(row["src_mds2"])))
+            except Exception:
+                w = np.nan
+
+        if not np.isfinite(w):
+            w = 1.0
+
+        D[u, v] = min(D[u, v], w)
+        D[v, u] = min(D[v, u], w)
+
+    # Floyd-Warshall, n is small
+    for k in range(n):
+        D = np.minimum(D, D[:, [k]] + D[[k], :])
+
+    finite = D[np.isfinite(D) & (D > 0)]
+    fill = float(finite.max()) if finite.size else 1.0
+    D[~np.isfinite(D)] = fill
+    return D
+
+
+def build_diffusion_operator(D: np.ndarray, cfg: Config) -> tuple[np.ndarray, float]:
+    positive = D[D > 0]
+    if positive.size == 0:
+        sigma = 1.0
+    elif cfg.kernel_scale == "mean":
+        sigma = float(np.mean(positive))
+    else:
+        sigma = float(np.median(positive))
+    if not np.isfinite(sigma) or sigma <= 0:
+        sigma = 1.0
+
+    K = np.exp(-(D ** 2) / (2.0 * sigma ** 2))
+    np.fill_diagonal(K, 0.0)
+
+    row_sum = K.sum(axis=1, keepdims=True)
+    row_sum[row_sum <= 1e-12] = 1.0
+    P = K / row_sum
+    return P, sigma
+
+
+def diffusion_eigendecomposition(P: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    vals, vecs = np.linalg.eig(P)
+    vals = np.real(vals)
+    vecs = np.real(vecs)
+
+    order = np.argsort(vals)[::-1]
+    vals = vals[order]
+    vecs = vecs[:, order]
+    return vals, vecs
+
+
+def diffusion_coords(vals: np.ndarray, vecs: np.ndarray, t: int) -> np.ndarray:
+    # skip trivial first eigenvector
+    lam = vals[1:3]
+    psi = vecs[:, 1:3]
+    return psi * (lam ** t)
+
+
+def seam_separation_score(df: pd.DataFrame, seam_threshold: float, xcol: str, ycol: str) -> float:
+    seam = pd.to_numeric(df["distance_to_seam"], errors="coerce") <= seam_threshold
+    A = df.loc[seam, [xcol, ycol]].to_numpy(dtype=float)
+    B = df.loc[~seam, [xcol, ycol]].to_numpy(dtype=float)
+    if len(A) < 2 or len(B) < 2:
+        return float("nan")
+    muA = A.mean(axis=0)
+    muB = B.mean(axis=0)
+    varA = float(np.mean(np.sum((A - muA) ** 2, axis=1)))
+    varB = float(np.mean(np.sum((B - muB) ** 2, axis=1)))
+    denom = np.sqrt(max(varA + varB, 1e-12))
+    return float(np.linalg.norm(muA - muB) / denom)
+
+
+def family_centroid_score(df: pd.DataFrame, xcol: str, ycol: str) -> float:
+    centroids = []
+    X = df[[xcol, ycol]].to_numpy(dtype=float)
+    for cls in CLASS_ORDER:
+        w = pd.to_numeric(df.get(cls, 0), errors="coerce").fillna(0.0).to_numpy(dtype=float)
+        if np.sum(w) <= 0:
+            continue
+        mu = (X * w[:, None]).sum(axis=0) / np.sum(w)
+        centroids.append(mu)
+    if len(centroids) < 2:
+        return float("nan")
+    centroids = np.vstack(centroids)
+    diffs = centroids[:, None, :] - centroids[None, :, :]
+    dist = np.sqrt(np.sum(diffs * diffs, axis=2))
+    iu = np.triu_indices_from(dist, k=1)
+    return float(np.mean(dist[iu]))
+
+
+def shared_hotspot_compactness(df: pd.DataFrame, xcol: str, ycol: str) -> float:
+    shared = pd.to_numeric(df.get("shared_hotspot", 0), errors="coerce").fillna(0) == 1
+    X = df.loc[shared, [xcol, ycol]].to_numpy(dtype=float)
+    if len(X) < 2:
+        return float("nan")
+    mu = X.mean(axis=0)
+    return float(np.mean(np.sqrt(np.sum((X - mu) ** 2, axis=1))))
+
+
+def bottleneck_proxy_score(df: pd.DataFrame, xcol: str, ycol: str) -> float:
+    """
+    Fairer diffusion-native proxy:
+    shared hotspots should occupy a narrower subregion than non-shared nodes.
+    Smaller ratio is better.
+    """
+    shared = pd.to_numeric(df.get("shared_hotspot", 0), errors="coerce").fillna(0) == 1
+    Xs = df.loc[shared, [xcol, ycol]].to_numpy(dtype=float)
+    Xn = df.loc[~shared, [xcol, ycol]].to_numpy(dtype=float)
+    if len(Xs) < 2 or len(Xn) < 2:
+        return float("nan")
+    mu_s = Xs.mean(axis=0)
+    mu_n = Xn.mean(axis=0)
+    spread_s = float(np.mean(np.sqrt(np.sum((Xs - mu_s) ** 2, axis=1))))
+    spread_n = float(np.mean(np.sqrt(np.sum((Xn - mu_n) ** 2, axis=1))))
+    if spread_n <= 1e-12:
+        return float("nan")
+    return spread_s / spread_n
+
+
+def axis_alignment_scores(df: pd.DataFrame, xcol: str, ycol: str) -> dict[str, float]:
+    x = pd.to_numeric(df[xcol], errors="coerce")
+    y = pd.to_numeric(df[ycol], errors="coerce")
+    seam = pd.to_numeric(df["distance_to_seam"], errors="coerce")
+    branch = pd.to_numeric(df.get("branch_exit", 0), errors="coerce").fillna(0.0)
+    corridor = pd.to_numeric(df.get("stable_seam_corridor", 0), errors="coerce").fillna(0.0)
+    shared = pd.to_numeric(df.get("shared_hotspot", 0), errors="coerce").fillna(0.0)
+
+    candidates = {
+        "seam_distance": max(abs(safe_corr(x, seam)), abs(safe_corr(y, seam))),
+        "branch_exit": max(abs(safe_corr(x, branch)), abs(safe_corr(y, branch))),
+        "corridor": max(abs(safe_corr(x, corridor)), abs(safe_corr(y, corridor))),
+        "shared_hotspot": max(abs(safe_corr(x, shared)), abs(safe_corr(y, shared))),
+    }
+    return candidates
+
+
+def render_panel(nodes: pd.DataFrame, scores: pd.DataFrame, vals: np.ndarray, outpath: Path, cfg: Config) -> None:
+    times = list(scores["diffusion_time"])
+    fig = plt.figure(figsize=(18, 10), constrained_layout=True)
+    gs = fig.add_gridspec(2, 4, width_ratios=[1.2, 1.2, 1.0, 1.0])
+
+    # top row: two selected diffusion times
+    chosen = [times[0], times[min(2, len(times) - 1)]]
+    seam_mask = pd.to_numeric(nodes["distance_to_seam"], errors="coerce") <= cfg.seam_threshold
+
+    for i, t in enumerate(chosen):
+        ax = fig.add_subplot(gs[0, i])
+        xcol, ycol = f"diff1_t{t}", f"diff2_t{t}"
+        sc = ax.scatter(
+            nodes[xcol], nodes[ycol],
+            c=pd.to_numeric(nodes["distance_to_seam"], errors="coerce"),
+            cmap="magma_r",
+            s=80, alpha=0.95, linewidths=0.35, edgecolors="white",
+        )
+        ax.scatter(
+            nodes.loc[seam_mask, xcol],
+            nodes.loc[seam_mask, ycol],
+            s=135, facecolors="none", edgecolors="black", linewidths=1.0,
+        )
+        shared = pd.to_numeric(nodes.get("shared_hotspot", 0), errors="coerce").fillna(0) == 1
+        top = nodes.loc[shared].copy().head(cfg.top_k_labels)
+        for _, row in top.iterrows():
+            ax.text(
+                float(row[xcol]) + 0.02,
+                float(row[ycol]) + 0.02,
+                f"{int(row['node_id'])}",
+                fontsize=8,
+                bbox=dict(boxstyle="round,pad=0.16", fc="white", ec="0.8", alpha=0.9),
+            )
+        ax.set_title(f"Diffusion coordinates (t={t})", fontsize=14, pad=8)
+        ax.set_xlabel("diff 1")
+        ax.set_ylabel("diff 2")
+        ax.grid(alpha=0.12)
+        ax.set_aspect("equal", adjustable="box")
+        fig.colorbar(sc, ax=ax, fraction=0.046, pad=0.02)
+
+    # eigenvalues
+    ax_eig = fig.add_subplot(gs[0, 2])
+    lam = vals[:10]
+    ax_eig.plot(np.arange(len(lam)), lam, marker="o")
+    ax_eig.set_title("Leading diffusion eigenvalues", fontsize=14, pad=8)
+    ax_eig.set_xlabel("index")
+    ax_eig.set_ylabel("eigenvalue")
+    ax_eig.grid(alpha=0.15)
+
+    # mode scores by t
+    ax_score = fig.add_subplot(gs[0, 3])
+    ax_score.plot(scores["diffusion_time"], scores["seam_separation"], marker="o", label="seam sep")
+    ax_score.plot(scores["diffusion_time"], scores["family_centroid_separation"], marker="o", label="family sep")
+    ax_score.plot(scores["diffusion_time"], scores["bottleneck_proxy"], marker="o", label="bottleneck ratio")
+    ax_score.set_title("Diffusion-time score trends", fontsize=14, pad=8)
+    ax_score.set_xlabel("diffusion time t")
+    ax_score.grid(alpha=0.15)
+    ax_score.legend()
+
+    # bottom left: axis alignments
+    ax_align = fig.add_subplot(gs[1, 0:2])
+    for label in ["axis_align_seam_distance", "axis_align_branch_exit", "axis_align_corridor", "axis_align_shared_hotspot"]:
+        ax_align.plot(scores["diffusion_time"], scores[label], marker="o", label=label.replace("axis_align_", ""))
+    ax_align.set_title("Axis-alignment by diffusion time", fontsize=14, pad=8)
+    ax_align.set_xlabel("diffusion time t")
+    ax_align.set_ylabel("max |corr(axis, field)|")
+    ax_align.grid(alpha=0.15)
+    ax_align.legend()
+
+    # bottom middle: seam & family separation
+    ax_sep = fig.add_subplot(gs[1, 2])
+    width = 0.36
+    xx = np.arange(len(scores))
+    ax_sep.bar(xx - width / 2, scores["seam_separation"], width, label="seam")
+    ax_sep.bar(xx + width / 2, scores["family_centroid_separation"], width, label="family")
+    ax_sep.set_xticks(xx)
+    ax_sep.set_xticklabels([str(int(t)) for t in scores["diffusion_time"]])
+    ax_sep.set_title("Separation scores", fontsize=14, pad=8)
+    ax_sep.set_xlabel("t")
+    ax_sep.grid(alpha=0.15, axis="y")
+    ax_sep.legend()
+
+    # bottom right: interpretation box
+    ax_diag = fig.add_subplot(gs[1, 3])
+    ax_diag.axis("off")
+    best_seam_row = scores.sort_values("seam_separation", ascending=False).iloc[0]
+    best_branch_row = scores.sort_values("axis_align_branch_exit", ascending=False).iloc[0]
+    best_corridor_row = scores.sort_values("axis_align_corridor", ascending=False).iloc[0]
+    text = (
+        "OBS-028b diagnostics\n\n"
+        f"best seam sep t: {int(best_seam_row['diffusion_time'])}\n"
+        f"best seam score: {best_seam_row['seam_separation']:.3f}\n\n"
+        f"best branch axis t: {int(best_branch_row['diffusion_time'])}\n"
+        f"branch align: {best_branch_row['axis_align_branch_exit']:.3f}\n\n"
+        f"best corridor axis t: {int(best_corridor_row['diffusion_time'])}\n"
+        f"corridor align: {best_corridor_row['axis_align_corridor']:.3f}\n\n"
+        "Interpretation:\n"
+        "diffusion should be judged\n"
+        "by slow-mode alignment and\n"
+        "bottleneck structure, not\n"
+        "only local-neighborhood fit."
+    )
+    ax_diag.text(
+        0.02, 0.98, text,
+        va="top", ha="left", fontsize=10, family="monospace",
+        bbox=dict(boxstyle="round,pad=0.35", fc="white", ec="0.85", alpha=0.95),
+    )
+
+    fig.suptitle("PAM Observatory — OBS-028b diffusion mode analysis", fontsize=20)
+    fig.savefig(outpath, dpi=220)
+    plt.close(fig)
+
+
+def build_summary(scores: pd.DataFrame, sigma: float) -> str:
+    lines = [
+        "=== OBS-028b Diffusion Mode Analysis Summary ===",
+        "",
+        f"kernel_sigma = {sigma:.6f}",
+        "",
+        "Scores by diffusion time",
+    ]
+    for _, row in scores.iterrows():
+        lines.append(
+            f"  t={int(row['diffusion_time'])}: "
+            f"seam_separation={row['seam_separation']:.4f}, "
+            f"family_centroid_separation={row['family_centroid_separation']:.4f}, "
+            f"shared_hotspot_compactness={row['shared_hotspot_compactness']:.4f}, "
+            f"bottleneck_proxy={row['bottleneck_proxy']:.4f}, "
+            f"axis_align_seam_distance={row['axis_align_seam_distance']:.4f}, "
+            f"axis_align_branch_exit={row['axis_align_branch_exit']:.4f}, "
+            f"axis_align_corridor={row['axis_align_corridor']:.4f}, "
+            f"axis_align_shared_hotspot={row['axis_align_shared_hotspot']:.4f}"
+        )
+
+    best_seam = scores.sort_values("seam_separation", ascending=False).iloc[0]
+    best_branch = scores.sort_values("axis_align_branch_exit", ascending=False).iloc[0]
+    best_corridor = scores.sort_values("axis_align_corridor", ascending=False).iloc[0]
+    best_bottle = scores.sort_values("bottleneck_proxy", ascending=True).iloc[0]
+
+    lines.extend(
+        [
+            "",
+            "Best-by-diffusion-native criterion",
+            f"  seam separation: t={int(best_seam['diffusion_time'])}",
+            f"  branch-exit axis alignment: t={int(best_branch['diffusion_time'])}",
+            f"  corridor axis alignment: t={int(best_corridor['diffusion_time'])}",
+            f"  bottleneck concentration: t={int(best_bottle['diffusion_time'])}",
+            "",
+            "Interpretive guide",
+            "- high seam separation means diffusion coordinates isolate seam regime well",
+            "- high branch/corridor alignment means a leading diffusion axis tracks family tendency",
+            "- lower bottleneck_proxy means shared hotspots concentrate more tightly than the background",
+            "- diffusion may be useful even if it is not the best general-purpose 2D display embedding",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fair diffusion-native analysis of observatory structure.")
+    parser.add_argument("--nodes-csv", default=Config.nodes_csv)
+    parser.add_argument("--edges-csv", default=Config.edges_csv)
+    parser.add_argument("--routes-csv", default=Config.routes_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--seam-threshold", type=float, default=Config.seam_threshold)
+    parser.add_argument("--hotspot-quantile", type=float, default=Config.hotspot_quantile)
+    parser.add_argument("--kernel-scale", default=Config.kernel_scale, choices=["median", "mean"])
+    parser.add_argument("--top-k-labels", type=int, default=Config.top_k_labels)
+    args = parser.parse_args()
+
+    cfg = Config(
+        nodes_csv=args.nodes_csv,
+        edges_csv=args.edges_csv,
+        routes_csv=args.routes_csv,
+        outdir=args.outdir,
+        seam_threshold=args.seam_threshold,
+        hotspot_quantile=args.hotspot_quantile,
+        kernel_scale=args.kernel_scale,
+        top_k_labels=args.top_k_labels,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    nodes, edges, routes = load_inputs(cfg)
+    nodes = build_node_augmented_table(nodes, routes, cfg)
+    D = compute_graph_distance(nodes, edges)
+    P, sigma = build_diffusion_operator(D, cfg)
+    vals, vecs = diffusion_eigendecomposition(P)
+
+    score_rows = []
+    for t in cfg.diffusion_times:
+        coords = diffusion_coords(vals, vecs, t)
+        nodes[f"diff1_t{t}"] = coords[:, 0]
+        nodes[f"diff2_t{t}"] = coords[:, 1]
+
+        row = {
+            "diffusion_time": t,
+            "seam_separation": seam_separation_score(nodes, cfg.seam_threshold, f"diff1_t{t}", f"diff2_t{t}"),
+            "family_centroid_separation": family_centroid_score(nodes, f"diff1_t{t}", f"diff2_t{t}"),
+            "shared_hotspot_compactness": shared_hotspot_compactness(nodes, f"diff1_t{t}", f"diff2_t{t}"),
+            "bottleneck_proxy": bottleneck_proxy_score(nodes, f"diff1_t{t}", f"diff2_t{t}"),
+        }
+        row.update(axis_alignment_scores(nodes, f"diff1_t{t}", f"diff2_t{t}"))
+        row = {
+            **row,
+            "axis_align_seam_distance": row["seam_distance"],
+            "axis_align_branch_exit": row["branch_exit"],
+            "axis_align_corridor": row["corridor"],
+            "axis_align_shared_hotspot": row["shared_hotspot"],
+        }
+        del row["seam_distance"]
+        del row["branch_exit"]
+        del row["corridor"]
+        del row["shared_hotspot"]
+        score_rows.append(row)
+
+    scores = pd.DataFrame(score_rows)
+    nodes.to_csv(outdir / "diffusion_modes_nodes.csv", index=False)
+    scores.to_csv(outdir / "diffusion_mode_scores.csv", index=False)
+
+    summary = build_summary(scores, sigma)
+    (outdir / "obs028b_diffusion_mode_analysis_summary.txt").write_text(summary, encoding="utf-8")
+
+    render_panel(nodes, scores, vals, outdir / "obs028b_diffusion_mode_analysis.png", cfg)
+
+    print(outdir / "diffusion_modes_nodes.csv")
+    print(outdir / "diffusion_mode_scores.csv")
+    print(outdir / "obs028b_diffusion_mode_analysis_summary.txt")
+    print(outdir / "obs028b_diffusion_mode_analysis.png")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/studies/obs028c_export_canonical_seam_bundle.py
+++ b/experiments/studies/obs028c_export_canonical_seam_bundle.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""
+OBS-028c — Export canonical seam bundle.
+
+Freeze the seam program (OBS-023 through OBS-028b) into one stable bundle for
+downstream observatory work.
+
+Exports
+-------
+<outdir>/
+  seam_nodes.csv
+  seam_family_summary.csv
+  seam_embedding_summary.csv
+  seam_metadata.txt
+
+Primary purpose
+---------------
+Create one canonical seam-side substrate containing:
+
+- relational obstruction field
+- anisotropy field
+- hotspot classes
+- family occupancy summary
+- embedding policy summary
+
+Inputs
+------
+outputs/obs022_scene_bundle/scene_nodes.csv
+outputs/obs023_local_direction_mismatch/local_direction_mismatch_nodes.csv
+outputs/fim_response_operator_decomposition/response_operator_decomposition_nodes.csv
+outputs/obs025_anisotropy_vs_relational_obstruction/obs025_anisotropy_vs_relational_obstruction_nodes.csv
+outputs/obs026_family_two_field_occupancy/family_two_field_class_summary.csv
+outputs/obs027_seam_regime_synthesis/obs027_seam_regime_synthesis_summary.txt
+outputs/obs028_embedding_comparison/embedding_scores.csv
+outputs/obs028b_diffusion_mode_analysis/diffusion_mode_scores.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class Config:
+    scene_nodes_csv: str = "outputs/obs022_scene_bundle/scene_nodes.csv"
+    mismatch_csv: str = "outputs/obs023_local_direction_mismatch/local_direction_mismatch_nodes.csv"
+    decomposition_csv: str = "outputs/fim_response_operator_decomposition/response_operator_decomposition_nodes.csv"
+    obs025_csv: str = "outputs/obs025_anisotropy_vs_relational_obstruction/obs025_anisotropy_vs_relational_obstruction_nodes.csv"
+    family_summary_csv: str = "outputs/obs026_family_two_field_occupancy/family_two_field_class_summary.csv"
+    obs027_summary_txt: str = "outputs/obs027_seam_regime_synthesis/obs027_seam_regime_synthesis_summary.txt"
+    embedding_scores_csv: str = "outputs/obs028_embedding_comparison/embedding_scores.csv"
+    diffusion_scores_csv: str = "outputs/obs028b_diffusion_mode_analysis/diffusion_mode_scores.csv"
+    outdir: str = "outputs/obs028c_canonical_seam_bundle"
+    seam_threshold: float = 0.15
+    hotspot_quantile: float = 0.85
+
+
+CANONICAL_NODE_COLS = [
+    "node_id",
+    "r",
+    "alpha",
+    "mds1",
+    "mds2",
+    "signed_phase",
+    "distance_to_seam",
+    "lazarus_score",
+    "response_strength",
+    "node_holonomy_proxy",
+    "local_direction_mismatch_deg",
+    "neighbor_direction_mismatch_mean",
+    "transport_align_mean_deg",
+    "sym_traceless_norm",
+    "scalar_norm",
+    "antisymmetric_norm",
+    "commutator_norm_rsp",
+    "anisotropy_hotspot",
+    "relational_hotspot",
+    "shared_hotspot",
+]
+
+CLASS_ORDER = [
+    "branch_exit",
+    "stable_seam_corridor",
+    "reorganization_heavy",
+]
+
+
+def load_csv(path: str | Path) -> pd.DataFrame:
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(p)
+    df = pd.read_csv(p)
+    for col in df.columns:
+        if col not in {"path_id", "path_family", "route_class", "hotspot_class", "dominant_component"}:
+            try:
+                df[col] = pd.to_numeric(df[col], errors="coerce")
+            except Exception:
+                pass
+    return df
+
+
+def safe_mean(s: pd.Series) -> float:
+    s = pd.to_numeric(s, errors="coerce")
+    return float(s.mean()) if s.notna().any() else float("nan")
+
+
+def first_present(df: pd.DataFrame, choices: list[str]) -> str | None:
+    for c in choices:
+        if c in df.columns:
+            return c
+    return None
+
+
+def build_seam_nodes(cfg: Config) -> pd.DataFrame:
+    base = load_csv(cfg.scene_nodes_csv)
+    mm = load_csv(cfg.mismatch_csv)
+    dec = load_csv(cfg.decomposition_csv)
+    o25 = load_csv(cfg.obs025_csv)
+
+    out = base.copy()
+
+    # OBS-023 mismatch fields
+    mm_cols = [
+        c for c in [
+            "node_id",
+            "local_direction_mismatch_deg",
+            "neighbor_direction_mismatch_mean",
+            "neighbor_direction_mismatch_deg",
+            "transport_align_mean_deg",
+        ] if c in mm.columns
+    ]
+    if "node_id" in mm_cols:
+        mm_use = mm[mm_cols].drop_duplicates(subset=["node_id"])
+        # normalize naming if needed
+        if "neighbor_direction_mismatch_deg" in mm_use.columns and "neighbor_direction_mismatch_mean" not in mm_use.columns:
+            mm_use = mm_use.rename(columns={"neighbor_direction_mismatch_deg": "neighbor_direction_mismatch_mean"})
+        out = out.merge(mm_use, on="node_id", how="left")
+
+    # response decomposition fields
+    dec_cols = [
+        c for c in [
+            "node_id",
+            "sym_traceless_norm",
+            "scalar_norm",
+            "antisymmetric_norm",
+            "commutator_norm_rsp",
+        ] if c in dec.columns
+    ]
+    if "node_id" in dec_cols:
+        out = out.merge(dec[dec_cols].drop_duplicates(subset=["node_id"]), on="node_id", how="left")
+
+    # obs025 hotspot fields and any stabilized copies
+    o25_cols = [
+        c for c in [
+            "node_id",
+            "sym_traceless_norm",
+            "neighbor_direction_mismatch_mean",
+            "anisotropy_hotspot",
+            "relational_hotspot",
+            "shared_hotspot",
+        ] if c in o25.columns
+    ]
+    if "node_id" in o25_cols:
+        out = out.merge(
+            o25[o25_cols].drop_duplicates(subset=["node_id"]),
+            on="node_id",
+            how="left",
+            suffixes=("", "_obs025"),
+        )
+
+        for col in ["sym_traceless_norm", "neighbor_direction_mismatch_mean", "anisotropy_hotspot", "relational_hotspot", "shared_hotspot"]:
+            alt = f"{col}_obs025"
+            if alt in out.columns:
+                if col not in out.columns:
+                    out[col] = out[alt]
+                else:
+                    out[col] = out[col].where(out[col].notna(), out[alt])
+                out = out.drop(columns=[alt])
+
+    # derive hotspots if still missing
+    if "anisotropy_hotspot" not in out.columns and "sym_traceless_norm" in out.columns:
+        thr = float(pd.to_numeric(out["sym_traceless_norm"], errors="coerce").quantile(cfg.hotspot_quantile))
+        out["anisotropy_hotspot"] = (pd.to_numeric(out["sym_traceless_norm"], errors="coerce") >= thr).astype(int)
+
+    if "relational_hotspot" not in out.columns:
+        rel_col = first_present(out, ["neighbor_direction_mismatch_mean", "transport_align_mean_deg"])
+        if rel_col is not None:
+            thr = float(pd.to_numeric(out[rel_col], errors="coerce").quantile(cfg.hotspot_quantile))
+            out["relational_hotspot"] = (pd.to_numeric(out[rel_col], errors="coerce") >= thr).astype(int)
+        else:
+            out["relational_hotspot"] = 0
+
+    if "shared_hotspot" not in out.columns:
+        out["shared_hotspot"] = (
+            (pd.to_numeric(out["anisotropy_hotspot"], errors="coerce").fillna(0) == 1)
+            & (pd.to_numeric(out["relational_hotspot"], errors="coerce").fillna(0) == 1)
+        ).astype(int)
+
+    keep = [c for c in CANONICAL_NODE_COLS if c in out.columns]
+    out = out[keep].copy()
+
+    if "distance_to_seam" in out.columns:
+        seam_mask = pd.to_numeric(out["distance_to_seam"], errors="coerce") <= cfg.seam_threshold
+        out["seam_band"] = seam_mask.astype(int)
+
+    hotspot_class = np.full(len(out), "non_hotspot", dtype=object)
+    aniso = pd.to_numeric(out.get("anisotropy_hotspot", 0), errors="coerce").fillna(0).astype(int)
+    rel = pd.to_numeric(out.get("relational_hotspot", 0), errors="coerce").fillna(0).astype(int)
+    shared = pd.to_numeric(out.get("shared_hotspot", 0), errors="coerce").fillna(0).astype(int)
+    hotspot_class[(aniso == 1) & (shared == 0)] = "anisotropy_only"
+    hotspot_class[(rel == 1) & (shared == 0)] = "relational_only"
+    hotspot_class[shared == 1] = "shared"
+    out["hotspot_class"] = hotspot_class
+
+    return out.sort_values(["r", "alpha"]).reset_index(drop=True)
+
+
+def build_family_summary(cfg: Config) -> pd.DataFrame:
+    fam = load_csv(cfg.family_summary_csv)
+    if "route_class" in fam.columns:
+        order = {k: i for i, k in enumerate(CLASS_ORDER)}
+        fam["order"] = fam["route_class"].map(lambda x: order.get(x, 999))
+        fam = fam.sort_values("order").drop(columns=["order"]).reset_index(drop=True)
+    return fam
+
+
+def build_embedding_summary(cfg: Config) -> pd.DataFrame:
+    emb = load_csv(cfg.embedding_scores_csv)
+    diff = load_csv(cfg.diffusion_scores_csv)
+
+    rows = []
+
+    if len(emb):
+        best_seam = emb.sort_values("seam_separation", ascending=False).iloc[0]
+        best_family = emb.sort_values("family_centroid_separation", ascending=False).iloc[0]
+        best_trust = emb.sort_values("trustworthiness", ascending=False).iloc[0]
+        rows.extend(
+            [
+                {"source": "obs028", "metric": "best_seam_separation", "value": best_seam["seam_separation"], "label": str(best_seam["embedding"])},
+                {"source": "obs028", "metric": "best_family_separation", "value": best_family["family_centroid_separation"], "label": str(best_family["embedding"])},
+                {"source": "obs028", "metric": "best_trustworthiness", "value": best_trust["trustworthiness"], "label": str(best_trust["embedding"])},
+            ]
+        )
+
+    if len(diff):
+        best_seam_t = diff.sort_values("seam_separation", ascending=False).iloc[0]
+        best_branch_t = diff.sort_values("axis_align_branch_exit", ascending=False).iloc[0]
+        rows.extend(
+            [
+                {"source": "obs028b", "metric": "best_diffusion_seam_time", "value": best_seam_t["seam_separation"], "label": f"t={int(best_seam_t['diffusion_time'])}"},
+                {"source": "obs028b", "metric": "best_diffusion_branch_time", "value": best_branch_t["axis_align_branch_exit"], "label": f"t={int(best_branch_t['diffusion_time'])}"},
+            ]
+        )
+
+    return pd.DataFrame(rows)
+
+
+def write_metadata(cfg: Config, seam_nodes: pd.DataFrame, fam: pd.DataFrame, emb: pd.DataFrame) -> str:
+    seam_mask = pd.to_numeric(seam_nodes.get("distance_to_seam"), errors="coerce") <= cfg.seam_threshold
+    aniso_only = int(((seam_nodes["hotspot_class"] == "anisotropy_only")).sum()) if "hotspot_class" in seam_nodes.columns else 0
+    rel_only = int(((seam_nodes["hotspot_class"] == "relational_only")).sum()) if "hotspot_class" in seam_nodes.columns else 0
+    shared = int(((seam_nodes["hotspot_class"] == "shared")).sum()) if "hotspot_class" in seam_nodes.columns else 0
+
+    lines = [
+        "=== OBS-028c Canonical Seam Bundle Metadata ===",
+        "",
+        "Bundle purpose",
+        "- freeze the seam arc (OBS-023 through OBS-028b) into one reusable observatory substrate",
+        "",
+        "Counts",
+        f"n_nodes={len(seam_nodes)}",
+        f"n_seam_band_nodes={int(seam_mask.sum()) if seam_mask.notna().any() else 0}",
+        f"n_anisotropy_only_hotspots={aniso_only}",
+        f"n_relational_only_hotspots={rel_only}",
+        f"n_shared_hotspots={shared}",
+        f"n_family_rows={len(fam)}",
+        f"n_embedding_summary_rows={len(emb)}",
+        "",
+        "Canonical seam interpretation",
+        "- the seam is a multi-field structural regime",
+        "- relational obstruction is the stronger seam discriminator",
+        "- response anisotropy is a distinct seam-side field",
+        "- families differ by residency pattern within this regime",
+        "- diffusion exposes seam distance as a dominant slow mode",
+        "",
+        "Recommended embedding policy",
+        "- MDS remains canonical for geometry-faithful observatory layout",
+        "- UMAP is the strongest supplementary exploratory embedding",
+        "- diffusion is best treated as a slow-mode diagnostic rather than primary display coordinates",
+        "",
+        "Primary node fields",
+    ]
+
+    for c in seam_nodes.columns:
+        lines.append(f"  - {c}")
+
+    lines.extend(["", "Inputs"])
+    for label, path in [
+        ("scene_nodes_csv", cfg.scene_nodes_csv),
+        ("mismatch_csv", cfg.mismatch_csv),
+        ("decomposition_csv", cfg.decomposition_csv),
+        ("obs025_csv", cfg.obs025_csv),
+        ("family_summary_csv", cfg.family_summary_csv),
+        ("obs027_summary_txt", cfg.obs027_summary_txt),
+        ("embedding_scores_csv", cfg.embedding_scores_csv),
+        ("diffusion_scores_csv", cfg.diffusion_scores_csv),
+    ]:
+        lines.append(f"{label}={path}")
+
+    # include obs027 summary text if present
+    p = Path(cfg.obs027_summary_txt)
+    if p.exists():
+        lines.extend(["", "OBS-027 summary excerpt"])
+        try:
+            text = p.read_text(encoding="utf-8").strip().splitlines()
+            lines.extend(text[:20])
+        except Exception:
+            pass
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Export canonical seam bundle.")
+    parser.add_argument("--scene-nodes-csv", default=Config.scene_nodes_csv)
+    parser.add_argument("--mismatch-csv", default=Config.mismatch_csv)
+    parser.add_argument("--decomposition-csv", default=Config.decomposition_csv)
+    parser.add_argument("--obs025-csv", default=Config.obs025_csv)
+    parser.add_argument("--family-summary-csv", default=Config.family_summary_csv)
+    parser.add_argument("--obs027-summary-txt", default=Config.obs027_summary_txt)
+    parser.add_argument("--embedding-scores-csv", default=Config.embedding_scores_csv)
+    parser.add_argument("--diffusion-scores-csv", default=Config.diffusion_scores_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--seam-threshold", type=float, default=Config.seam_threshold)
+    parser.add_argument("--hotspot-quantile", type=float, default=Config.hotspot_quantile)
+    args = parser.parse_args()
+
+    cfg = Config(
+        scene_nodes_csv=args.scene_nodes_csv,
+        mismatch_csv=args.mismatch_csv,
+        decomposition_csv=args.decomposition_csv,
+        obs025_csv=args.obs025_csv,
+        family_summary_csv=args.family_summary_csv,
+        obs027_summary_txt=args.obs027_summary_txt,
+        embedding_scores_csv=args.embedding_scores_csv,
+        diffusion_scores_csv=args.diffusion_scores_csv,
+        outdir=args.outdir,
+        seam_threshold=args.seam_threshold,
+        hotspot_quantile=args.hotspot_quantile,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    seam_nodes = build_seam_nodes(cfg)
+    fam = build_family_summary(cfg)
+    emb = build_embedding_summary(cfg)
+    metadata = write_metadata(cfg, seam_nodes, fam, emb)
+
+    seam_nodes.to_csv(outdir / "seam_nodes.csv", index=False)
+    fam.to_csv(outdir / "seam_family_summary.csv", index=False)
+    emb.to_csv(outdir / "seam_embedding_summary.csv", index=False)
+    (outdir / "seam_metadata.txt").write_text(metadata, encoding="utf-8")
+
+    print(outdir / "seam_nodes.csv")
+    print(outdir / "seam_family_summary.csv")
+    print(outdir / "seam_embedding_summary.csv")
+    print(outdir / "seam_metadata.txt")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR adds the seam-regime foundation layer for the current observatory arc.

It introduces:
- family-level two-field occupancy analysis
- seam regime synthesis across anisotropy and relational obstruction
- embedding comparison across multiple layout methods
- diffusion-mode analysis as a seam-distance diagnostic
- canonical seam-bundle export for downstream studies

## Included studies

- `obs026_family_two_field_occupancy.py`
- `obs027_seam_regime_synthesis.py`
- `obs028_embedding_comparison.py`
- `obs028b_diffusion_mode_analysis.py`
- `obs028c_export_canonical_seam_bundle.py`

## Why this PR

This is the correct foundation for the later seam-dynamics and gateway-law arc.

It freezes:
- the two-field seam regime
- family occupancy structure
- canonical embedding policy
- reusable seam-bundle export

## Notes

- This is intended as the first PR in a stacked seam-study sequence.
- Later PRs build directly on the seam bundle exported here.