### PR TITLE
Add seam transition algebra and proto-groupoid studies

### DIFF
--- a/experiments/studies/obs029_seam_escape_channels.py
+++ b/experiments/studies/obs029_seam_escape_channels.py
@@ -1,0 +1,570 @@
+#!/usr/bin/env python3
+"""
+OBS-029 — Seam escape channels.
+
+Study the directional geometry by which branch-exit paths leave the seam-core,
+and compare that against seam-resident families.
+
+Core idea
+---------
+Using the canonical seam bundle plus route data, identify local seam-to-offseam
+transitions and ask:
+
+1. Do branch-exit paths leave the seam through consistent directions in MDS space?
+2. Are there preferred escape channels from shared / relational hotspot nodes?
+3. Do stable corridor and reorganization-heavy paths fail to use those channels?
+
+Inputs
+------
+outputs/obs028c_canonical_seam_bundle/seam_nodes.csv
+outputs/obs022_scene_bundle/scene_routes.csv
+
+Outputs
+-------
+outputs/obs029_seam_escape_channels/
+  seam_escape_steps.csv
+  seam_escape_class_summary.csv
+  obs029_seam_escape_channels_summary.txt
+  obs029_seam_escape_channels_figure.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class Config:
+    seam_nodes_csv: str = "outputs/obs028c_canonical_seam_bundle/seam_nodes.csv"
+    routes_csv: str = "outputs/obs022_scene_bundle/scene_routes.csv"
+    outdir: str = "outputs/obs029_seam_escape_channels"
+    seam_threshold: float = 0.15
+    min_exit_gain: float = 0.20
+    min_committed_offsteps: int = 2
+    direction_bin_deg: float = 30.0
+    top_k_vectors: int = 12
+
+
+CLASS_ORDER = [
+    "branch_exit",
+    "stable_seam_corridor",
+    "reorganization_heavy",
+]
+
+
+def safe_mean(s: pd.Series | np.ndarray) -> float:
+    ss = pd.to_numeric(pd.Series(s), errors="coerce")
+    return float(ss.mean()) if ss.notna().any() else float("nan")
+
+
+def circ_mean_deg(theta_deg: pd.Series | np.ndarray) -> float:
+    a = pd.to_numeric(pd.Series(theta_deg), errors="coerce").dropna().to_numpy(dtype=float)
+    if len(a) == 0:
+        return float("nan")
+    rad = np.radians(a)
+    return float((np.degrees(np.arctan2(np.mean(np.sin(rad)), np.mean(np.cos(rad)))) + 360.0) % 360.0)
+
+
+def circ_resultant_length(theta_deg: pd.Series | np.ndarray) -> float:
+    a = pd.to_numeric(pd.Series(theta_deg), errors="coerce").dropna().to_numpy(dtype=float)
+    if len(a) == 0:
+        return float("nan")
+    rad = np.radians(a)
+    return float(np.hypot(np.mean(np.cos(rad)), np.mean(np.sin(rad))))
+
+
+def classify_routes(routes: pd.DataFrame) -> pd.DataFrame:
+    out = routes.copy()
+    fam = out.get("path_family", pd.Series(index=out.index, dtype=object))
+    is_branch = pd.to_numeric(out.get("is_branch_away", 0), errors="coerce").fillna(0).eq(1)
+    is_rep = pd.to_numeric(out.get("is_representative", 0), errors="coerce").fillna(0).eq(1)
+
+    out["route_class"] = np.select(
+        [
+            is_branch,
+            is_rep & fam.eq("stable_seam_corridor"),
+            is_rep & fam.eq("reorganization_heavy"),
+        ],
+        [
+            "branch_exit",
+            "stable_seam_corridor",
+            "reorganization_heavy",
+        ],
+        default="other",
+    )
+    return out
+
+
+def load_inputs(cfg: Config) -> tuple[pd.DataFrame, pd.DataFrame]:
+    seam_nodes = pd.read_csv(cfg.seam_nodes_csv)
+    routes = pd.read_csv(cfg.routes_csv)
+
+    for df in (seam_nodes, routes):
+        for col in df.columns:
+            if col not in {"path_id", "path_family", "route_class", "hotspot_class"}:
+                try:
+                    df[col] = pd.to_numeric(df[col], errors="coerce")
+                except Exception:
+                    pass
+
+    routes = classify_routes(routes)
+
+    keep_cols = [
+        c for c in [
+            "node_id",
+            "r",
+            "alpha",
+            "mds1",
+            "mds2",
+            "signed_phase",
+            "distance_to_seam",
+            "neighbor_direction_mismatch_mean",
+            "sym_traceless_norm",
+            "anisotropy_hotspot",
+            "relational_hotspot",
+            "shared_hotspot",
+            "hotspot_class",
+            "seam_band",
+        ] if c in seam_nodes.columns
+    ]
+
+    seam_use = seam_nodes[keep_cols].drop_duplicates(subset=["node_id"]).copy()
+    seam_use = seam_use.rename(
+        columns={
+            c: f"{c}_bundle" for c in seam_use.columns if c != "node_id"
+        }
+    )
+
+    routes = routes.merge(
+        seam_use,
+        on="node_id",
+        how="left",
+    )
+
+    # Normalize canonical columns from bundle copy
+    for base_col in [
+        "r",
+        "alpha",
+        "mds1",
+        "mds2",
+        "signed_phase",
+        "distance_to_seam",
+        "neighbor_direction_mismatch_mean",
+        "sym_traceless_norm",
+        "anisotropy_hotspot",
+        "relational_hotspot",
+        "shared_hotspot",
+        "hotspot_class",
+        "seam_band",
+    ]:
+        bundle_col = f"{base_col}_bundle"
+
+        if base_col not in routes.columns and bundle_col in routes.columns:
+            routes[base_col] = routes[bundle_col]
+        elif base_col in routes.columns and bundle_col in routes.columns:
+            routes[base_col] = routes[base_col].where(routes[base_col].notna(), routes[bundle_col])
+
+    drop_cols = [c for c in routes.columns if c.endswith("_bundle")]
+    if drop_cols:
+        routes = routes.drop(columns=drop_cols)
+
+    required = ["distance_to_seam", "mds1", "mds2", "hotspot_class"]
+    missing = [c for c in required if c not in routes.columns]
+    if missing:
+        raise ValueError(f"Missing required normalized route columns: {missing}")
+
+    return seam_nodes, routes
+
+
+def angle_deg(dx: float, dy: float) -> float:
+    return float((np.degrees(np.arctan2(dy, dx)) + 360.0) % 360.0)
+
+
+def direction_bin(theta_deg: float, bin_width: float) -> str:
+    center = int((np.floor((theta_deg + bin_width / 2.0) / bin_width) * bin_width) % 360)
+    return f"{center:03d}"
+
+
+def compute_escape_steps(routes: pd.DataFrame, cfg: Config) -> pd.DataFrame:
+    rows = []
+
+    work = routes[routes["route_class"].isin(CLASS_ORDER)].copy()
+    if "step" in work.columns:
+        work = work.sort_values(["path_id", "step"]).reset_index(drop=True)
+
+    for path_id, grp in work.groupby("path_id", sort=False):
+        grp = grp.sort_values("step").copy().reset_index(drop=True)
+        if len(grp) < 2:
+            continue
+
+        d2s = pd.to_numeric(grp["distance_to_seam"], errors="coerce")
+        seam_mask = (d2s <= cfg.seam_threshold).fillna(False).to_numpy(dtype=bool)
+
+        for i in range(len(grp) - 1):
+            a = grp.iloc[i]
+            b = grp.iloc[i + 1]
+
+            da = pd.to_numeric(a.get("distance_to_seam"), errors="coerce")
+            db = pd.to_numeric(b.get("distance_to_seam"), errors="coerce")
+            if pd.isna(da) or pd.isna(db):
+                continue
+
+            from_seam = bool(da <= cfg.seam_threshold)
+            to_off = bool(db > cfg.seam_threshold)
+            exit_gain = float(db - da)
+
+            x0 = pd.to_numeric(a.get("mds1"), errors="coerce")
+            y0 = pd.to_numeric(a.get("mds2"), errors="coerce")
+            x1 = pd.to_numeric(b.get("mds1"), errors="coerce")
+            y1 = pd.to_numeric(b.get("mds2"), errors="coerce")
+            if any(pd.isna(v) for v in [x0, y0, x1, y1]):
+                continue
+
+            dx = float(x1 - x0)
+            dy = float(y1 - y0)
+            step_len = float(np.hypot(dx, dy))
+            theta = angle_deg(dx, dy) if step_len > 1e-12 else np.nan
+
+            hotspot_class = a.get("hotspot_class", np.nan)
+            if pd.isna(hotspot_class):
+                hotspot_class = "non_hotspot"
+
+            is_escape_step = bool(from_seam and to_off and exit_gain >= cfg.min_exit_gain)
+
+            # committed escape = remain off-seam for k subsequent rows after the crossing
+            committed = False
+            off_run_length = 0
+            if is_escape_step:
+                j = i + 1
+                while j < len(grp):
+                    dj = pd.to_numeric(grp.iloc[j].get("distance_to_seam"), errors="coerce")
+                    if pd.isna(dj) or dj <= cfg.seam_threshold:
+                        break
+                    off_run_length += 1
+                    j += 1
+                committed = off_run_length >= cfg.min_committed_offsteps
+
+            rows.append(
+                {
+                    "path_id": path_id,
+                    "route_class": a["route_class"],
+                    "path_family": a.get("path_family", np.nan),
+                    "step": pd.to_numeric(a.get("step"), errors="coerce"),
+                    "node_id": pd.to_numeric(a.get("node_id"), errors="coerce"),
+                    "from_hotspot_class": hotspot_class,
+                    "from_shared_hotspot": int(pd.to_numeric(a.get("shared_hotspot"), errors="coerce") == 1),
+                    "from_relational_hotspot": int(pd.to_numeric(a.get("relational_hotspot"), errors="coerce") == 1),
+                    "from_anisotropy_hotspot": int(pd.to_numeric(a.get("anisotropy_hotspot"), errors="coerce") == 1),
+                    "from_distance_to_seam": float(da),
+                    "to_distance_to_seam": float(db),
+                    "exit_gain": exit_gain,
+                    "from_seam": int(from_seam),
+                    "to_offseam": int(to_off),
+                    "is_escape_step": int(is_escape_step),
+                    "is_committed_escape": int(committed),
+                    "off_run_length": int(off_run_length),
+                    "dx": dx,
+                    "dy": dy,
+                    "step_len": step_len,
+                    "theta_deg": theta,
+                    "theta_bin": direction_bin(theta, cfg.direction_bin_deg) if np.isfinite(theta) else np.nan,
+                    "from_mds1": float(x0),
+                    "from_mds2": float(y0),
+                    "to_mds1": float(x1),
+                    "to_mds2": float(y1),
+                    "from_relational": pd.to_numeric(a.get("neighbor_direction_mismatch_mean"), errors="coerce"),
+                    "from_anisotropy": pd.to_numeric(a.get("sym_traceless_norm"), errors="coerce"),
+                }
+            )
+
+    return pd.DataFrame(rows)
+
+
+def summarize_classes(escape_steps: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+
+    for cls in CLASS_ORDER:
+        grp = escape_steps[escape_steps["route_class"] == cls].copy()
+        esc = grp[grp["is_escape_step"] == 1].copy()
+        com = grp[grp["is_committed_escape"] == 1].copy()
+
+        if len(grp) == 0:
+            continue
+
+        path_touch = (
+            grp.groupby("path_id", as_index=False)
+            .agg(
+                has_escape=("is_escape_step", "max"),
+                has_committed_escape=("is_committed_escape", "max"),
+            )
+        )
+
+        counts = com["theta_bin"].value_counts() if len(com) else pd.Series(dtype=int)
+        top_bin = counts.index[0] if len(counts) else np.nan
+        top_bin_share = float(counts.iloc[0] / max(len(com), 1)) if len(counts) else np.nan
+
+        rows.append(
+            {
+                "route_class": cls,
+                "n_steps": int(len(grp)),
+                "n_escape_steps": int(len(esc)),
+                "n_committed_escape_steps": int(len(com)),
+                "escape_step_share": float(len(esc) / max(len(grp), 1)),
+                "committed_escape_share": float(len(com) / max(len(grp), 1)),
+                "path_escape_touch_share": safe_mean(path_touch["has_escape"]),
+                "path_committed_escape_touch_share": safe_mean(path_touch["has_committed_escape"]),
+                "mean_exit_gain": safe_mean(com["exit_gain"]),
+                "mean_escape_len": safe_mean(com["step_len"]),
+                "mean_off_run_length": safe_mean(com["off_run_length"]),
+                "mean_escape_theta_deg": circ_mean_deg(com["theta_deg"]),
+                "escape_direction_concentration": circ_resultant_length(com["theta_deg"]),
+                "top_direction_bin": top_bin,
+                "top_direction_bin_share": top_bin_share,
+                "shared_escape_share": safe_mean(com["from_shared_hotspot"]),
+                "relational_escape_share": safe_mean(com["from_relational_hotspot"]),
+                "anisotropy_escape_share": safe_mean(com["from_anisotropy_hotspot"]),
+                "mean_from_relational": safe_mean(com["from_relational"]),
+                "mean_from_anisotropy": safe_mean(com["from_anisotropy"]),
+                "mean_from_distance_to_seam": safe_mean(com["from_distance_to_seam"]),
+            }
+        )
+
+    out = pd.DataFrame(rows)
+    order = {k: i for i, k in enumerate(CLASS_ORDER)}
+    out["order"] = out["route_class"].map(lambda x: order.get(x, 999))
+    return out.sort_values("order").drop(columns="order").reset_index(drop=True)
+
+
+def build_summary(summary_df: pd.DataFrame) -> str:
+    lines = [
+        "=== OBS-029 Seam Escape Channels Summary ===",
+        "",
+    ]
+
+    for _, row in summary_df.iterrows():
+        lines.extend(
+            [
+                f"{row['route_class']}",
+                f"  n_steps                              = {int(row['n_steps'])}",
+                f"  n_escape_steps                       = {int(row['n_escape_steps'])}",
+                f"  n_committed_escape_steps             = {int(row['n_committed_escape_steps'])}",
+                f"  escape_step_share                    = {float(row['escape_step_share']):.4f}",
+                f"  committed_escape_share               = {float(row['committed_escape_share']):.4f}",
+                f"  path_escape_touch_share              = {float(row['path_escape_touch_share']):.4f}",
+                f"  path_committed_escape_touch_share    = {float(row['path_committed_escape_touch_share']):.4f}",
+                f"  mean_exit_gain                       = {float(row['mean_exit_gain']):.4f}",
+                f"  mean_escape_len                      = {float(row['mean_escape_len']):.4f}",
+                f"  mean_off_run_length                  = {float(row['mean_off_run_length']):.4f}",
+                f"  mean_escape_theta_deg                = {float(row['mean_escape_theta_deg']):.4f}",
+                f"  escape_direction_concentration       = {float(row['escape_direction_concentration']):.4f}",
+                f"  top_direction_bin                    = {row['top_direction_bin']}",
+                f"  top_direction_bin_share              = {float(row['top_direction_bin_share']):.4f}",
+                f"  shared_escape_share                  = {float(row['shared_escape_share']):.4f}",
+                f"  relational_escape_share              = {float(row['relational_escape_share']):.4f}",
+                f"  anisotropy_escape_share              = {float(row['anisotropy_escape_share']):.4f}",
+                f"  mean_from_relational                 = {float(row['mean_from_relational']):.4f}",
+                f"  mean_from_anisotropy                 = {float(row['mean_from_anisotropy']):.4f}",
+                f"  mean_from_distance_to_seam           = {float(row['mean_from_distance_to_seam']):.4f}",
+                "",
+            ]
+        )
+
+    lines.extend(
+        [
+            "Interpretive guide",
+            "- escape_step captures local seam-to-offseam departures",
+            "- committed_escape captures departures that remain off-seam for multiple subsequent steps",
+            "- high escape_direction_concentration suggests a coherent preferred escape channel",
+            "- committed escape is the better measure of true release than local oscillation",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def render_figure(seam_nodes: pd.DataFrame, escape_steps: pd.DataFrame, summary_df: pd.DataFrame, outpath: Path, cfg: Config) -> None:
+    fig = plt.figure(figsize=(16.5, 10), constrained_layout=True)
+    gs = fig.add_gridspec(2, 3, width_ratios=[1.55, 1.05, 1.05], height_ratios=[1.0, 1.0])
+
+    ax_map = fig.add_subplot(gs[:, 0])
+    ax_bar = fig.add_subplot(gs[0, 1])
+    ax_conc = fig.add_subplot(gs[0, 2])
+    ax_touch = fig.add_subplot(gs[1, 1])
+    ax_diag = fig.add_subplot(gs[1, 2])
+
+    # base seam map
+    ax_map.scatter(
+        seam_nodes["mds1"],
+        seam_nodes["mds2"],
+        c=pd.to_numeric(seam_nodes["distance_to_seam"], errors="coerce"),
+        cmap="magma_r",
+        s=70,
+        alpha=0.85,
+        linewidths=0.25,
+        edgecolors="white",
+        zorder=1,
+    )
+
+    shared = seam_nodes[pd.to_numeric(seam_nodes.get("shared_hotspot", 0), errors="coerce").fillna(0) == 1]
+    if len(shared):
+        ax_map.scatter(
+            shared["mds1"],
+            shared["mds2"],
+            s=170,
+            c="#FFD166",
+            edgecolors="black",
+            linewidths=1.0,
+            alpha=0.98,
+            zorder=2,
+        )
+
+    colors = {
+        "branch_exit": "#1f77b4",
+        "stable_seam_corridor": "#2ca02c",
+        "reorganization_heavy": "#d62728",
+    }
+
+    for cls in CLASS_ORDER:
+        esc = escape_steps[(escape_steps["route_class"] == cls) & (escape_steps["is_escape_step"] == 1)].copy()
+        if len(esc) == 0:
+            continue
+
+        # top-k by exit gain for readability
+        esc = escape_steps[(escape_steps["route_class"] == cls) & (escape_steps["is_committed_escape"] == 1)].copy()
+        for _, row in esc.iterrows():
+            ax_map.arrow(
+                float(row["from_mds1"]),
+                float(row["from_mds2"]),
+                float(row["dx"]),
+                float(row["dy"]),
+                width=0.004,
+                head_width=0.06,
+                head_length=0.08,
+                length_includes_head=True,
+                color=colors[cls],
+                alpha=0.85,
+                zorder=3,
+            )
+
+    ax_map.set_title("OBS-029 seam escape vectors", fontsize=16, pad=8)
+    ax_map.set_xlabel("MDS 1")
+    ax_map.set_ylabel("MDS 2")
+    ax_map.grid(alpha=0.10)
+    ax_map.set_aspect("equal", adjustable="box")
+
+    # escape step share
+    x = np.arange(len(summary_df))
+    ax_bar.bar(x, summary_df["committed_escape_share"], color=[colors[c] for c in summary_df["route_class"]])
+    ax_bar.set_xticks(x)
+    ax_bar.set_xticklabels(summary_df["route_class"], rotation=12)
+    ax_bar.set_title("Committed escape share", fontsize=14, pad=8)
+    ax_bar.set_ylabel("share of steps")
+    ax_bar.grid(alpha=0.15, axis="y")
+
+    # direction concentration
+    ax_conc.bar(x, summary_df["escape_direction_concentration"], color=[colors[c] for c in summary_df["route_class"]])
+    ax_conc.set_xticks(x)
+    ax_conc.set_xticklabels(summary_df["route_class"], rotation=12)
+    ax_conc.set_title("Directional concentration", fontsize=14, pad=8)
+    ax_conc.set_ylabel("resultant length")
+    ax_conc.grid(alpha=0.15, axis="y")
+
+    # escape origin hotspot shares
+    width = 0.24
+    ax_touch.bar(x - width, summary_df["shared_escape_share"], width, label="shared", color="#FFD166", edgecolor="black")
+    ax_touch.bar(x, summary_df["relational_escape_share"], width, label="relational", color="#B23A48")
+    ax_touch.bar(x + width, summary_df["anisotropy_escape_share"], width, label="anisotropy", color="#2A9D8F")
+    ax_touch.set_xticks(x)
+    ax_touch.set_xticklabels(summary_df["route_class"], rotation=12)
+    ax_touch.set_title("Escape-origin hotspot type", fontsize=14, pad=8)
+    ax_touch.set_ylabel("share of escape steps")
+    ax_touch.grid(alpha=0.15, axis="y")
+    ax_touch.legend()
+
+    # diagnostics
+    ax_diag.axis("off")
+    if len(summary_df):
+        best_escape = summary_df.sort_values("committed_escape_share", ascending=False).iloc[0]
+        best_conc = summary_df.sort_values("escape_direction_concentration", ascending=False).iloc[0]
+        text = (
+            "OBS-029 diagnostics\n\n"
+            f"highest committed escape:\n{best_escape['route_class']} ({best_escape['committed_escape_share']:.3f})\n\n"
+            f"strongest directionality:\n{best_conc['route_class']} ({best_conc['escape_direction_concentration']:.3f})\n\n"
+            "Interpretation:\n"
+            "if branch_exit dominates both,\n"
+            "the seam has coherent escape\n"
+            "channels rather than random\n"
+            "release directions."
+        )
+    else:
+        text = "No summary rows available."
+
+    ax_diag.text(
+        0.02,
+        0.98,
+        text,
+        va="top",
+        ha="left",
+        fontsize=10.2,
+        family="monospace",
+        bbox=dict(boxstyle="round,pad=0.35", fc="white", ec="0.85", alpha=0.95),
+    )
+
+    fig.suptitle("PAM Observatory — OBS-029 seam escape channels", fontsize=21)
+    fig.savefig(outpath, dpi=220)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Analyze seam escape channels from the canonical seam bundle.")
+    parser.add_argument("--seam-nodes-csv", default=Config.seam_nodes_csv)
+    parser.add_argument("--routes-csv", default=Config.routes_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--seam-threshold", type=float, default=Config.seam_threshold)
+    parser.add_argument("--min-exit-gain", type=float, default=Config.min_exit_gain)
+    parser.add_argument("--direction-bin-deg", type=float, default=Config.direction_bin_deg)
+    parser.add_argument("--top-k-vectors", type=int, default=Config.top_k_vectors)
+    parser.add_argument("--min-committed-offsteps", type=int, default=Config.min_committed_offsteps)
+    args = parser.parse_args()
+
+    cfg = Config(
+        seam_nodes_csv=args.seam_nodes_csv,
+        routes_csv=args.routes_csv,
+        outdir=args.outdir,
+        seam_threshold=args.seam_threshold,
+        min_exit_gain=args.min_exit_gain,
+        direction_bin_deg=args.direction_bin_deg,
+        top_k_vectors=args.top_k_vectors,
+        min_committed_offsteps=args.min_committed_offsteps,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    seam_nodes, routes = load_inputs(cfg)
+    escape_steps = compute_escape_steps(routes, cfg)
+    summary_df = summarize_classes(escape_steps)
+
+    steps_csv = outdir / "seam_escape_steps.csv"
+    class_csv = outdir / "seam_escape_class_summary.csv"
+    txt_path = outdir / "obs029_seam_escape_channels_summary.txt"
+    png_path = outdir / "obs029_seam_escape_channels_figure.png"
+
+    escape_steps.to_csv(steps_csv, index=False)
+    summary_df.to_csv(class_csv, index=False)
+    txt_path.write_text(build_summary(summary_df), encoding="utf-8")
+    render_figure(seam_nodes, escape_steps, summary_df, png_path, cfg)
+
+    print(steps_csv)
+    print(class_csv)
+    print(txt_path)
+    print(png_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/studies/obs030_seam_transition_algebra.py
+++ b/experiments/studies/obs030_seam_transition_algebra.py
@@ -1,0 +1,557 @@
+#!/usr/bin/env python3
+"""
+OBS-030 — Seam transition algebra.
+
+Formalize the seam program as a typed local transition system.
+
+Objects
+-------
+Local seam-state types assigned to route steps from the canonical seam bundle.
+
+State types
+-----------
+- off_seam
+- relational_flank
+- anisotropy_flank
+- shared_core
+- mixed_seam
+- seam_resident_low
+- post_exit
+
+Arrows
+------
+Observed step-to-step transitions between state types along route families.
+
+This study asks:
+1. Which typed transitions are most common?
+2. Which transitions are family-specific?
+3. Which two-step compositions form stereotyped motifs?
+4. Is branch_exit associated with relational release motifs?
+5. Is reorganization_heavy associated with anisotropy-side release motifs?
+
+Inputs
+------
+outputs/obs028c_canonical_seam_bundle/seam_nodes.csv
+outputs/obs022_scene_bundle/scene_routes.csv
+
+Outputs
+-------
+outputs/obs030_seam_transition_algebra/
+  seam_transition_steps.csv
+  seam_transition_counts.csv
+  seam_transition_compositions.csv
+  seam_transition_family_summary.csv
+  obs030_seam_transition_algebra_summary.txt
+  obs030_seam_transition_algebra_figure.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class Config:
+    seam_nodes_csv: str = "outputs/obs028c_canonical_seam_bundle/seam_nodes.csv"
+    routes_csv: str = "outputs/obs022_scene_bundle/scene_routes.csv"
+    outdir: str = "outputs/obs030_seam_transition_algebra"
+    seam_threshold: float = 0.15
+    post_exit_threshold: float = 0.50
+    top_k_transitions: int = 12
+    top_k_compositions: int = 10
+
+
+CLASS_ORDER = [
+    "branch_exit",
+    "stable_seam_corridor",
+    "reorganization_heavy",
+]
+
+STATE_ORDER = [
+    "off_seam",
+    "post_exit",
+    "seam_resident_low",
+    "mixed_seam",
+    "relational_flank",
+    "anisotropy_flank",
+    "shared_core",
+]
+
+
+def safe_mean(s: pd.Series | np.ndarray) -> float:
+    ss = pd.to_numeric(pd.Series(s), errors="coerce")
+    return float(ss.mean()) if ss.notna().any() else float("nan")
+
+
+def classify_routes(routes: pd.DataFrame) -> pd.DataFrame:
+    out = routes.copy()
+    fam = out.get("path_family", pd.Series(index=out.index, dtype=object))
+    is_branch = pd.to_numeric(out.get("is_branch_away", 0), errors="coerce").fillna(0).eq(1)
+    is_rep = pd.to_numeric(out.get("is_representative", 0), errors="coerce").fillna(0).eq(1)
+
+    out["route_class"] = np.select(
+        [
+            is_branch,
+            is_rep & fam.eq("stable_seam_corridor"),
+            is_rep & fam.eq("reorganization_heavy"),
+        ],
+        [
+            "branch_exit",
+            "stable_seam_corridor",
+            "reorganization_heavy",
+        ],
+        default="other",
+    )
+    return out
+
+
+def load_inputs(cfg: Config) -> tuple[pd.DataFrame, pd.DataFrame]:
+    seam_nodes = pd.read_csv(cfg.seam_nodes_csv)
+    routes = pd.read_csv(cfg.routes_csv)
+
+    for df in (seam_nodes, routes):
+        for col in df.columns:
+            if col not in {"path_id", "path_family", "route_class", "hotspot_class"}:
+                try:
+                    df[col] = pd.to_numeric(df[col], errors="coerce")
+                except Exception:
+                    pass
+
+    routes = classify_routes(routes)
+
+    keep_cols = [
+        c for c in [
+            "node_id",
+            "r",
+            "alpha",
+            "mds1",
+            "mds2",
+            "distance_to_seam",
+            "neighbor_direction_mismatch_mean",
+            "sym_traceless_norm",
+            "anisotropy_hotspot",
+            "relational_hotspot",
+            "shared_hotspot",
+            "hotspot_class",
+            "seam_band",
+        ] if c in seam_nodes.columns
+    ]
+
+    seam_use = seam_nodes[keep_cols].drop_duplicates(subset=["node_id"]).copy()
+    seam_use = seam_use.rename(columns={c: f"{c}_bundle" for c in seam_use.columns if c != "node_id"})
+
+    routes = routes.merge(seam_use, on="node_id", how="left")
+
+    for base_col in [
+        "r",
+        "alpha",
+        "mds1",
+        "mds2",
+        "distance_to_seam",
+        "neighbor_direction_mismatch_mean",
+        "sym_traceless_norm",
+        "anisotropy_hotspot",
+        "relational_hotspot",
+        "shared_hotspot",
+        "hotspot_class",
+        "seam_band",
+    ]:
+        bundle_col = f"{base_col}_bundle"
+        if base_col not in routes.columns and bundle_col in routes.columns:
+            routes[base_col] = routes[bundle_col]
+        elif base_col in routes.columns and bundle_col in routes.columns:
+            routes[base_col] = routes[base_col].where(routes[base_col].notna(), routes[bundle_col])
+
+    drop_cols = [c for c in routes.columns if c.endswith("_bundle")]
+    if drop_cols:
+        routes = routes.drop(columns=drop_cols)
+
+    return seam_nodes, routes
+
+
+def assign_state_type(row: pd.Series, cfg: Config) -> str:
+    d2s = pd.to_numeric(row.get("distance_to_seam"), errors="coerce")
+    rel = pd.to_numeric(row.get("neighbor_direction_mismatch_mean"), errors="coerce")
+    aniso = pd.to_numeric(row.get("sym_traceless_norm"), errors="coerce")
+    shared = int(pd.to_numeric(row.get("shared_hotspot"), errors="coerce") == 1)
+    rel_hot = int(pd.to_numeric(row.get("relational_hotspot"), errors="coerce") == 1)
+    aniso_hot = int(pd.to_numeric(row.get("anisotropy_hotspot"), errors="coerce") == 1)
+
+    if pd.isna(d2s):
+        return "off_seam"
+
+    if d2s > cfg.post_exit_threshold:
+        return "post_exit"
+
+    if d2s > cfg.seam_threshold:
+        return "off_seam"
+
+    # seam-band states
+    if shared == 1:
+        return "shared_core"
+    if rel_hot == 1 and aniso_hot == 0:
+        return "relational_flank"
+    if aniso_hot == 1 and rel_hot == 0:
+        return "anisotropy_flank"
+    if rel_hot == 1 and aniso_hot == 1:
+        return "mixed_seam"
+
+    # seam-resident but not hotspot
+    if np.isfinite(rel) or np.isfinite(aniso):
+        return "seam_resident_low"
+
+    return "mixed_seam"
+
+
+def build_step_table(routes: pd.DataFrame, cfg: Config) -> pd.DataFrame:
+    work = routes[routes["route_class"].isin(CLASS_ORDER)].copy()
+    work = work.sort_values(["path_id", "step"]).reset_index(drop=True)
+
+    work["state_type"] = work.apply(lambda row: assign_state_type(row, cfg), axis=1)
+
+    rows = []
+    for path_id, grp in work.groupby("path_id", sort=False):
+        grp = grp.sort_values("step").copy().reset_index(drop=True)
+
+        for i in range(len(grp) - 1):
+            a = grp.iloc[i]
+            b = grp.iloc[i + 1]
+
+            rows.append(
+                {
+                    "path_id": path_id,
+                    "route_class": a["route_class"],
+                    "path_family": a.get("path_family", np.nan),
+                    "step": pd.to_numeric(a.get("step"), errors="coerce"),
+                    "node_id": pd.to_numeric(a.get("node_id"), errors="coerce"),
+                    "next_node_id": pd.to_numeric(b.get("node_id"), errors="coerce"),
+                    "state_from": a["state_type"],
+                    "state_to": b["state_type"],
+                    "distance_from": pd.to_numeric(a.get("distance_to_seam"), errors="coerce"),
+                    "distance_to": pd.to_numeric(b.get("distance_to_seam"), errors="coerce"),
+                    "relational_from": pd.to_numeric(a.get("neighbor_direction_mismatch_mean"), errors="coerce"),
+                    "anisotropy_from": pd.to_numeric(a.get("sym_traceless_norm"), errors="coerce"),
+                    "dx": pd.to_numeric(b.get("mds1"), errors="coerce") - pd.to_numeric(a.get("mds1"), errors="coerce"),
+                    "dy": pd.to_numeric(b.get("mds2"), errors="coerce") - pd.to_numeric(a.get("mds2"), errors="coerce"),
+                }
+            )
+
+    return work, pd.DataFrame(rows)
+
+
+def build_transition_counts(transition_steps: pd.DataFrame) -> pd.DataFrame:
+    counts = (
+        transition_steps.groupby(["route_class", "state_from", "state_to"], as_index=False)
+        .agg(
+            n_transitions=("path_id", "size"),
+            n_paths=("path_id", "nunique"),
+            mean_distance_from=("distance_from", "mean"),
+            mean_distance_to=("distance_to", "mean"),
+            mean_relational_from=("relational_from", "mean"),
+            mean_anisotropy_from=("anisotropy_from", "mean"),
+        )
+    )
+
+    total = counts.groupby("route_class")["n_transitions"].transform("sum")
+    counts["transition_share"] = counts["n_transitions"] / total.clip(lower=1)
+
+    state_rank = {s: i for i, s in enumerate(STATE_ORDER)}
+    counts["from_order"] = counts["state_from"].map(lambda x: state_rank.get(x, 999))
+    counts["to_order"] = counts["state_to"].map(lambda x: state_rank.get(x, 999))
+    counts = counts.sort_values(
+        ["route_class", "n_transitions", "from_order", "to_order"],
+        ascending=[True, False, True, True],
+    ).drop(columns=["from_order", "to_order"]).reset_index(drop=True)
+    return counts
+
+
+def build_transition_compositions(transition_steps: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+
+    for path_id, grp in transition_steps.groupby("path_id", sort=False):
+        grp = grp.sort_values("step").copy().reset_index(drop=True)
+        if len(grp) < 2:
+            continue
+
+        for i in range(len(grp) - 1):
+            a = grp.iloc[i]
+            b = grp.iloc[i + 1]
+            if a["state_to"] != b["state_from"]:
+                continue
+
+            rows.append(
+                {
+                    "path_id": path_id,
+                    "route_class": a["route_class"],
+                    "composition": f"{a['state_from']} -> {a['state_to']} -> {b['state_to']}",
+                    "state_a": a["state_from"],
+                    "state_b": a["state_to"],
+                    "state_c": b["state_to"],
+                }
+            )
+
+    comp = pd.DataFrame(rows)
+    if len(comp) == 0:
+        return pd.DataFrame(columns=["route_class", "composition", "n_compositions", "n_paths", "composition_share"])
+
+    out = (
+        comp.groupby(["route_class", "composition"], as_index=False)
+        .agg(
+            n_compositions=("path_id", "size"),
+            n_paths=("path_id", "nunique"),
+        )
+    )
+    total = out.groupby("route_class")["n_compositions"].transform("sum")
+    out["composition_share"] = out["n_compositions"] / total.clip(lower=1)
+    return out.sort_values(["route_class", "n_compositions"], ascending=[True, False]).reset_index(drop=True)
+
+
+def build_family_summary(transition_counts: pd.DataFrame, compositions: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+
+    target_transitions = {
+        "relational_release": ("relational_flank", "post_exit"),
+        "anisotropy_release": ("anisotropy_flank", "post_exit"),
+        "core_retention": ("shared_core", "shared_core"),
+        "core_to_low": ("shared_core", "seam_resident_low"),
+        "off_reentry": ("off_seam", "relational_flank"),
+    }
+
+    for cls in CLASS_ORDER:
+        sub = transition_counts[transition_counts["route_class"] == cls].copy()
+        comp = compositions[compositions["route_class"] == cls].copy()
+
+        total_trans = int(sub["n_transitions"].sum()) if len(sub) else 0
+        row = {
+            "route_class": cls,
+            "n_transitions": total_trans,
+        }
+
+        for label, (a, b) in target_transitions.items():
+            hit = sub[(sub["state_from"] == a) & (sub["state_to"] == b)]
+            row[f"{label}_count"] = int(hit["n_transitions"].sum()) if len(hit) else 0
+            row[f"{label}_share"] = float(hit["transition_share"].sum()) if len(hit) else 0.0
+
+        if len(sub):
+            top = sub.sort_values("n_transitions", ascending=False).head(3)
+            row["top_transition_1"] = f"{top.iloc[0]['state_from']} -> {top.iloc[0]['state_to']}" if len(top) >= 1 else np.nan
+            row["top_transition_2"] = f"{top.iloc[1]['state_from']} -> {top.iloc[1]['state_to']}" if len(top) >= 2 else np.nan
+            row["top_transition_3"] = f"{top.iloc[2]['state_from']} -> {top.iloc[2]['state_to']}" if len(top) >= 3 else np.nan
+        else:
+            row["top_transition_1"] = np.nan
+            row["top_transition_2"] = np.nan
+            row["top_transition_3"] = np.nan
+
+        if len(comp):
+            topc = comp.sort_values("n_compositions", ascending=False).head(3)
+            row["top_composition_1"] = topc.iloc[0]["composition"] if len(topc) >= 1 else np.nan
+            row["top_composition_2"] = topc.iloc[1]["composition"] if len(topc) >= 2 else np.nan
+            row["top_composition_3"] = topc.iloc[2]["composition"] if len(topc) >= 3 else np.nan
+        else:
+            row["top_composition_1"] = np.nan
+            row["top_composition_2"] = np.nan
+            row["top_composition_3"] = np.nan
+
+        rows.append(row)
+
+    out = pd.DataFrame(rows)
+    order = {k: i for i, k in enumerate(CLASS_ORDER)}
+    out["order"] = out["route_class"].map(lambda x: order.get(x, 999))
+    return out.sort_values("order").drop(columns="order").reset_index(drop=True)
+
+
+def build_summary(family_summary: pd.DataFrame, transition_counts: pd.DataFrame, compositions: pd.DataFrame) -> str:
+    lines = [
+        "=== OBS-030 Seam Transition Algebra Summary ===",
+        "",
+        "State types",
+        "  off_seam",
+        "  post_exit",
+        "  seam_resident_low",
+        "  mixed_seam",
+        "  relational_flank",
+        "  anisotropy_flank",
+        "  shared_core",
+        "",
+    ]
+
+    for _, row in family_summary.iterrows():
+        lines.extend(
+            [
+                f"{row['route_class']}",
+                f"  n_transitions            = {int(row['n_transitions'])}",
+                f"  relational_release_share = {float(row['relational_release_share']):.4f}",
+                f"  anisotropy_release_share = {float(row['anisotropy_release_share']):.4f}",
+                f"  core_retention_share     = {float(row['core_retention_share']):.4f}",
+                f"  core_to_low_share        = {float(row['core_to_low_share']):.4f}",
+                f"  off_reentry_share        = {float(row['off_reentry_share']):.4f}",
+                f"  top_transition_1         = {row['top_transition_1']}",
+                f"  top_transition_2         = {row['top_transition_2']}",
+                f"  top_transition_3         = {row['top_transition_3']}",
+                f"  top_composition_1        = {row['top_composition_1']}",
+                f"  top_composition_2        = {row['top_composition_2']}",
+                f"  top_composition_3        = {row['top_composition_3']}",
+                "",
+            ]
+        )
+
+    lines.extend(
+        [
+            "Interpretive guide",
+            "- relational_release tracks typed exit from the relational flank into post-exit state",
+            "- anisotropy_release tracks typed exit from the anisotropy flank into post-exit state",
+            "- core_retention tracks seam-core staying behavior",
+            "- compositions expose stereotyped multistep motifs rather than single-step transitions only",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def render_figure(transition_counts: pd.DataFrame, compositions: pd.DataFrame, family_summary: pd.DataFrame, outpath: Path, cfg: Config) -> None:
+    fig = plt.figure(figsize=(16.5, 10), constrained_layout=True)
+    gs = fig.add_gridspec(2, 3, width_ratios=[1.2, 1.2, 1.0], height_ratios=[1.0, 1.0])
+
+    ax_rel = fig.add_subplot(gs[0, 0])
+    ax_aniso = fig.add_subplot(gs[0, 1])
+    ax_core = fig.add_subplot(gs[0, 2])
+    ax_top = fig.add_subplot(gs[1, 0:2])
+    ax_diag = fig.add_subplot(gs[1, 2])
+
+    colors = {
+        "branch_exit": "#1f77b4",
+        "stable_seam_corridor": "#2ca02c",
+        "reorganization_heavy": "#d62728",
+    }
+
+    x = np.arange(len(family_summary))
+
+    ax_rel.bar(x, family_summary["relational_release_share"], color=[colors[c] for c in family_summary["route_class"]])
+    ax_rel.set_xticks(x)
+    ax_rel.set_xticklabels(family_summary["route_class"], rotation=12)
+    ax_rel.set_title("Relational release share", fontsize=14, pad=8)
+    ax_rel.grid(alpha=0.15, axis="y")
+
+    ax_aniso.bar(x, family_summary["anisotropy_release_share"], color=[colors[c] for c in family_summary["route_class"]])
+    ax_aniso.set_xticks(x)
+    ax_aniso.set_xticklabels(family_summary["route_class"], rotation=12)
+    ax_aniso.set_title("Anisotropy release share", fontsize=14, pad=8)
+    ax_aniso.grid(alpha=0.15, axis="y")
+
+    ax_core.bar(x - 0.18, family_summary["core_retention_share"], 0.36, label="core retention")
+    ax_core.bar(x + 0.18, family_summary["core_to_low_share"], 0.36, label="core→low")
+    ax_core.set_xticks(x)
+    ax_core.set_xticklabels(family_summary["route_class"], rotation=12)
+    ax_core.set_title("Core behavior", fontsize=14, pad=8)
+    ax_core.grid(alpha=0.15, axis="y")
+    ax_core.legend()
+
+    # top transitions table-like text
+    ax_top.axis("off")
+    y = 0.95
+    for cls in CLASS_ORDER:
+        sub = transition_counts[transition_counts["route_class"] == cls].head(cfg.top_k_transitions // 3 + 1)
+        ax_top.text(0.02, y, cls, fontsize=12, fontweight="bold")
+        y -= 0.06
+        for _, row in sub.head(3).iterrows():
+            txt = f"{row['state_from']} -> {row['state_to']} : {int(row['n_transitions'])} ({float(row['transition_share']):.3f})"
+            ax_top.text(0.04, y, txt, fontsize=10, family="monospace")
+            y -= 0.045
+        y -= 0.035
+
+    ax_top.set_title("Top typed transitions by family", fontsize=14, pad=8)
+
+    # diagnostics
+    ax_diag.axis("off")
+    if len(family_summary):
+        best_rel = family_summary.sort_values("relational_release_share", ascending=False).iloc[0]
+        best_aniso = family_summary.sort_values("anisotropy_release_share", ascending=False).iloc[0]
+        best_core = family_summary.sort_values("core_retention_share", ascending=False).iloc[0]
+        text = (
+            "OBS-030 diagnostics\n\n"
+            f"strongest relational release:\n{best_rel['route_class']} ({best_rel['relational_release_share']:.3f})\n\n"
+            f"strongest anisotropy release:\n{best_aniso['route_class']} ({best_aniso['anisotropy_release_share']:.3f})\n\n"
+            f"strongest core retention:\n{best_core['route_class']} ({best_core['core_retention_share']:.3f})\n\n"
+            "Goal:\n"
+            "turn seam dynamics into\n"
+            "typed local moves and\n"
+            "composable motifs."
+        )
+    else:
+        text = "No family summary rows available."
+
+    ax_diag.text(
+        0.02,
+        0.98,
+        text,
+        va="top",
+        ha="left",
+        fontsize=10.2,
+        family="monospace",
+        bbox=dict(boxstyle="round,pad=0.35", fc="white", ec="0.85", alpha=0.95),
+    )
+
+    fig.suptitle("PAM Observatory — OBS-030 seam transition algebra", fontsize=21)
+    fig.savefig(outpath, dpi=220)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Formalize seam dynamics as a typed transition algebra.")
+    parser.add_argument("--seam-nodes-csv", default=Config.seam_nodes_csv)
+    parser.add_argument("--routes-csv", default=Config.routes_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--seam-threshold", type=float, default=Config.seam_threshold)
+    parser.add_argument("--post-exit-threshold", type=float, default=Config.post_exit_threshold)
+    parser.add_argument("--top-k-transitions", type=int, default=Config.top_k_transitions)
+    parser.add_argument("--top-k-compositions", type=int, default=Config.top_k_compositions)
+    args = parser.parse_args()
+
+    cfg = Config(
+        seam_nodes_csv=args.seam_nodes_csv,
+        routes_csv=args.routes_csv,
+        outdir=args.outdir,
+        seam_threshold=args.seam_threshold,
+        post_exit_threshold=args.post_exit_threshold,
+        top_k_transitions=args.top_k_transitions,
+        top_k_compositions=args.top_k_compositions,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    _, routes = load_inputs(cfg)
+    step_nodes, transition_steps = build_step_table(routes, cfg)
+    transition_counts = build_transition_counts(transition_steps)
+    compositions = build_transition_compositions(transition_steps)
+    family_summary = build_family_summary(transition_counts, compositions)
+
+    steps_csv = outdir / "seam_transition_steps.csv"
+    counts_csv = outdir / "seam_transition_counts.csv"
+    comp_csv = outdir / "seam_transition_compositions.csv"
+    fam_csv = outdir / "seam_transition_family_summary.csv"
+    txt_path = outdir / "obs030_seam_transition_algebra_summary.txt"
+    png_path = outdir / "obs030_seam_transition_algebra_figure.png"
+
+    transition_steps.to_csv(steps_csv, index=False)
+    transition_counts.to_csv(counts_csv, index=False)
+    compositions.to_csv(comp_csv, index=False)
+    family_summary.to_csv(fam_csv, index=False)
+    txt_path.write_text(build_summary(family_summary, transition_counts, compositions), encoding="utf-8")
+    render_figure(transition_counts, compositions, family_summary, png_path, cfg)
+
+    print(steps_csv)
+    print(counts_csv)
+    print(comp_csv)
+    print(fam_csv)
+    print(txt_path)
+    print(png_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/studies/obs030b_seam_transition_motifs.py
+++ b/experiments/studies/obs030b_seam_transition_motifs.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""
+OBS-030b — Seam transition motifs.
+
+Refine OBS-030 by promoting short-horizon transition motifs to first-class
+objects, instead of relying only on one-step typed transitions.
+
+Why
+---
+OBS-030 showed that the transition-algebra direction is correct, but that
+single-step release arrows are too strict. In practice, seam release often
+appears as a short motif such as:
+
+    relational_flank -> off_seam -> post_exit
+    anisotropy_flank -> off_seam -> post_exit
+
+rather than a single immediate jump into post_exit.
+
+This study therefore classifies 3-state motifs and groups them into
+interpretable motif families.
+
+Inputs
+------
+outputs/obs030_seam_transition_algebra/seam_transition_steps.csv
+
+Outputs
+-------
+outputs/obs030b_seam_transition_motifs/
+  seam_transition_motifs.csv
+  seam_motif_counts.csv
+  seam_motif_family_summary.csv
+  obs030b_seam_transition_motifs_summary.txt
+  obs030b_seam_transition_motifs_figure.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class Config:
+    transition_steps_csv: str = "outputs/obs030_seam_transition_algebra/seam_transition_steps.csv"
+    outdir: str = "outputs/obs030b_seam_transition_motifs"
+    top_k_motifs: int = 12
+
+
+CLASS_ORDER = [
+    "branch_exit",
+    "stable_seam_corridor",
+    "reorganization_heavy",
+]
+
+
+def safe_mean(s: pd.Series | np.ndarray) -> float:
+    ss = pd.to_numeric(pd.Series(s), errors="coerce")
+    return float(ss.mean()) if ss.notna().any() else float("nan")
+
+
+def classify_motif(a: str, b: str, c: str) -> str:
+    # release motifs
+    if a == "relational_flank" and b in {"off_seam", "post_exit"} and c == "post_exit":
+        return "relational_release_motif"
+    if a == "anisotropy_flank" and b in {"off_seam", "post_exit"} and c == "post_exit":
+        return "anisotropy_release_motif"
+    if a == "shared_core" and b in {"off_seam", "post_exit", "seam_resident_low"} and c in {"off_seam", "post_exit"}:
+        return "core_release_motif"
+
+    # seam-core residency / low-stress residency
+    if a == "shared_core" and b == "shared_core" and c == "shared_core":
+        return "core_retention_motif"
+    if a == "seam_resident_low" and b == "seam_resident_low" and c == "seam_resident_low":
+        return "low_residency_motif"
+
+    # flank oscillation / shuttling
+    if {a, b, c}.issubset({"relational_flank", "anisotropy_flank"}):
+        return "flank_shuttle_motif"
+
+    # off-seam persistence
+    if a == "off_seam" and b == "off_seam" and c == "off_seam":
+        return "off_seam_persistence_motif"
+    if a == "post_exit" and b == "post_exit" and c == "post_exit":
+        return "post_exit_persistence_motif"
+
+    # re-entry motifs
+    if a == "off_seam" and b in {"relational_flank", "anisotropy_flank", "shared_core"}:
+        return "reentry_motif"
+    if a == "post_exit" and b in {"relational_flank", "anisotropy_flank", "shared_core"}:
+        return "reentry_motif"
+
+    # seam to low / low to flank
+    if a == "shared_core" and b == "seam_resident_low":
+        return "core_to_low_motif"
+    if a == "seam_resident_low" and c in {"relational_flank", "anisotropy_flank"}:
+        return "low_to_flank_motif"
+
+    return "other_motif"
+
+
+def build_motifs(steps: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+
+    for path_id, grp in steps.groupby("path_id", sort=False):
+        grp = grp.sort_values("step").copy().reset_index(drop=True)
+        if len(grp) < 2:
+            continue
+
+        for i in range(len(grp) - 1):
+            a = grp.iloc[i]
+            b = grp.iloc[i + 1]
+
+            state_a = str(a["state_from"])
+            state_b = str(a["state_to"])
+            state_c = str(b["state_to"]) if a["state_to"] == b["state_from"] else None
+            if state_c is None:
+                continue
+
+            motif = f"{state_a} -> {state_b} -> {state_c}"
+            motif_class = classify_motif(state_a, state_b, state_c)
+
+            rows.append(
+                {
+                    "path_id": path_id,
+                    "route_class": a["route_class"],
+                    "step": pd.to_numeric(a.get("step"), errors="coerce"),
+                    "motif": motif,
+                    "motif_class": motif_class,
+                    "state_a": state_a,
+                    "state_b": state_b,
+                    "state_c": state_c,
+                    "distance_a": pd.to_numeric(a.get("distance_from"), errors="coerce"),
+                    "distance_b": pd.to_numeric(a.get("distance_to"), errors="coerce"),
+                    "relational_a": pd.to_numeric(a.get("relational_from"), errors="coerce"),
+                    "anisotropy_a": pd.to_numeric(a.get("anisotropy_from"), errors="coerce"),
+                }
+            )
+
+    return pd.DataFrame(rows)
+
+
+def build_motif_counts(motifs: pd.DataFrame) -> pd.DataFrame:
+    if len(motifs) == 0:
+        return pd.DataFrame(
+            columns=[
+                "route_class", "motif_class", "motif", "n_motifs",
+                "n_paths", "motif_share", "mean_distance_a",
+                "mean_relational_a", "mean_anisotropy_a"
+            ]
+        )
+
+    out = (
+        motifs.groupby(["route_class", "motif_class", "motif"], as_index=False)
+        .agg(
+            n_motifs=("path_id", "size"),
+            n_paths=("path_id", "nunique"),
+            mean_distance_a=("distance_a", "mean"),
+            mean_relational_a=("relational_a", "mean"),
+            mean_anisotropy_a=("anisotropy_a", "mean"),
+        )
+    )
+    total = out.groupby("route_class")["n_motifs"].transform("sum")
+    out["motif_share"] = out["n_motifs"] / total.clip(lower=1)
+    return out.sort_values(["route_class", "n_motifs"], ascending=[True, False]).reset_index(drop=True)
+
+
+def build_family_summary(counts: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+
+    target_classes = [
+        "relational_release_motif",
+        "anisotropy_release_motif",
+        "core_release_motif",
+        "core_retention_motif",
+        "low_residency_motif",
+        "flank_shuttle_motif",
+        "off_seam_persistence_motif",
+        "post_exit_persistence_motif",
+        "reentry_motif",
+        "core_to_low_motif",
+    ]
+
+    for cls in CLASS_ORDER:
+        sub = counts[counts["route_class"] == cls].copy()
+
+        row = {
+            "route_class": cls,
+            "n_motifs": int(sub["n_motifs"].sum()) if len(sub) else 0,
+        }
+
+        for mc in target_classes:
+            hit = sub[sub["motif_class"] == mc]
+            row[f"{mc}_count"] = int(hit["n_motifs"].sum()) if len(hit) else 0
+            row[f"{mc}_share"] = float(hit["motif_share"].sum()) if len(hit) else 0.0
+
+        top = sub.sort_values("n_motifs", ascending=False).head(5) if len(sub) else pd.DataFrame()
+        for i in range(5):
+            row[f"top_motif_{i+1}"] = top.iloc[i]["motif"] if len(top) > i else np.nan
+
+        rows.append(row)
+
+    out = pd.DataFrame(rows)
+    order = {k: i for i, k in enumerate(CLASS_ORDER)}
+    out["order"] = out["route_class"].map(lambda x: order.get(x, 999))
+    return out.sort_values("order").drop(columns="order").reset_index(drop=True)
+
+
+def build_summary(family_summary: pd.DataFrame) -> str:
+    lines = [
+        "=== OBS-030b Seam Transition Motifs Summary ===",
+        "",
+        "Motif classes",
+        "  relational_release_motif",
+        "  anisotropy_release_motif",
+        "  core_release_motif",
+        "  core_retention_motif",
+        "  low_residency_motif",
+        "  flank_shuttle_motif",
+        "  off_seam_persistence_motif",
+        "  post_exit_persistence_motif",
+        "  reentry_motif",
+        "  core_to_low_motif",
+        "",
+    ]
+
+    for _, row in family_summary.iterrows():
+        lines.extend(
+            [
+                f"{row['route_class']}",
+                f"  n_motifs                         = {int(row['n_motifs'])}",
+                f"  relational_release_motif_share   = {float(row['relational_release_motif_share']):.4f}",
+                f"  anisotropy_release_motif_share   = {float(row['anisotropy_release_motif_share']):.4f}",
+                f"  core_release_motif_share         = {float(row['core_release_motif_share']):.4f}",
+                f"  core_retention_motif_share       = {float(row['core_retention_motif_share']):.4f}",
+                f"  low_residency_motif_share        = {float(row['low_residency_motif_share']):.4f}",
+                f"  flank_shuttle_motif_share        = {float(row['flank_shuttle_motif_share']):.4f}",
+                f"  off_seam_persistence_motif_share = {float(row['off_seam_persistence_motif_share']):.4f}",
+                f"  post_exit_persistence_motif_share= {float(row['post_exit_persistence_motif_share']):.4f}",
+                f"  reentry_motif_share              = {float(row['reentry_motif_share']):.4f}",
+                f"  core_to_low_motif_share          = {float(row['core_to_low_motif_share']):.4f}",
+                f"  top_motif_1                      = {row['top_motif_1']}",
+                f"  top_motif_2                      = {row['top_motif_2']}",
+                f"  top_motif_3                      = {row['top_motif_3']}",
+                "",
+            ]
+        )
+
+    lines.extend(
+        [
+            "Interpretive guide",
+            "- release motifs are short-horizon typed departures, not single-step jumps only",
+            "- flank_shuttle motifs capture seam-internal oscillation between relational and anisotropy sides",
+            "- off_seam/post_exit persistence motifs capture staying gone once released",
+            "- reentry motifs capture return from off-seam states back into seam structure",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def render_figure(family_summary: pd.DataFrame, outpath: Path, cfg: Config) -> None:
+    fig = plt.figure(figsize=(16.5, 10), constrained_layout=True)
+    gs = fig.add_gridspec(2, 3, width_ratios=[1.15, 1.15, 1.0], height_ratios=[1.0, 1.0])
+
+    ax_rel = fig.add_subplot(gs[0, 0])
+    ax_aniso = fig.add_subplot(gs[0, 1])
+    ax_core = fig.add_subplot(gs[0, 2])
+    ax_res = fig.add_subplot(gs[1, 0])
+    ax_re = fig.add_subplot(gs[1, 1])
+    ax_diag = fig.add_subplot(gs[1, 2])
+
+    colors = {
+        "branch_exit": "#1f77b4",
+        "stable_seam_corridor": "#2ca02c",
+        "reorganization_heavy": "#d62728",
+    }
+
+    x = np.arange(len(family_summary))
+    c = [colors[k] for k in family_summary["route_class"]]
+
+    ax_rel.bar(x, family_summary["relational_release_motif_share"], color=c)
+    ax_rel.set_xticks(x)
+    ax_rel.set_xticklabels(family_summary["route_class"], rotation=12)
+    ax_rel.set_title("Relational release motifs", fontsize=14, pad=8)
+    ax_rel.grid(alpha=0.15, axis="y")
+
+    ax_aniso.bar(x, family_summary["anisotropy_release_motif_share"], color=c)
+    ax_aniso.set_xticks(x)
+    ax_aniso.set_xticklabels(family_summary["route_class"], rotation=12)
+    ax_aniso.set_title("Anisotropy release motifs", fontsize=14, pad=8)
+    ax_aniso.grid(alpha=0.15, axis="y")
+
+    width = 0.36
+    ax_core.bar(x - width / 2, family_summary["core_retention_motif_share"], width, label="core retention")
+    ax_core.bar(x + width / 2, family_summary["core_release_motif_share"], width, label="core release")
+    ax_core.set_xticks(x)
+    ax_core.set_xticklabels(family_summary["route_class"], rotation=12)
+    ax_core.set_title("Core motifs", fontsize=14, pad=8)
+    ax_core.grid(alpha=0.15, axis="y")
+    ax_core.legend()
+
+    ax_res.bar(x - width / 2, family_summary["off_seam_persistence_motif_share"], width, label="off-seam persist")
+    ax_res.bar(x + width / 2, family_summary["post_exit_persistence_motif_share"], width, label="post-exit persist")
+    ax_res.set_xticks(x)
+    ax_res.set_xticklabels(family_summary["route_class"], rotation=12)
+    ax_res.set_title("Release persistence motifs", fontsize=14, pad=8)
+    ax_res.grid(alpha=0.15, axis="y")
+    ax_res.legend()
+
+    ax_re.bar(x - width / 2, family_summary["reentry_motif_share"], width, label="re-entry")
+    ax_re.bar(x + width / 2, family_summary["flank_shuttle_motif_share"], width, label="flank shuttle")
+    ax_re.set_xticks(x)
+    ax_re.set_xticklabels(family_summary["route_class"], rotation=12)
+    ax_re.set_title("Re-entry / seam-internal motifs", fontsize=14, pad=8)
+    ax_re.grid(alpha=0.15, axis="y")
+    ax_re.legend()
+
+    ax_diag.axis("off")
+    best_rel = family_summary.sort_values("relational_release_motif_share", ascending=False).iloc[0]
+    best_aniso = family_summary.sort_values("anisotropy_release_motif_share", ascending=False).iloc[0]
+    best_re = family_summary.sort_values("reentry_motif_share", ascending=False).iloc[0]
+    text = (
+        "OBS-030b diagnostics\n\n"
+        f"strongest relational release:\n{best_rel['route_class']} ({best_rel['relational_release_motif_share']:.3f})\n\n"
+        f"strongest anisotropy release:\n{best_aniso['route_class']} ({best_aniso['anisotropy_release_motif_share']:.3f})\n\n"
+        f"strongest re-entry:\n{best_re['route_class']} ({best_re['reentry_motif_share']:.3f})\n\n"
+        "Goal:\n"
+        "upgrade one-step arrows\n"
+        "into short-horizon typed\n"
+        "motifs that match the\n"
+        "observed seam dynamics."
+    )
+    ax_diag.text(
+        0.02, 0.98, text,
+        va="top", ha="left", fontsize=10.2, family="monospace",
+        bbox=dict(boxstyle="round,pad=0.35", fc="white", ec="0.85", alpha=0.95),
+    )
+
+    fig.suptitle("PAM Observatory — OBS-030b seam transition motifs", fontsize=21)
+    fig.savefig(outpath, dpi=220)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Promote seam transitions to short-horizon typed motifs.")
+    parser.add_argument("--transition-steps-csv", default=Config.transition_steps_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--top-k-motifs", type=int, default=Config.top_k_motifs)
+    args = parser.parse_args()
+
+    cfg = Config(
+        transition_steps_csv=args.transition_steps_csv,
+        outdir=args.outdir,
+        top_k_motifs=args.top_k_motifs,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    steps = pd.read_csv(cfg.transition_steps_csv)
+    motifs = build_motifs(steps)
+    counts = build_motif_counts(motifs)
+    family_summary = build_family_summary(counts)
+
+    motifs_csv = outdir / "seam_transition_motifs.csv"
+    counts_csv = outdir / "seam_motif_counts.csv"
+    fam_csv = outdir / "seam_motif_family_summary.csv"
+    txt_path = outdir / "obs030b_seam_transition_motifs_summary.txt"
+    png_path = outdir / "obs030b_seam_transition_motifs_figure.png"
+
+    motifs.to_csv(motifs_csv, index=False)
+    counts.to_csv(counts_csv, index=False)
+    family_summary.to_csv(fam_csv, index=False)
+    txt_path.write_text(build_summary(family_summary), encoding="utf-8")
+    render_figure(family_summary, png_path, cfg)
+
+    print(motifs_csv)
+    print(counts_csv)
+    print(fam_csv)
+    print(txt_path)
+    print(png_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/studies/obs030c_motif_generator_algebra.py
+++ b/experiments/studies/obs030c_motif_generator_algebra.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+"""
+OBS-030c — Motif generator algebra.
+
+Bridge the seam observatory from empirical motif structure toward a compact
+algebraic object.
+
+This study compresses OBS-030b motif behavior into:
+
+1. a reduced state alphabet
+2. a reduced generator alphabet
+3. family-specific generator usage
+4. generator composition patterns
+
+Reduced state alphabet
+----------------------
+R = relational_flank
+A = anisotropy_flank
+L = seam_resident_low
+O = off_seam
+P = post_exit
+C = shared_core
+
+Generator alphabet
+------------------
+g_rel_release      : relational release toward post-exit
+g_aniso_release    : anisotropy-side release toward post-exit
+g_flank_shuttle    : seam-internal R/A oscillation
+g_low_residency    : low seam residency / L persistence
+g_off_persist      : off-seam persistence
+g_post_persist     : post-exit persistence
+g_reentry          : off/post re-entry into seam structure
+g_core_behavior    : shared-core retention/release/decay
+g_other            : uncategorized motif
+
+Inputs
+------
+outputs/obs030b_seam_transition_motifs/seam_transition_motifs.csv
+
+Outputs
+-------
+outputs/obs030c_motif_generator_algebra/
+  motif_generator_assignments.csv
+  motif_generator_counts.csv
+  motif_generator_compositions.csv
+  motif_generator_family_summary.csv
+  obs030c_motif_generator_algebra_summary.txt
+  obs030c_motif_generator_algebra_figure.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class Config:
+    motifs_csv: str = "outputs/obs030b_seam_transition_motifs/seam_transition_motifs.csv"
+    outdir: str = "outputs/obs030c_motif_generator_algebra"
+    top_k_generators: int = 8
+    top_k_compositions: int = 10
+
+
+CLASS_ORDER = [
+    "branch_exit",
+    "stable_seam_corridor",
+    "reorganization_heavy",
+]
+
+GENERATOR_ORDER = [
+    "g_rel_release",
+    "g_aniso_release",
+    "g_flank_shuttle",
+    "g_low_residency",
+    "g_off_persist",
+    "g_post_persist",
+    "g_reentry",
+    "g_core_behavior",
+    "g_other",
+]
+
+
+def reduce_state(s: str) -> str:
+    mapping = {
+        "relational_flank": "R",
+        "anisotropy_flank": "A",
+        "seam_resident_low": "L",
+        "off_seam": "O",
+        "post_exit": "P",
+        "shared_core": "C",
+        "mixed_seam": "L",
+    }
+    return mapping.get(str(s), "L")
+
+
+def assign_generator(motif_class: str, a: str, b: str, c: str) -> str:
+    ra, rb, rc = reduce_state(a), reduce_state(b), reduce_state(c)
+
+    if motif_class == "relational_release_motif":
+        return "g_rel_release"
+    if motif_class == "anisotropy_release_motif":
+        return "g_aniso_release"
+
+    if motif_class == "flank_shuttle_motif":
+        return "g_flank_shuttle"
+
+    if motif_class == "low_residency_motif":
+        return "g_low_residency"
+
+    if motif_class == "off_seam_persistence_motif":
+        return "g_off_persist"
+    if motif_class == "post_exit_persistence_motif":
+        return "g_post_persist"
+
+    if motif_class == "reentry_motif":
+        return "g_reentry"
+
+    if motif_class in {"core_retention_motif", "core_release_motif", "core_to_low_motif"}:
+        return "g_core_behavior"
+
+    # fallback structural rules
+    if ra == "R" and rc == "P":
+        return "g_rel_release"
+    if ra == "A" and rc == "P":
+        return "g_aniso_release"
+    if {ra, rb, rc}.issubset({"R", "A"}):
+        return "g_flank_shuttle"
+    if ra == rb == rc == "L":
+        return "g_low_residency"
+    if ra == rb == rc == "O":
+        return "g_off_persist"
+    if ra == rb == rc == "P":
+        return "g_post_persist"
+    if ra in {"O", "P"} and rb in {"R", "A", "L", "C"}:
+        return "g_reentry"
+    if "C" in {ra, rb, rc}:
+        return "g_core_behavior"
+
+    return "g_other"
+
+
+def load_motifs(path: str | Path) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    for col in df.columns:
+        if col not in {"path_id", "path_family", "route_class", "motif", "motif_class", "state_a", "state_b", "state_c"}:
+            try:
+                df[col] = pd.to_numeric(df[col], errors="coerce")
+            except Exception:
+                pass
+    return df
+
+
+def build_generator_assignments(motifs: pd.DataFrame) -> pd.DataFrame:
+    out = motifs.copy()
+    out["state_a_red"] = out["state_a"].map(reduce_state)
+    out["state_b_red"] = out["state_b"].map(reduce_state)
+    out["state_c_red"] = out["state_c"].map(reduce_state)
+    out["generator"] = [
+        assign_generator(mc, a, b, c)
+        for mc, a, b, c in zip(out["motif_class"], out["state_a"], out["state_b"], out["state_c"])
+    ]
+    out["generator_word"] = out["state_a_red"] + "~" + out["state_b_red"] + "~" + out["state_c_red"]
+    return out
+
+
+def build_generator_counts(assignments: pd.DataFrame) -> pd.DataFrame:
+    counts = (
+        assignments.groupby(["route_class", "generator"], as_index=False)
+        .agg(
+            n_motifs=("path_id", "size"),
+            n_paths=("path_id", "nunique"),
+        )
+    )
+    total = counts.groupby("route_class")["n_motifs"].transform("sum")
+    counts["generator_share"] = counts["n_motifs"] / total.clip(lower=1)
+
+    order = {g: i for i, g in enumerate(GENERATOR_ORDER)}
+    counts["g_order"] = counts["generator"].map(lambda x: order.get(x, 999))
+    counts = counts.sort_values(["route_class", "g_order"]).drop(columns=["g_order"]).reset_index(drop=True)
+    return counts
+
+
+def build_generator_compositions(assignments: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+
+    for path_id, grp in assignments.groupby("path_id", sort=False):
+        grp = grp.sort_values("step").copy().reset_index(drop=True)
+        if len(grp) < 2:
+            continue
+
+        for i in range(len(grp) - 1):
+            a = grp.iloc[i]
+            b = grp.iloc[i + 1]
+
+            rows.append(
+                {
+                    "path_id": path_id,
+                    "route_class": a["route_class"],
+                    "generator_1": a["generator"],
+                    "generator_2": b["generator"],
+                    "composition": f"{a['generator']} ; {b['generator']}",
+                }
+            )
+
+    comp = pd.DataFrame(rows)
+    if len(comp) == 0:
+        return pd.DataFrame(columns=["route_class", "generator_1", "generator_2", "composition", "n_compositions", "n_paths", "composition_share"])
+
+    out = (
+        comp.groupby(["route_class", "generator_1", "generator_2", "composition"], as_index=False)
+        .agg(
+            n_compositions=("path_id", "size"),
+            n_paths=("path_id", "nunique"),
+        )
+    )
+    total = out.groupby("route_class")["n_compositions"].transform("sum")
+    out["composition_share"] = out["n_compositions"] / total.clip(lower=1)
+    return out.sort_values(["route_class", "n_compositions"], ascending=[True, False]).reset_index(drop=True)
+
+
+def build_family_summary(counts: pd.DataFrame, compositions: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+
+    for cls in CLASS_ORDER:
+        sub = counts[counts["route_class"] == cls].copy()
+        comp = compositions[compositions["route_class"] == cls].copy()
+
+        row = {
+            "route_class": cls,
+            "n_generators": int(sub["n_motifs"].sum()) if len(sub) else 0,
+        }
+
+        for g in GENERATOR_ORDER:
+            hit = sub[sub["generator"] == g]
+            row[f"{g}_share"] = float(hit["generator_share"].sum()) if len(hit) else 0.0
+            row[f"{g}_count"] = int(hit["n_motifs"].sum()) if len(hit) else 0
+
+        topg = sub.sort_values("n_motifs", ascending=False).head(5) if len(sub) else pd.DataFrame()
+        for i in range(5):
+            row[f"top_generator_{i+1}"] = topg.iloc[i]["generator"] if len(topg) > i else np.nan
+
+        topc = comp.sort_values("n_compositions", ascending=False).head(5) if len(comp) else pd.DataFrame()
+        for i in range(5):
+            row[f"top_composition_{i+1}"] = topc.iloc[i]["composition"] if len(topc) > i else np.nan
+
+        rows.append(row)
+
+    out = pd.DataFrame(rows)
+    order = {k: i for i, k in enumerate(CLASS_ORDER)}
+    out["order"] = out["route_class"].map(lambda x: order.get(x, 999))
+    return out.sort_values("order").drop(columns=["order"]).reset_index(drop=True)
+
+
+def build_summary(family_summary: pd.DataFrame) -> str:
+    lines = [
+        "=== OBS-030c Motif Generator Algebra Summary ===",
+        "",
+        "Reduced state alphabet",
+        "  R = relational_flank",
+        "  A = anisotropy_flank",
+        "  L = seam_resident_low",
+        "  O = off_seam",
+        "  P = post_exit",
+        "  C = shared_core",
+        "",
+        "Generator alphabet",
+        "  g_rel_release",
+        "  g_aniso_release",
+        "  g_flank_shuttle",
+        "  g_low_residency",
+        "  g_off_persist",
+        "  g_post_persist",
+        "  g_reentry",
+        "  g_core_behavior",
+        "  g_other",
+        "",
+    ]
+
+    for _, row in family_summary.iterrows():
+        lines.extend(
+            [
+                f"{row['route_class']}",
+                f"  n_generators          = {int(row['n_generators'])}",
+                f"  g_rel_release_share   = {float(row['g_rel_release_share']):.4f}",
+                f"  g_aniso_release_share = {float(row['g_aniso_release_share']):.4f}",
+                f"  g_flank_shuttle_share = {float(row['g_flank_shuttle_share']):.4f}",
+                f"  g_low_residency_share = {float(row['g_low_residency_share']):.4f}",
+                f"  g_off_persist_share   = {float(row['g_off_persist_share']):.4f}",
+                f"  g_post_persist_share  = {float(row['g_post_persist_share']):.4f}",
+                f"  g_reentry_share       = {float(row['g_reentry_share']):.4f}",
+                f"  g_core_behavior_share = {float(row['g_core_behavior_share']):.4f}",
+                f"  top_generator_1       = {row['top_generator_1']}",
+                f"  top_generator_2       = {row['top_generator_2']}",
+                f"  top_generator_3       = {row['top_generator_3']}",
+                f"  top_composition_1     = {row['top_composition_1']}",
+                f"  top_composition_2     = {row['top_composition_2']}",
+                f"  top_composition_3     = {row['top_composition_3']}",
+                "",
+            ]
+        )
+
+    lines.extend(
+        [
+            "Interpretive guide",
+            "- generators are compressed motif-types, not single steps",
+            "- compositions reveal family-specific concatenation laws",
+            "- this is the immediate precursor to a partial algebra / proto-groupoid framing",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def render_figure(family_summary: pd.DataFrame, outpath: Path) -> None:
+    fig = plt.figure(figsize=(16.5, 10), constrained_layout=True)
+    gs = fig.add_gridspec(2, 3, width_ratios=[1.15, 1.15, 1.0], height_ratios=[1.0, 1.0])
+
+    ax_release = fig.add_subplot(gs[0, 0])
+    ax_persist = fig.add_subplot(gs[0, 1])
+    ax_internal = fig.add_subplot(gs[0, 2])
+    ax_reentry = fig.add_subplot(gs[1, 0])
+    ax_top = fig.add_subplot(gs[1, 1])
+    ax_diag = fig.add_subplot(gs[1, 2])
+
+    colors = {
+        "branch_exit": "#1f77b4",
+        "stable_seam_corridor": "#2ca02c",
+        "reorganization_heavy": "#d62728",
+    }
+    x = np.arange(len(family_summary))
+    c = [colors[k] for k in family_summary["route_class"]]
+    width = 0.36
+
+    ax_release.bar(x - width / 2, family_summary["g_rel_release_share"], width, label="rel release")
+    ax_release.bar(x + width / 2, family_summary["g_aniso_release_share"], width, label="aniso release")
+    ax_release.set_xticks(x)
+    ax_release.set_xticklabels(family_summary["route_class"], rotation=12)
+    ax_release.set_title("Release generators", fontsize=14, pad=8)
+    ax_release.grid(alpha=0.15, axis="y")
+    ax_release.legend()
+
+    ax_persist.bar(x - width / 2, family_summary["g_off_persist_share"], width, label="off persist")
+    ax_persist.bar(x + width / 2, family_summary["g_post_persist_share"], width, label="post persist")
+    ax_persist.set_xticks(x)
+    ax_persist.set_xticklabels(family_summary["route_class"], rotation=12)
+    ax_persist.set_title("Persistence generators", fontsize=14, pad=8)
+    ax_persist.grid(alpha=0.15, axis="y")
+    ax_persist.legend()
+
+    ax_internal.bar(x - width / 2, family_summary["g_flank_shuttle_share"], width, label="flank shuttle")
+    ax_internal.bar(x + width / 2, family_summary["g_low_residency_share"], width, label="low residency")
+    ax_internal.set_xticks(x)
+    ax_internal.set_xticklabels(family_summary["route_class"], rotation=12)
+    ax_internal.set_title("Seam-internal generators", fontsize=14, pad=8)
+    ax_internal.grid(alpha=0.15, axis="y")
+    ax_internal.legend()
+
+    ax_reentry.bar(x - width / 2, family_summary["g_reentry_share"], width, label="reentry")
+    ax_reentry.bar(x + width / 2, family_summary["g_core_behavior_share"], width, label="core behavior")
+    ax_reentry.set_xticks(x)
+    ax_reentry.set_xticklabels(family_summary["route_class"], rotation=12)
+    ax_reentry.set_title("Reentry / core generators", fontsize=14, pad=8)
+    ax_reentry.grid(alpha=0.15, axis="y")
+    ax_reentry.legend()
+
+    ax_top.axis("off")
+    y = 0.95
+    for _, row in family_summary.iterrows():
+        ax_top.text(0.02, y, str(row["route_class"]), fontsize=12, fontweight="bold")
+        y -= 0.06
+        for i in range(1, 4):
+            ax_top.text(0.04, y, f"g{i}: {row[f'top_generator_{i}']}", fontsize=10, family="monospace")
+            y -= 0.045
+        for i in range(1, 3):
+            ax_top.text(0.04, y, f"c{i}: {row[f'top_composition_{i}']}", fontsize=10, family="monospace")
+            y -= 0.045
+        y -= 0.04
+    ax_top.set_title("Top generators / compositions", fontsize=14, pad=8)
+
+    ax_diag.axis("off")
+    best_post = family_summary.sort_values("g_post_persist_share", ascending=False).iloc[0]
+    best_shuttle = family_summary.sort_values("g_flank_shuttle_share", ascending=False).iloc[0]
+    best_re = family_summary.sort_values("g_reentry_share", ascending=False).iloc[0]
+    text = (
+        "OBS-030c diagnostics\n\n"
+        f"strongest post persistence:\n{best_post['route_class']} ({best_post['g_post_persist_share']:.3f})\n\n"
+        f"strongest flank shuttle:\n{best_shuttle['route_class']} ({best_shuttle['g_flank_shuttle_share']:.3f})\n\n"
+        f"strongest reentry:\n{best_re['route_class']} ({best_re['g_reentry_share']:.3f})\n\n"
+        "Meaning:\n"
+        "motif dynamics can now be\n"
+        "compressed into a small\n"
+        "generator set with family-\n"
+        "specific composition laws."
+    )
+    ax_diag.text(
+        0.02, 0.98, text,
+        va="top", ha="left", fontsize=10.2, family="monospace",
+        bbox=dict(boxstyle="round,pad=0.35", fc="white", ec="0.85", alpha=0.95),
+    )
+
+    fig.suptitle("PAM Observatory — OBS-030c motif generator algebra", fontsize=21)
+    fig.savefig(outpath, dpi=220)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compress seam motifs into a generator algebra.")
+    parser.add_argument("--motifs-csv", default=Config.motifs_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--top-k-generators", type=int, default=Config.top_k_generators)
+    parser.add_argument("--top-k-compositions", type=int, default=Config.top_k_compositions)
+    args = parser.parse_args()
+
+    cfg = Config(
+        motifs_csv=args.motifs_csv,
+        outdir=args.outdir,
+        top_k_generators=args.top_k_generators,
+        top_k_compositions=args.top_k_compositions,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    motifs = load_motifs(cfg.motifs_csv)
+    assignments = build_generator_assignments(motifs)
+    counts = build_generator_counts(assignments)
+    compositions = build_generator_compositions(assignments)
+    family_summary = build_family_summary(counts, compositions)
+
+    assign_csv = outdir / "motif_generator_assignments.csv"
+    counts_csv = outdir / "motif_generator_counts.csv"
+    comp_csv = outdir / "motif_generator_compositions.csv"
+    fam_csv = outdir / "motif_generator_family_summary.csv"
+    txt_path = outdir / "obs030c_motif_generator_algebra_summary.txt"
+    png_path = outdir / "obs030c_motif_generator_algebra_figure.png"
+
+    assignments.to_csv(assign_csv, index=False)
+    counts.to_csv(counts_csv, index=False)
+    compositions.to_csv(comp_csv, index=False)
+    family_summary.to_csv(fam_csv, index=False)
+    txt_path.write_text(build_summary(family_summary), encoding="utf-8")
+    render_figure(family_summary, png_path)
+
+    print(assign_csv)
+    print(counts_csv)
+    print(comp_csv)
+    print(fam_csv)
+    print(txt_path)
+    print(png_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/studies/obs030d_resolve_other_generators.py
+++ b/experiments/studies/obs030d_resolve_other_generators.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""
+OBS-030d — Resolve residual motif generators.
+
+Purpose
+-------
+Inspect the motifs currently assigned to g_other in OBS-030c and promote the
+dominant recurring reduced words into explicit generators.
+
+This is the final cleanup step before any proto-groupoid framing.
+
+Inputs
+------
+outputs/obs030c_motif_generator_algebra/motif_generator_assignments.csv
+
+Outputs
+-------
+outputs/obs030d_resolve_other_generators/
+  resolved_generator_assignments.csv
+  resolved_generator_counts.csv
+  resolved_generator_compositions.csv
+  resolved_generator_family_summary.csv
+  obs030d_resolve_other_generators_summary.txt
+  obs030d_resolve_other_generators_figure.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class Config:
+    assignments_csv: str = "outputs/obs030c_motif_generator_algebra/motif_generator_assignments.csv"
+    outdir: str = "outputs/obs030d_resolve_other_generators"
+    min_word_count: int = 3
+    top_k_words: int = 12
+
+
+CLASS_ORDER = [
+    "branch_exit",
+    "stable_seam_corridor",
+    "reorganization_heavy",
+]
+
+GENERATOR_ORDER = [
+    "g_rel_release",
+    "g_aniso_release",
+    "g_flank_shuttle",
+    "g_low_residency",
+    "g_off_persist",
+    "g_post_persist",
+    "g_reentry",
+    "g_core_behavior",
+    "g_off_to_post",
+    "g_flank_to_off",
+    "g_low_to_off",
+    "g_off_to_flank_edge",
+    "g_post_to_off",
+    "g_other",
+]
+
+
+def load_assignments(path: str | Path) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    for col in df.columns:
+        if col not in {
+            "path_id", "path_family", "route_class", "motif", "motif_class",
+            "state_a", "state_b", "state_c", "state_a_red", "state_b_red",
+            "state_c_red", "generator", "generator_word"
+        }:
+            try:
+                df[col] = pd.to_numeric(df[col], errors="coerce")
+            except Exception:
+                pass
+    return df
+
+
+def resolve_other(word: str, current: str) -> str:
+    if current != "g_other":
+        return current
+
+    # explicit residual patterns
+    if word == "O~O~P":
+        return "g_off_to_post"
+    if word == "R~A~O" or word == "A~R~O" or word == "A~A~O" or word == "R~R~O":
+        return "g_flank_to_off"
+    if word == "L~L~O" or word == "L~O~O":
+        return "g_low_to_off"
+    if word == "O~R~R" or word == "O~A~A" or word == "O~R~A" or word == "O~A~R":
+        return "g_off_to_flank_edge"
+    if word == "P~O~O" or word == "P~O~P":
+        return "g_post_to_off"
+
+    return "g_other"
+
+
+def build_word_table(assignments: pd.DataFrame) -> pd.DataFrame:
+    other = assignments[assignments["generator"] == "g_other"].copy()
+    if len(other) == 0:
+        return pd.DataFrame(columns=["route_class", "generator_word", "n_words", "n_paths", "word_share"])
+
+    out = (
+        other.groupby(["route_class", "generator_word"], as_index=False)
+        .agg(
+            n_words=("path_id", "size"),
+            n_paths=("path_id", "nunique"),
+        )
+    )
+    total = out.groupby("route_class")["n_words"].transform("sum")
+    out["word_share"] = out["n_words"] / total.clip(lower=1)
+    return out.sort_values(["route_class", "n_words"], ascending=[True, False]).reset_index(drop=True)
+
+
+def build_resolved_assignments(assignments: pd.DataFrame) -> pd.DataFrame:
+    out = assignments.copy()
+    out["generator_resolved"] = [
+        resolve_other(word, gen)
+        for word, gen in zip(out["generator_word"], out["generator"])
+    ]
+    return out
+
+
+def build_generator_counts(assignments: pd.DataFrame) -> pd.DataFrame:
+    counts = (
+        assignments.groupby(["route_class", "generator_resolved"], as_index=False)
+        .agg(
+            n_motifs=("path_id", "size"),
+            n_paths=("path_id", "nunique"),
+        )
+    )
+    total = counts.groupby("route_class")["n_motifs"].transform("sum")
+    counts["generator_share"] = counts["n_motifs"] / total.clip(lower=1)
+
+    order = {g: i for i, g in enumerate(GENERATOR_ORDER)}
+    counts["g_order"] = counts["generator_resolved"].map(lambda x: order.get(x, 999))
+    return counts.sort_values(["route_class", "g_order"]).drop(columns=["g_order"]).reset_index(drop=True)
+
+
+def build_generator_compositions(assignments: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+
+    for path_id, grp in assignments.groupby("path_id", sort=False):
+        grp = grp.sort_values("step").copy().reset_index(drop=True)
+        if len(grp) < 2:
+            continue
+
+        for i in range(len(grp) - 1):
+            a = grp.iloc[i]
+            b = grp.iloc[i + 1]
+            rows.append(
+                {
+                    "path_id": path_id,
+                    "route_class": a["route_class"],
+                    "generator_1": a["generator_resolved"],
+                    "generator_2": b["generator_resolved"],
+                    "composition": f"{a['generator_resolved']} ; {b['generator_resolved']}",
+                }
+            )
+
+    comp = pd.DataFrame(rows)
+    if len(comp) == 0:
+        return pd.DataFrame(columns=["route_class", "generator_1", "generator_2", "composition", "n_compositions", "n_paths", "composition_share"])
+
+    out = (
+        comp.groupby(["route_class", "generator_1", "generator_2", "composition"], as_index=False)
+        .agg(
+            n_compositions=("path_id", "size"),
+            n_paths=("path_id", "nunique"),
+        )
+    )
+    total = out.groupby("route_class")["n_compositions"].transform("sum")
+    out["composition_share"] = out["n_compositions"] / total.clip(lower=1)
+    return out.sort_values(["route_class", "n_compositions"], ascending=[True, False]).reset_index(drop=True)
+
+
+def build_family_summary(counts: pd.DataFrame, comps: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+
+    for cls in CLASS_ORDER:
+        sub = counts[counts["route_class"] == cls].copy()
+        comp = comps[comps["route_class"] == cls].copy()
+
+        row = {"route_class": cls, "n_generators": int(sub["n_motifs"].sum()) if len(sub) else 0}
+        for g in GENERATOR_ORDER:
+            hit = sub[sub["generator_resolved"] == g]
+            row[f"{g}_share"] = float(hit["generator_share"].sum()) if len(hit) else 0.0
+
+        topg = sub.sort_values("n_motifs", ascending=False).head(5) if len(sub) else pd.DataFrame()
+        for i in range(5):
+            row[f"top_generator_{i+1}"] = topg.iloc[i]["generator_resolved"] if len(topg) > i else np.nan
+
+        topc = comp.sort_values("n_compositions", ascending=False).head(5) if len(comp) else pd.DataFrame()
+        for i in range(5):
+            row[f"top_composition_{i+1}"] = topc.iloc[i]["composition"] if len(topc) > i else np.nan
+
+        rows.append(row)
+
+    out = pd.DataFrame(rows)
+    order = {k: i for i, k in enumerate(CLASS_ORDER)}
+    out["order"] = out["route_class"].map(lambda x: order.get(x, 999))
+    return out.sort_values("order").drop(columns=["order"]).reset_index(drop=True)
+
+
+def build_summary(word_table: pd.DataFrame, family_summary: pd.DataFrame) -> str:
+    lines = [
+        "=== OBS-030d Resolve Other Generators Summary ===",
+        "",
+        "Residual resolution policy",
+        "- O~O~P -> g_off_to_post",
+        "- flank~flank/off patterns -> g_flank_to_off",
+        "- L~L~O or L~O~O -> g_low_to_off",
+        "- O~flank patterns -> g_off_to_flank_edge",
+        "- P~O~* patterns -> g_post_to_off",
+        "",
+        "Top residual words before resolution",
+    ]
+
+    for cls in CLASS_ORDER:
+        sub = word_table[word_table["route_class"] == cls].head(5)
+        lines.append(f"  {cls}")
+        if len(sub) == 0:
+            lines.append("    none")
+        else:
+            for _, row in sub.iterrows():
+                lines.append(
+                    f"    {row['generator_word']}: n={int(row['n_words'])}, share={float(row['word_share']):.4f}"
+                )
+
+    lines.extend(["", "Resolved family signatures"])
+    for _, row in family_summary.iterrows():
+        lines.extend(
+            [
+                f"{row['route_class']}",
+                f"  g_rel_release_share     = {float(row['g_rel_release_share']):.4f}",
+                f"  g_flank_shuttle_share   = {float(row['g_flank_shuttle_share']):.4f}",
+                f"  g_off_persist_share     = {float(row['g_off_persist_share']):.4f}",
+                f"  g_post_persist_share    = {float(row['g_post_persist_share']):.4f}",
+                f"  g_reentry_share         = {float(row['g_reentry_share']):.4f}",
+                f"  g_off_to_post_share     = {float(row['g_off_to_post_share']):.4f}",
+                f"  g_flank_to_off_share    = {float(row['g_flank_to_off_share']):.4f}",
+                f"  g_low_to_off_share      = {float(row['g_low_to_off_share']):.4f}",
+                f"  g_off_to_flank_edge_share = {float(row['g_off_to_flank_edge_share']):.4f}",
+                f"  g_post_to_off_share     = {float(row['g_post_to_off_share']):.4f}",
+                f"  g_other_share           = {float(row['g_other_share']):.4f}",
+                f"  top_generator_1         = {row['top_generator_1']}",
+                f"  top_generator_2         = {row['top_generator_2']}",
+                f"  top_generator_3         = {row['top_generator_3']}",
+                f"  top_composition_1       = {row['top_composition_1']}",
+                f"  top_composition_2       = {row['top_composition_2']}",
+                "",
+            ]
+        )
+
+    lines.extend(
+        [
+            "Interpretive guide",
+            "- this step is successful if g_other is no longer dominant",
+            "- named generators should capture the leading family signatures and compositions",
+            "- once residual mass is small, the generator algebra is stable enough for proto-groupoid framing",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def render_figure(family_summary: pd.DataFrame, outpath: Path) -> None:
+    fig = plt.figure(figsize=(16.5, 10), constrained_layout=True)
+    gs = fig.add_gridspec(2, 3, width_ratios=[1.15, 1.15, 1.0], height_ratios=[1.0, 1.0])
+
+    ax_new = fig.add_subplot(gs[0, 0])
+    ax_persist = fig.add_subplot(gs[0, 1])
+    ax_internal = fig.add_subplot(gs[0, 2])
+    ax_other = fig.add_subplot(gs[1, 0])
+    ax_top = fig.add_subplot(gs[1, 1])
+    ax_diag = fig.add_subplot(gs[1, 2])
+
+    x = np.arange(len(family_summary))
+    width = 0.24
+
+    ax_new.bar(x - width, family_summary["g_off_to_post_share"], width, label="off→post")
+    ax_new.bar(x, family_summary["g_flank_to_off_share"], width, label="flank→off")
+    ax_new.bar(x + width, family_summary["g_low_to_off_share"], width, label="low→off")
+    ax_new.set_xticks(x)
+    ax_new.set_xticklabels(family_summary["route_class"], rotation=12)
+    ax_new.set_title("Resolved residual generators", fontsize=14, pad=8)
+    ax_new.grid(alpha=0.15, axis="y")
+    ax_new.legend()
+
+    ax_persist.bar(x - width / 2, family_summary["g_off_persist_share"], width, label="off persist")
+    ax_persist.bar(x + width / 2, family_summary["g_post_persist_share"], width, label="post persist")
+    ax_persist.set_xticks(x)
+    ax_persist.set_xticklabels(family_summary["route_class"], rotation=12)
+    ax_persist.set_title("Persistence generators", fontsize=14, pad=8)
+    ax_persist.grid(alpha=0.15, axis="y")
+    ax_persist.legend()
+
+    ax_internal.bar(x - width / 2, family_summary["g_flank_shuttle_share"], width, label="flank shuttle")
+    ax_internal.bar(x + width / 2, family_summary["g_reentry_share"], width, label="reentry")
+    ax_internal.set_xticks(x)
+    ax_internal.set_xticklabels(family_summary["route_class"], rotation=12)
+    ax_internal.set_title("Seam-edge generators", fontsize=14, pad=8)
+    ax_internal.grid(alpha=0.15, axis="y")
+    ax_internal.legend()
+
+    ax_other.bar(x, family_summary["g_other_share"])
+    ax_other.set_xticks(x)
+    ax_other.set_xticklabels(family_summary["route_class"], rotation=12)
+    ax_other.set_title("Residual g_other share", fontsize=14, pad=8)
+    ax_other.grid(alpha=0.15, axis="y")
+
+    ax_top.axis("off")
+    y = 0.95
+    for _, row in family_summary.iterrows():
+        ax_top.text(0.02, y, str(row["route_class"]), fontsize=12, fontweight="bold")
+        y -= 0.06
+        for i in range(1, 4):
+            ax_top.text(0.04, y, f"g{i}: {row[f'top_generator_{i}']}", fontsize=10, family="monospace")
+            y -= 0.045
+        for i in range(1, 3):
+            ax_top.text(0.04, y, f"c{i}: {row[f'top_composition_{i}']}", fontsize=10, family="monospace")
+            y -= 0.045
+        y -= 0.04
+    ax_top.set_title("Top resolved generators / compositions", fontsize=14, pad=8)
+
+    ax_diag.axis("off")
+    worst = family_summary.sort_values("g_other_share", ascending=False).iloc[0]
+    best_post = family_summary.sort_values("g_post_persist_share", ascending=False).iloc[0]
+    best_shuttle = family_summary.sort_values("g_flank_shuttle_share", ascending=False).iloc[0]
+    text = (
+        "OBS-030d diagnostics\n\n"
+        f"largest residual g_other:\n{worst['route_class']} ({worst['g_other_share']:.3f})\n\n"
+        f"strongest post persistence:\n{best_post['route_class']} ({best_post['g_post_persist_share']:.3f})\n\n"
+        f"strongest flank shuttle:\n{best_shuttle['route_class']} ({best_shuttle['g_flank_shuttle_share']:.3f})\n\n"
+        "Success criterion:\n"
+        "g_other is no longer\n"
+        "dominant, so the named\n"
+        "generator set can support\n"
+        "a proto-groupoid step."
+    )
+    ax_diag.text(
+        0.02, 0.98, text,
+        va="top", ha="left", fontsize=10.2, family="monospace",
+        bbox=dict(boxstyle="round,pad=0.35", fc="white", ec="0.85", alpha=0.95),
+    )
+
+    fig.suptitle("PAM Observatory — OBS-030d resolve other generators", fontsize=21)
+    fig.savefig(outpath, dpi=220)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Resolve residual motif generators into named generators.")
+    parser.add_argument("--assignments-csv", default=Config.assignments_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--min-word-count", type=int, default=Config.min_word_count)
+    parser.add_argument("--top-k-words", type=int, default=Config.top_k_words)
+    args = parser.parse_args()
+
+    cfg = Config(
+        assignments_csv=args.assignments_csv,
+        outdir=args.outdir,
+        min_word_count=args.min_word_count,
+        top_k_words=args.top_k_words,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    assignments = load_assignments(cfg.assignments_csv)
+    word_table = build_word_table(assignments)
+    resolved = build_resolved_assignments(assignments)
+    counts = build_generator_counts(resolved)
+    comps = build_generator_compositions(resolved)
+    family_summary = build_family_summary(counts, comps)
+
+    resolved_csv = outdir / "resolved_generator_assignments.csv"
+    counts_csv = outdir / "resolved_generator_counts.csv"
+    comps_csv = outdir / "resolved_generator_compositions.csv"
+    fam_csv = outdir / "resolved_generator_family_summary.csv"
+    txt_path = outdir / "obs030d_resolve_other_generators_summary.txt"
+    png_path = outdir / "obs030d_resolve_other_generators_figure.png"
+
+    resolved.to_csv(resolved_csv, index=False)
+    counts.to_csv(counts_csv, index=False)
+    comps.to_csv(comps_csv, index=False)
+    family_summary.to_csv(fam_csv, index=False)
+    txt_path.write_text(build_summary(word_table, family_summary), encoding="utf-8")
+    render_figure(family_summary, png_path)
+
+    print(resolved_csv)
+    print(counts_csv)
+    print(comps_csv)
+    print(fam_csv)
+    print(txt_path)
+    print(png_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/studies/obs030e_complete_generator_basis.py
+++ b/experiments/studies/obs030e_complete_generator_basis.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""
+OBS-030e — Complete generator basis.
+
+Final cleanup pass on the motif generator algebra before any proto-groupoid step.
+
+Goal
+----
+Resolve the remaining dominant `g_other` mass in OBS-030d by promoting a small
+set of seam-edge / bridge generators:
+
+- g_low_flank_shuttle
+- g_off_to_edge
+- g_edge_to_post
+
+This should reduce the residual bucket enough that:
+- family signatures are mostly expressible in named generators
+- top compositions are mostly between named generators
+- the algebra is stable enough for a proto-groupoid framing
+
+Inputs
+------
+outputs/obs030d_resolve_other_generators/resolved_generator_assignments.csv
+
+Outputs
+-------
+outputs/obs030e_complete_generator_basis/
+  completed_generator_assignments.csv
+  completed_generator_counts.csv
+  completed_generator_compositions.csv
+  completed_generator_family_summary.csv
+  obs030e_complete_generator_basis_summary.txt
+  obs030e_complete_generator_basis_figure.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class Config:
+    assignments_csv: str = "outputs/obs030d_resolve_other_generators/resolved_generator_assignments.csv"
+    outdir: str = "outputs/obs030e_complete_generator_basis"
+    top_k_words: int = 12
+
+
+CLASS_ORDER = [
+    "branch_exit",
+    "stable_seam_corridor",
+    "reorganization_heavy",
+]
+
+GENERATOR_ORDER = [
+    "g_rel_release",
+    "g_aniso_release",
+    "g_flank_shuttle",
+    "g_low_flank_shuttle",
+    "g_low_residency",
+    "g_off_persist",
+    "g_post_persist",
+    "g_reentry",
+    "g_core_behavior",
+    "g_off_to_post",
+    "g_flank_to_off",
+    "g_low_to_off",
+    "g_off_to_edge",
+    "g_edge_to_post",
+    "g_post_to_off",
+    "g_other",
+]
+
+
+def load_assignments(path: str | Path) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    for col in df.columns:
+        if col not in {
+            "path_id", "path_family", "route_class", "motif", "motif_class",
+            "state_a", "state_b", "state_c", "state_a_red", "state_b_red",
+            "state_c_red", "generator", "generator_word", "generator_resolved"
+        }:
+            try:
+                df[col] = pd.to_numeric(df[col], errors="coerce")
+            except Exception:
+                pass
+    return df
+
+
+def finalize_generator(word: str, current: str) -> str:
+    if current != "g_other":
+        return current
+
+    # New seam-edge / bridge generators
+    if word in {"L~L~R", "L~R~L", "R~L~L", "L~L~A", "L~A~L", "A~L~L"}:
+        return "g_low_flank_shuttle"
+
+    if word in {"O~O~R", "O~O~A", "O~O~L"}:
+        return "g_off_to_edge"
+
+    if word in {"O~P~P", "L~L~P", "L~P~P", "R~P~P", "A~P~P"}:
+        return "g_edge_to_post"
+
+    return "g_other"
+
+
+def build_word_table(assignments: pd.DataFrame) -> pd.DataFrame:
+    gen_col = "generator_resolved" if "generator_resolved" in assignments.columns else "generator"
+    other = assignments[assignments[gen_col] == "g_other"].copy()
+    if len(other) == 0:
+        return pd.DataFrame(columns=["route_class", "generator_word", "n_words", "n_paths", "word_share"])
+
+    out = (
+        other.groupby(["route_class", "generator_word"], as_index=False)
+        .agg(
+            n_words=("path_id", "size"),
+            n_paths=("path_id", "nunique"),
+        )
+    )
+    total = out.groupby("route_class")["n_words"].transform("sum")
+    out["word_share"] = out["n_words"] / total.clip(lower=1)
+    return out.sort_values(["route_class", "n_words"], ascending=[True, False]).reset_index(drop=True)
+
+
+def build_completed_assignments(assignments: pd.DataFrame) -> pd.DataFrame:
+    source_col = "generator_resolved" if "generator_resolved" in assignments.columns else "generator"
+    out = assignments.copy()
+    out["generator_completed"] = [
+        finalize_generator(word, gen)
+        for word, gen in zip(out["generator_word"], out[source_col])
+    ]
+    return out
+
+
+def build_generator_counts(assignments: pd.DataFrame) -> pd.DataFrame:
+    counts = (
+        assignments.groupby(["route_class", "generator_completed"], as_index=False)
+        .agg(
+            n_motifs=("path_id", "size"),
+            n_paths=("path_id", "nunique"),
+        )
+    )
+    total = counts.groupby("route_class")["n_motifs"].transform("sum")
+    counts["generator_share"] = counts["n_motifs"] / total.clip(lower=1)
+
+    order = {g: i for i, g in enumerate(GENERATOR_ORDER)}
+    counts["g_order"] = counts["generator_completed"].map(lambda x: order.get(x, 999))
+    return counts.sort_values(["route_class", "g_order"]).drop(columns=["g_order"]).reset_index(drop=True)
+
+
+def build_generator_compositions(assignments: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+
+    for path_id, grp in assignments.groupby("path_id", sort=False):
+        grp = grp.sort_values("step").copy().reset_index(drop=True)
+        if len(grp) < 2:
+            continue
+
+        for i in range(len(grp) - 1):
+            a = grp.iloc[i]
+            b = grp.iloc[i + 1]
+            rows.append(
+                {
+                    "path_id": path_id,
+                    "route_class": a["route_class"],
+                    "generator_1": a["generator_completed"],
+                    "generator_2": b["generator_completed"],
+                    "composition": f"{a['generator_completed']} ; {b['generator_completed']}",
+                }
+            )
+
+    comp = pd.DataFrame(rows)
+    if len(comp) == 0:
+        return pd.DataFrame(columns=["route_class", "generator_1", "generator_2", "composition", "n_compositions", "n_paths", "composition_share"])
+
+    out = (
+        comp.groupby(["route_class", "generator_1", "generator_2", "composition"], as_index=False)
+        .agg(
+            n_compositions=("path_id", "size"),
+            n_paths=("path_id", "nunique"),
+        )
+    )
+    total = out.groupby("route_class")["n_compositions"].transform("sum")
+    out["composition_share"] = out["n_compositions"] / total.clip(lower=1)
+    return out.sort_values(["route_class", "n_compositions"], ascending=[True, False]).reset_index(drop=True)
+
+
+def build_family_summary(counts: pd.DataFrame, comps: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+
+    for cls in CLASS_ORDER:
+        sub = counts[counts["route_class"] == cls].copy()
+        comp = comps[comps["route_class"] == cls].copy()
+
+        row = {"route_class": cls, "n_generators": int(sub["n_motifs"].sum()) if len(sub) else 0}
+        for g in GENERATOR_ORDER:
+            hit = sub[sub["generator_completed"] == g]
+            row[f"{g}_share"] = float(hit["generator_share"].sum()) if len(hit) else 0.0
+
+        topg = sub.sort_values("n_motifs", ascending=False).head(5) if len(sub) else pd.DataFrame()
+        for i in range(5):
+            row[f"top_generator_{i+1}"] = topg.iloc[i]["generator_completed"] if len(topg) > i else np.nan
+
+        topc = comp.sort_values("n_compositions", ascending=False).head(5) if len(comp) else pd.DataFrame()
+        for i in range(5):
+            row[f"top_composition_{i+1}"] = topc.iloc[i]["composition"] if len(topc) > i else np.nan
+
+        rows.append(row)
+
+    out = pd.DataFrame(rows)
+    order = {k: i for i, k in enumerate(CLASS_ORDER)}
+    out["order"] = out["route_class"].map(lambda x: order.get(x, 999))
+    return out.sort_values("order").drop(columns=["order"]).reset_index(drop=True)
+
+
+def build_summary(word_table: pd.DataFrame, family_summary: pd.DataFrame) -> str:
+    lines = [
+        "=== OBS-030e Complete Generator Basis Summary ===",
+        "",
+        "Final completion policy",
+        "- L~L~R / L~R~L / R~L~L (+ A variants) -> g_low_flank_shuttle",
+        "- O~O~R / O~O~A / O~O~L -> g_off_to_edge",
+        "- O~P~P / L~L~P / *~P~P edge patterns -> g_edge_to_post",
+        "",
+        "Top residual words before final completion",
+    ]
+
+    for cls in CLASS_ORDER:
+        sub = word_table[word_table["route_class"] == cls].head(5)
+        lines.append(f"  {cls}")
+        if len(sub) == 0:
+            lines.append("    none")
+        else:
+            for _, row in sub.iterrows():
+                lines.append(
+                    f"    {row['generator_word']}: n={int(row['n_words'])}, share={float(row['word_share']):.4f}"
+                )
+
+    lines.extend(["", "Completed family signatures"])
+    for _, row in family_summary.iterrows():
+        lines.extend(
+            [
+                f"{row['route_class']}",
+                f"  g_rel_release_share        = {float(row['g_rel_release_share']):.4f}",
+                f"  g_flank_shuttle_share      = {float(row['g_flank_shuttle_share']):.4f}",
+                f"  g_low_flank_shuttle_share  = {float(row['g_low_flank_shuttle_share']):.4f}",
+                f"  g_off_persist_share        = {float(row['g_off_persist_share']):.4f}",
+                f"  g_post_persist_share       = {float(row['g_post_persist_share']):.4f}",
+                f"  g_reentry_share            = {float(row['g_reentry_share']):.4f}",
+                f"  g_off_to_post_share        = {float(row['g_off_to_post_share']):.4f}",
+                f"  g_flank_to_off_share       = {float(row['g_flank_to_off_share']):.4f}",
+                f"  g_low_to_off_share         = {float(row['g_low_to_off_share']):.4f}",
+                f"  g_off_to_edge_share        = {float(row['g_off_to_edge_share']):.4f}",
+                f"  g_edge_to_post_share       = {float(row['g_edge_to_post_share']):.4f}",
+                f"  g_post_to_off_share        = {float(row['g_post_to_off_share']):.4f}",
+                f"  g_other_share              = {float(row['g_other_share']):.4f}",
+                f"  top_generator_1            = {row['top_generator_1']}",
+                f"  top_generator_2            = {row['top_generator_2']}",
+                f"  top_generator_3            = {row['top_generator_3']}",
+                f"  top_composition_1          = {row['top_composition_1']}",
+                f"  top_composition_2          = {row['top_composition_2']}",
+                "",
+            ]
+        )
+
+    lines.extend(
+        [
+            "Interpretive guide",
+            "- this step succeeds if g_other is no longer dominant",
+            "- family signatures should now be carried by named generators",
+            "- once residual mass is small, the generator algebra is stable enough for proto-groupoid framing",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def render_figure(family_summary: pd.DataFrame, outpath: Path) -> None:
+    fig = plt.figure(figsize=(16.5, 10), constrained_layout=True)
+    gs = fig.add_gridspec(2, 3, width_ratios=[1.15, 1.15, 1.0], height_ratios=[1.0, 1.0])
+
+    ax_complete = fig.add_subplot(gs[0, 0])
+    ax_persist = fig.add_subplot(gs[0, 1])
+    ax_edge = fig.add_subplot(gs[0, 2])
+    ax_other = fig.add_subplot(gs[1, 0])
+    ax_top = fig.add_subplot(gs[1, 1])
+    ax_diag = fig.add_subplot(gs[1, 2])
+
+    x = np.arange(len(family_summary))
+    width = 0.24
+
+    ax_complete.bar(x - width, family_summary["g_low_flank_shuttle_share"], width, label="low↔flank")
+    ax_complete.bar(x, family_summary["g_off_to_edge_share"], width, label="off→edge")
+    ax_complete.bar(x + width, family_summary["g_edge_to_post_share"], width, label="edge→post")
+    ax_complete.set_xticks(x)
+    ax_complete.set_xticklabels(family_summary["route_class"], rotation=12)
+    ax_complete.set_title("Final completed generators", fontsize=14, pad=8)
+    ax_complete.grid(alpha=0.15, axis="y")
+    ax_complete.legend()
+
+    ax_persist.bar(x - width / 2, family_summary["g_off_persist_share"], width, label="off persist")
+    ax_persist.bar(x + width / 2, family_summary["g_post_persist_share"], width, label="post persist")
+    ax_persist.set_xticks(x)
+    ax_persist.set_xticklabels(family_summary["route_class"], rotation=12)
+    ax_persist.set_title("Persistence generators", fontsize=14, pad=8)
+    ax_persist.grid(alpha=0.15, axis="y")
+    ax_persist.legend()
+
+    ax_edge.bar(x - width / 2, family_summary["g_flank_shuttle_share"], width, label="flank shuttle")
+    ax_edge.bar(x + width / 2, family_summary["g_reentry_share"], width, label="reentry")
+    ax_edge.set_xticks(x)
+    ax_edge.set_xticklabels(family_summary["route_class"], rotation=12)
+    ax_edge.set_title("Seam-edge generators", fontsize=14, pad=8)
+    ax_edge.grid(alpha=0.15, axis="y")
+    ax_edge.legend()
+
+    ax_other.bar(x, family_summary["g_other_share"])
+    ax_other.set_xticks(x)
+    ax_other.set_xticklabels(family_summary["route_class"], rotation=12)
+    ax_other.set_title("Residual g_other share", fontsize=14, pad=8)
+    ax_other.grid(alpha=0.15, axis="y")
+
+    ax_top.axis("off")
+    y = 0.95
+    for _, row in family_summary.iterrows():
+        ax_top.text(0.02, y, str(row["route_class"]), fontsize=12, fontweight="bold")
+        y -= 0.06
+        for i in range(1, 4):
+            ax_top.text(0.04, y, f"g{i}: {row[f'top_generator_{i}']}", fontsize=10, family="monospace")
+            y -= 0.045
+        for i in range(1, 3):
+            ax_top.text(0.04, y, f"c{i}: {row[f'top_composition_{i}']}", fontsize=10, family="monospace")
+            y -= 0.045
+        y -= 0.04
+    ax_top.set_title("Top completed generators / compositions", fontsize=14, pad=8)
+
+    ax_diag.axis("off")
+    worst = family_summary.sort_values("g_other_share", ascending=False).iloc[0]
+    best_post = family_summary.sort_values("g_post_persist_share", ascending=False).iloc[0]
+    best_shuttle = family_summary.sort_values("g_flank_shuttle_share", ascending=False).iloc[0]
+    text = (
+        "OBS-030e diagnostics\n\n"
+        f"largest residual g_other:\n{worst['route_class']} ({worst['g_other_share']:.3f})\n\n"
+        f"strongest post persistence:\n{best_post['route_class']} ({best_post['g_post_persist_share']:.3f})\n\n"
+        f"strongest flank shuttle:\n{best_shuttle['route_class']} ({best_shuttle['g_flank_shuttle_share']:.3f})\n\n"
+        "Success criterion:\n"
+        "g_other is no longer\n"
+        "dominant, so the named\n"
+        "generator set can support\n"
+        "a proto-groupoid step."
+    )
+    ax_diag.text(
+        0.02, 0.98, text,
+        va="top", ha="left", fontsize=10.2, family="monospace",
+        bbox=dict(boxstyle="round,pad=0.35", fc="white", ec="0.85", alpha=0.95),
+    )
+
+    fig.suptitle("PAM Observatory — OBS-030e complete generator basis", fontsize=21)
+    fig.savefig(outpath, dpi=220)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Complete the seam motif generator basis.")
+    parser.add_argument("--assignments-csv", default=Config.assignments_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--top-k-words", type=int, default=Config.top_k_words)
+    args = parser.parse_args()
+
+    cfg = Config(
+        assignments_csv=args.assignments_csv,
+        outdir=args.outdir,
+        top_k_words=args.top_k_words,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    assignments = load_assignments(cfg.assignments_csv)
+    word_table = build_word_table(assignments)
+    completed = build_completed_assignments(assignments)
+    counts = build_generator_counts(completed)
+    comps = build_generator_compositions(completed)
+    family_summary = build_family_summary(counts, comps)
+
+    assign_csv = outdir / "completed_generator_assignments.csv"
+    counts_csv = outdir / "completed_generator_counts.csv"
+    comps_csv = outdir / "completed_generator_compositions.csv"
+    fam_csv = outdir / "completed_generator_family_summary.csv"
+    txt_path = outdir / "obs030e_complete_generator_basis_summary.txt"
+    png_path = outdir / "obs030e_complete_generator_basis_figure.png"
+
+    completed.to_csv(assign_csv, index=False)
+    counts.to_csv(counts_csv, index=False)
+    comps.to_csv(comps_csv, index=False)
+    family_summary.to_csv(fam_csv, index=False)
+    txt_path.write_text(build_summary(word_table, family_summary), encoding="utf-8")
+    render_figure(family_summary, png_path)
+
+    print(assign_csv)
+    print(counts_csv)
+    print(comps_csv)
+    print(fam_csv)
+    print(txt_path)
+    print(png_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/studies/obs031_proto_groupoid_of_seam_dynamics.py
+++ b/experiments/studies/obs031_proto_groupoid_of_seam_dynamics.py
@@ -1,0 +1,584 @@
+#!/usr/bin/env python3
+"""
+OBS-031 — Proto-groupoid of seam dynamics.
+
+Purpose
+-------
+Lift the cleaned generator algebra from OBS-030e into an explicit empirical
+proto-groupoid / partial composition system.
+
+This is intentionally disciplined:
+- not a formal theorem
+- not a claim of full invertibility
+- not a maximal abstract construction
+
+Instead, this study builds a compact algebraic object from the observed seam
+dynamics:
+
+1. objects = reduced seam states
+2. arrows = named empirical generators
+3. source/target typing for each generator
+4. observed partial compositions between generators
+5. family-specific proto-groupoid signatures / subalgebras
+
+Inputs
+------
+outputs/obs030e_complete_generator_basis/completed_generator_assignments.csv
+outputs/obs030e_complete_generator_basis/completed_generator_compositions.csv
+
+Outputs
+-------
+outputs/obs031_proto_groupoid_of_seam_dynamics/
+  proto_groupoid_generators.csv
+  proto_groupoid_compositions.csv
+  proto_groupoid_family_summary.csv
+  proto_groupoid_objects.csv
+  obs031_proto_groupoid_of_seam_dynamics_summary.txt
+  obs031_proto_groupoid_of_seam_dynamics_figure.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class Config:
+    assignments_csv: str = (
+        "outputs/obs030e_complete_generator_basis/completed_generator_assignments.csv"
+    )
+    compositions_csv: str = (
+        "outputs/obs030e_complete_generator_basis/completed_generator_compositions.csv"
+    )
+    outdir: str = "outputs/obs031_proto_groupoid_of_seam_dynamics"
+    min_generator_share: float = 0.02
+    min_composition_share: float = 0.02
+    top_k_compositions: int = 12
+
+
+CLASS_ORDER = [
+    "branch_exit",
+    "stable_seam_corridor",
+    "reorganization_heavy",
+]
+
+OBJECT_ORDER = ["R", "A", "L", "O", "P", "C"]
+
+GENERATOR_ORDER = [
+    "g_rel_release",
+    "g_aniso_release",
+    "g_flank_shuttle",
+    "g_low_flank_shuttle",
+    "g_low_residency",
+    "g_off_persist",
+    "g_post_persist",
+    "g_reentry",
+    "g_core_behavior",
+    "g_off_to_post",
+    "g_flank_to_off",
+    "g_low_to_off",
+    "g_off_to_edge",
+    "g_edge_to_post",
+    "g_post_to_off",
+    "g_other",
+]
+
+
+def load_csv(path: str | Path) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    for col in df.columns:
+        if col not in {
+            "path_id",
+            "path_family",
+            "route_class",
+            "motif",
+            "motif_class",
+            "state_a",
+            "state_b",
+            "state_c",
+            "state_a_red",
+            "state_b_red",
+            "state_c_red",
+            "generator",
+            "generator_word",
+            "generator_resolved",
+            "generator_completed",
+            "generator_1",
+            "generator_2",
+            "composition",
+        }:
+            try:
+                df[col] = pd.to_numeric(df[col], errors="coerce")
+            except Exception:
+                pass
+    return df
+
+
+def source_target_from_row(row: pd.Series) -> tuple[str, str]:
+    src = str(row["state_a_red"])
+    tgt = str(row["state_c_red"])
+    return src, tgt
+
+
+def build_objects(assignments: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+    for obj in OBJECT_ORDER:
+        n_as_source = int((assignments["state_a_red"] == obj).sum())
+        n_as_middle = int((assignments["state_b_red"] == obj).sum())
+        n_as_target = int((assignments["state_c_red"] == obj).sum())
+        rows.append(
+            {
+                "object": obj,
+                "n_as_source": n_as_source,
+                "n_as_middle": n_as_middle,
+                "n_as_target": n_as_target,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def build_generators(assignments: pd.DataFrame, cfg: Config) -> pd.DataFrame:
+    work = assignments.copy()
+
+    st = work.apply(source_target_from_row, axis=1)
+    work["source_object"] = [x[0] for x in st]
+    work["target_object"] = [x[1] for x in st]
+
+    out = (
+        work.groupby(["route_class", "generator_completed", "source_object", "target_object"], as_index=False)
+        .agg(
+            n_instances=("path_id", "size"),
+            n_paths=("path_id", "nunique"),
+        )
+    )
+
+    total = out.groupby("route_class")["n_instances"].transform("sum")
+    out["generator_share"] = out["n_instances"] / total.clip(lower=1)
+
+    # overall aggregation too
+    overall = (
+        work.groupby(["generator_completed", "source_object", "target_object"], as_index=False)
+        .agg(
+            n_instances=("path_id", "size"),
+            n_paths=("path_id", "nunique"),
+        )
+    )
+    overall["route_class"] = "overall"
+    total_overall = float(overall["n_instances"].sum())
+    overall["generator_share"] = overall["n_instances"] / max(total_overall, 1.0)
+
+    out = pd.concat([out, overall], ignore_index=True)
+
+    order_map = {g: i for i, g in enumerate(GENERATOR_ORDER)}
+    obj_map = {o: i for i, o in enumerate(OBJECT_ORDER)}
+    out["g_order"] = out["generator_completed"].map(lambda x: order_map.get(x, 999))
+    out["s_order"] = out["source_object"].map(lambda x: obj_map.get(x, 999))
+    out["t_order"] = out["target_object"].map(lambda x: obj_map.get(x, 999))
+    out = out.sort_values(
+        ["route_class", "g_order", "s_order", "t_order"]
+    ).drop(columns=["g_order", "s_order", "t_order"]).reset_index(drop=True)
+    return out
+
+
+def build_compositions(compositions: pd.DataFrame, assignments: pd.DataFrame, cfg: Config) -> pd.DataFrame:
+    # Need typing for generators
+    gen_type = (
+        assignments.groupby("generator_completed", as_index=False)
+        .agg(
+            source_object=("state_a_red", lambda s: s.mode().iloc[0] if len(s.mode()) else s.iloc[0]),
+            target_object=("state_c_red", lambda s: s.mode().iloc[0] if len(s.mode()) else s.iloc[0]),
+        )
+    )
+    gen_type_map = gen_type.set_index("generator_completed")[["source_object", "target_object"]].to_dict("index")
+
+    work = compositions.copy()
+    work["source_1"] = work["generator_1"].map(lambda g: gen_type_map.get(g, {}).get("source_object", np.nan))
+    work["target_1"] = work["generator_1"].map(lambda g: gen_type_map.get(g, {}).get("target_object", np.nan))
+    work["source_2"] = work["generator_2"].map(lambda g: gen_type_map.get(g, {}).get("source_object", np.nan))
+    work["target_2"] = work["generator_2"].map(lambda g: gen_type_map.get(g, {}).get("target_object", np.nan))
+
+    work["composition_typed"] = (
+        work["generator_1"]
+        + " : "
+        + work["source_1"].astype(str)
+        + "→"
+        + work["target_1"].astype(str)
+        + " ; "
+        + work["generator_2"]
+        + " : "
+        + work["source_2"].astype(str)
+        + "→"
+        + work["target_2"].astype(str)
+    )
+    work["composable_match"] = (work["target_1"] == work["source_2"]).astype(int)
+
+    # Case 1: already aggregated input from OBS-030e
+    if "n_compositions" in work.columns:
+        if "n_paths" not in work.columns:
+            work["n_paths"] = np.nan
+
+        out = (
+            work.groupby(
+                [
+                    "route_class",
+                    "generator_1",
+                    "generator_2",
+                    "source_1",
+                    "target_1",
+                    "source_2",
+                    "target_2",
+                    "composable_match",
+                    "composition_typed",
+                ],
+                as_index=False,
+            )
+            .agg(
+                n_compositions=("n_compositions", "sum"),
+                n_paths=("n_paths", "sum"),
+            )
+        )
+    else:
+        # Case 2: raw composition rows with path_id
+        if "path_id" not in work.columns:
+            raise ValueError("Compositions input has neither aggregated counts nor raw path_id rows.")
+
+        out = (
+            work.groupby(
+                [
+                    "route_class",
+                    "generator_1",
+                    "generator_2",
+                    "source_1",
+                    "target_1",
+                    "source_2",
+                    "target_2",
+                    "composable_match",
+                    "composition_typed",
+                ],
+                as_index=False,
+            )
+            .agg(
+                n_compositions=("path_id", "size"),
+                n_paths=("path_id", "nunique"),
+            )
+        )
+
+    total = out.groupby("route_class")["n_compositions"].transform("sum")
+    out["composition_share"] = out["n_compositions"] / total.clip(lower=1)
+
+    overall = (
+        out.groupby(
+            [
+                "generator_1",
+                "generator_2",
+                "source_1",
+                "target_1",
+                "source_2",
+                "target_2",
+                "composable_match",
+                "composition_typed",
+            ],
+            as_index=False,
+        )
+        .agg(
+            n_compositions=("n_compositions", "sum"),
+            n_paths=("n_paths", "sum"),
+        )
+    )
+    overall["route_class"] = "overall"
+    total_overall = float(overall["n_compositions"].sum())
+    overall["composition_share"] = overall["n_compositions"] / max(total_overall, 1.0)
+
+    out = pd.concat([out, overall], ignore_index=True)
+    return out.sort_values(["route_class", "n_compositions"], ascending=[True, False]).reset_index(drop=True)
+
+
+def build_family_summary(generators: pd.DataFrame, compositions: pd.DataFrame, cfg: Config) -> pd.DataFrame:
+    rows = []
+
+    gen_sub = generators[generators["route_class"] != "overall"].copy()
+    comp_sub = compositions[compositions["route_class"] != "overall"].copy()
+
+    for cls in CLASS_ORDER:
+        g = gen_sub[gen_sub["route_class"] == cls].copy()
+        c = comp_sub[comp_sub["route_class"] == cls].copy()
+
+        row = {
+            "route_class": cls,
+            "n_generator_instances": int(g["n_instances"].sum()) if len(g) else 0,
+            "n_compositions": int(c["n_compositions"].sum()) if len(c) else 0,
+            "share_named_nonother": float(g.loc[g["generator_completed"] != "g_other", "generator_share"].sum()) if len(g) else 0.0,
+            "share_other": float(g.loc[g["generator_completed"] == "g_other", "generator_share"].sum()) if len(g) else 0.0,
+            "share_composable_match": float(
+                safe_div(
+                    c.loc[c["composable_match"] == 1, "n_compositions"].sum(),
+                    c["n_compositions"].sum(),
+                )
+            ) if len(c) else 0.0,
+        }
+
+        for gen in GENERATOR_ORDER:
+            hit = g[g["generator_completed"] == gen]
+            row[f"{gen}_share"] = float(hit["generator_share"].sum()) if len(hit) else 0.0
+
+        topg = g.sort_values("n_instances", ascending=False).head(5)
+        for i in range(5):
+            row[f"top_generator_{i+1}"] = (
+                f"{topg.iloc[i]['generator_completed']}:{topg.iloc[i]['source_object']}→{topg.iloc[i]['target_object']}"
+                if len(topg) > i else np.nan
+            )
+
+        topc = c.sort_values("n_compositions", ascending=False).head(5)
+        for i in range(5):
+            row[f"top_composition_{i+1}"] = topc.iloc[i]["composition_typed"] if len(topc) > i else np.nan
+
+        rows.append(row)
+
+    out = pd.DataFrame(rows)
+    order = {k: i for i, k in enumerate(CLASS_ORDER)}
+    out["order"] = out["route_class"].map(lambda x: order.get(x, 999))
+    return out.sort_values("order").drop(columns=["order"]).reset_index(drop=True)
+
+
+def safe_div(a: float, b: float) -> float:
+    return float(a / b) if b else 0.0
+
+
+def build_summary(objects: pd.DataFrame, generators: pd.DataFrame, compositions: pd.DataFrame, family_summary: pd.DataFrame, cfg: Config) -> str:
+    overall_g = generators[generators["route_class"] == "overall"].copy()
+    overall_c = compositions[compositions["route_class"] == "overall"].copy()
+
+    named_share = float(overall_g.loc[overall_g["generator_completed"] != "g_other", "generator_share"].sum()) if len(overall_g) else 0.0
+    other_share = float(overall_g.loc[overall_g["generator_completed"] == "g_other", "generator_share"].sum()) if len(overall_g) else 0.0
+    composable_share = float(
+        safe_div(
+            overall_c.loc[overall_c["composable_match"] == 1, "n_compositions"].sum(),
+            overall_c["n_compositions"].sum(),
+        )
+    ) if len(overall_c) else 0.0
+
+    lines = [
+        "=== OBS-031 Proto-Groupoid of Seam Dynamics Summary ===",
+        "",
+        "Discipline",
+        "- empirical proto-groupoid / partial composition system",
+        "- not a theorem of invertibility",
+        "- not a claim of full categorical closure",
+        "",
+        "Objects",
+    ]
+    for _, row in objects.iterrows():
+        lines.append(
+            f"  {row['object']}: source={int(row['n_as_source'])}, middle={int(row['n_as_middle'])}, target={int(row['n_as_target'])}"
+        )
+
+    lines.extend(
+        [
+            "",
+            "Overall algebra quality",
+            f"  named_generator_share = {named_share:.4f}",
+            f"  residual_g_other_share = {other_share:.4f}",
+            f"  composable_match_share = {composable_share:.4f}",
+            "",
+            "Overall top generators",
+        ]
+    )
+
+    topg = overall_g.sort_values("n_instances", ascending=False).head(8)
+    for _, row in topg.iterrows():
+        lines.append(
+            f"  {row['generator_completed']} : {row['source_object']}→{row['target_object']} "
+            f"(n={int(row['n_instances'])}, share={float(row['generator_share']):.4f})"
+        )
+
+    lines.extend(["", "Family proto-groupoid signatures"])
+    for _, row in family_summary.iterrows():
+        lines.extend(
+            [
+                f"{row['route_class']}",
+                f"  share_named_nonother      = {float(row['share_named_nonother']):.4f}",
+                f"  share_other               = {float(row['share_other']):.4f}",
+                f"  share_composable_match    = {float(row['share_composable_match']):.4f}",
+                f"  g_rel_release_share       = {float(row['g_rel_release_share']):.4f}",
+                f"  g_flank_shuttle_share     = {float(row['g_flank_shuttle_share']):.4f}",
+                f"  g_low_flank_shuttle_share = {float(row['g_low_flank_shuttle_share']):.4f}",
+                f"  g_off_persist_share       = {float(row['g_off_persist_share']):.4f}",
+                f"  g_post_persist_share      = {float(row['g_post_persist_share']):.4f}",
+                f"  g_reentry_share           = {float(row['g_reentry_share']):.4f}",
+                f"  g_edge_to_post_share      = {float(row['g_edge_to_post_share']):.4f}",
+                f"  top_generator_1           = {row['top_generator_1']}",
+                f"  top_generator_2           = {row['top_generator_2']}",
+                f"  top_composition_1         = {row['top_composition_1']}",
+                f"  top_composition_2         = {row['top_composition_2']}",
+                "",
+            ]
+        )
+
+    lines.extend(
+        [
+            "Interpretive conclusion",
+            "- objects are reduced seam states",
+            "- arrows are named empirical generators",
+            "- partial composition is observed generator concatenation",
+            "- family-specific subalgebras are present",
+            "- this supports a proto-groupoid framing of seam dynamics",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def render_figure(objects: pd.DataFrame, generators: pd.DataFrame, compositions: pd.DataFrame, family_summary: pd.DataFrame, outpath: Path, cfg: Config) -> None:
+    fig = plt.figure(figsize=(16.5, 10), constrained_layout=True)
+    gs = fig.add_gridspec(2, 3, width_ratios=[1.15, 1.15, 1.0], height_ratios=[1.0, 1.0])
+
+    ax_named = fig.add_subplot(gs[0, 0])
+    ax_family = fig.add_subplot(gs[0, 1])
+    ax_comp = fig.add_subplot(gs[0, 2])
+    ax_top = fig.add_subplot(gs[1, 0:2])
+    ax_diag = fig.add_subplot(gs[1, 2])
+
+    overall_g = generators[generators["route_class"] == "overall"].copy()
+    overall_c = compositions[compositions["route_class"] == "overall"].copy()
+
+    topg = overall_g.sort_values("n_instances", ascending=False).head(8)
+    ax_named.barh(
+        np.arange(len(topg)),
+        topg["generator_share"].to_numpy(dtype=float),
+    )
+    ax_named.set_yticks(np.arange(len(topg)))
+    ax_named.set_yticklabels(
+        [f"{g}:{s}→{t}" for g, s, t in zip(topg["generator_completed"], topg["source_object"], topg["target_object"])]
+    )
+    ax_named.invert_yaxis()
+    ax_named.set_title("Overall top typed generators", fontsize=14, pad=8)
+    ax_named.grid(alpha=0.15, axis="x")
+
+    x = np.arange(len(family_summary))
+    width = 0.22
+    ax_family.bar(x - width, family_summary["g_post_persist_share"], width, label="post persist")
+    ax_family.bar(x, family_summary["g_flank_shuttle_share"], width, label="flank shuttle")
+    ax_family.bar(x + width, family_summary["g_low_flank_shuttle_share"], width, label="low↔flank")
+    ax_family.set_xticks(x)
+    ax_family.set_xticklabels(family_summary["route_class"], rotation=12)
+    ax_family.set_title("Family generator signatures", fontsize=14, pad=8)
+    ax_family.grid(alpha=0.15, axis="y")
+    ax_family.legend()
+
+    topc = overall_c.sort_values("n_compositions", ascending=False).head(cfg.top_k_compositions)
+    ax_comp.barh(
+        np.arange(len(topc)),
+        topc["composition_share"].to_numpy(dtype=float),
+    )
+    ax_comp.set_yticks(np.arange(len(topc)))
+    ax_comp.set_yticklabels(topc["composition_typed"].tolist(), fontsize=8)
+    ax_comp.invert_yaxis()
+    ax_comp.set_title("Top typed partial compositions", fontsize=14, pad=8)
+    ax_comp.grid(alpha=0.15, axis="x")
+
+    ax_top.axis("off")
+    y = 0.95
+    for _, row in family_summary.iterrows():
+        ax_top.text(0.02, y, str(row["route_class"]), fontsize=12, fontweight="bold")
+        y -= 0.06
+        ax_top.text(0.04, y, f"g1: {row['top_generator_1']}", fontsize=10, family="monospace")
+        y -= 0.045
+        ax_top.text(0.04, y, f"g2: {row['top_generator_2']}", fontsize=10, family="monospace")
+        y -= 0.045
+        ax_top.text(0.04, y, f"c1: {row['top_composition_1']}", fontsize=10, family="monospace")
+        y -= 0.045
+        ax_top.text(0.04, y, f"c2: {row['top_composition_2']}", fontsize=10, family="monospace")
+        y -= 0.07
+    ax_top.set_title("Family subalgebras", fontsize=14, pad=8)
+
+    named_share = float(overall_g.loc[overall_g["generator_completed"] != "g_other", "generator_share"].sum()) if len(overall_g) else 0.0
+    other_share = float(overall_g.loc[overall_g["generator_completed"] == "g_other", "generator_share"].sum()) if len(overall_g) else 0.0
+    composable_share = float(
+        safe_div(
+            overall_c.loc[overall_c["composable_match"] == 1, "n_compositions"].sum(),
+            overall_c["n_compositions"].sum(),
+        )
+    ) if len(overall_c) else 0.0
+
+    ax_diag.axis("off")
+    text = (
+        "OBS-031 diagnostics\n\n"
+        f"named generator share:\n{named_share:.3f}\n\n"
+        f"residual g_other share:\n{other_share:.3f}\n\n"
+        f"composable match share:\n{composable_share:.3f}\n\n"
+        "Interpretation:\n"
+        "the seam dynamics now admit\n"
+        "a partial typed-arrow system\n"
+        "with family-specific\n"
+        "subalgebras."
+    )
+    ax_diag.text(
+        0.02, 0.98, text,
+        va="top", ha="left", fontsize=10.2, family="monospace",
+        bbox=dict(boxstyle="round,pad=0.35", fc="white", ec="0.85", alpha=0.95),
+    )
+
+    fig.suptitle("PAM Observatory — OBS-031 proto-groupoid of seam dynamics", fontsize=21)
+    fig.savefig(outpath, dpi=220)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build an empirical proto-groupoid of seam dynamics.")
+    parser.add_argument("--assignments-csv", default=Config.assignments_csv)
+    parser.add_argument("--compositions-csv", default=Config.compositions_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--min-generator-share", type=float, default=Config.min_generator_share)
+    parser.add_argument("--min-composition-share", type=float, default=Config.min_composition_share)
+    parser.add_argument("--top-k-compositions", type=int, default=Config.top_k_compositions)
+    args = parser.parse_args()
+
+    cfg = Config(
+        assignments_csv=args.assignments_csv,
+        compositions_csv=args.compositions_csv,
+        outdir=args.outdir,
+        min_generator_share=args.min_generator_share,
+        min_composition_share=args.min_composition_share,
+        top_k_compositions=args.top_k_compositions,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    assignments = load_csv(cfg.assignments_csv)
+    compositions = load_csv(cfg.compositions_csv)
+
+    objects = build_objects(assignments)
+    generators = build_generators(assignments, cfg)
+    comp = build_compositions(compositions, assignments, cfg)
+    family_summary = build_family_summary(generators, comp, cfg)
+
+    objects_csv = outdir / "proto_groupoid_objects.csv"
+    gen_csv = outdir / "proto_groupoid_generators.csv"
+    comp_csv = outdir / "proto_groupoid_compositions.csv"
+    fam_csv = outdir / "proto_groupoid_family_summary.csv"
+    txt_path = outdir / "obs031_proto_groupoid_of_seam_dynamics_summary.txt"
+    png_path = outdir / "obs031_proto_groupoid_of_seam_dynamics_figure.png"
+
+    objects.to_csv(objects_csv, index=False)
+    generators.to_csv(gen_csv, index=False)
+    comp.to_csv(comp_csv, index=False)
+    family_summary.to_csv(fam_csv, index=False)
+    txt_path.write_text(build_summary(objects, generators, comp, family_summary, cfg), encoding="utf-8")
+    render_figure(objects, generators, comp, family_summary, png_path, cfg)
+
+    print(objects_csv)
+    print(gen_csv)
+    print(comp_csv)
+    print(fam_csv)
+    print(txt_path)
+    print(png_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/studies/obs032_quasi_inverses_and_asymmetry.py
+++ b/experiments/studies/obs032_quasi_inverses_and_asymmetry.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""
+OBS-032 — Quasi-inverses and asymmetry in the seam proto-groupoid.
+
+Purpose
+-------
+Measure which empirical generators behave approximately reversibly, and which
+encode genuinely one-way seam dynamics.
+
+This study sits directly on top of OBS-031.
+
+Core questions
+--------------
+1. Which typed arrows have an observed reverse partner?
+2. How asymmetric are forward vs reverse frequencies?
+3. Do forward-then-reverse compositions exist as local identity surrogates?
+4. Are corridor generators more reversible than branch-exit generators?
+5. Are release generators structurally one-way?
+
+Inputs
+------
+outputs/obs031_proto_groupoid_of_seam_dynamics/proto_groupoid_generators.csv
+outputs/obs031_proto_groupoid_of_seam_dynamics/proto_groupoid_compositions.csv
+
+Outputs
+-------
+outputs/obs032_quasi_inverses_and_asymmetry/
+  quasi_inverse_pairs.csv
+  quasi_inverse_family_summary.csv
+  obs032_quasi_inverses_and_asymmetry_summary.txt
+  obs032_quasi_inverses_and_asymmetry_figure.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class Config:
+    generators_csv: str = (
+        "outputs/obs031_proto_groupoid_of_seam_dynamics/proto_groupoid_generators.csv"
+    )
+    compositions_csv: str = (
+        "outputs/obs031_proto_groupoid_of_seam_dynamics/proto_groupoid_compositions.csv"
+    )
+    outdir: str = "outputs/obs032_quasi_inverses_and_asymmetry"
+    min_share: float = 0.0
+    top_k_pairs: int = 12
+
+
+CLASS_ORDER = [
+    "branch_exit",
+    "stable_seam_corridor",
+    "reorganization_heavy",
+]
+
+
+def safe_div(a: float, b: float) -> float:
+    return float(a / b) if b else 0.0
+
+
+def load_csv(path: str | Path) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    for col in df.columns:
+        if col not in {
+            "route_class",
+            "generator_completed",
+            "source_object",
+            "target_object",
+            "generator_1",
+            "generator_2",
+            "composition_typed",
+            "composition",
+        }:
+            try:
+                df[col] = pd.to_numeric(df[col], errors="coerce")
+            except Exception:
+                pass
+    return df
+
+
+def canonical_pair_key(gen: str, src: str, tgt: str) -> str:
+    a = f"{gen}:{src}->{tgt}"
+    b = f"{gen}:{tgt}->{src}"
+    return " || ".join(sorted([a, b]))
+
+
+def pair_orientation_label(gen: str, src: str, tgt: str) -> str:
+    return f"{gen}:{src}->{tgt}"
+
+
+def build_pair_table(generators: pd.DataFrame, compositions: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+
+    gen_sub = generators[generators["route_class"] != "overall"].copy()
+    comp_sub = compositions[compositions["route_class"] != "overall"].copy()
+
+    for cls in CLASS_ORDER:
+        g = gen_sub[gen_sub["route_class"] == cls].copy()
+        c = comp_sub[comp_sub["route_class"] == cls].copy()
+
+        # Candidate reversible pairs are same generator name with reversed source/target
+        grouped = g.groupby("generator_completed", sort=False)
+
+        for gen_name, gg in grouped:
+            seen = set()
+            for _, row in gg.iterrows():
+                src = str(row["source_object"])
+                tgt = str(row["target_object"])
+                key = (gen_name, frozenset([src, tgt]))
+                if key in seen:
+                    continue
+                seen.add(key)
+
+                fwd = gg[(gg["source_object"] == src) & (gg["target_object"] == tgt)]
+                rev = gg[(gg["source_object"] == tgt) & (gg["target_object"] == src)]
+
+                fwd_n = float(fwd["n_instances"].sum()) if len(fwd) else 0.0
+                rev_n = float(rev["n_instances"].sum()) if len(rev) else 0.0
+                total = fwd_n + rev_n
+
+                # symmetric balance: 1 is perfect symmetry, 0 is one-way
+                symmetry_score = 1.0 - abs(fwd_n - rev_n) / total if total > 0 else np.nan
+
+                # existence of reverse partner
+                reverse_exists = int(rev_n > 0)
+
+                # identity-surrogate compositions:
+                # gen(src->tgt) ; gen(tgt->src)
+                comp_match_1 = c[
+                    (c["generator_1"] == gen_name)
+                    & (c["generator_2"] == gen_name)
+                    & (c["source_1"] == src)
+                    & (c["target_1"] == tgt)
+                    & (c["source_2"] == tgt)
+                    & (c["target_2"] == src)
+                ]
+                comp_match_2 = c[
+                    (c["generator_1"] == gen_name)
+                    & (c["generator_2"] == gen_name)
+                    & (c["source_1"] == tgt)
+                    & (c["target_1"] == src)
+                    & (c["source_2"] == src)
+                    & (c["target_2"] == tgt)
+                ]
+                id_surrogate_count = float(comp_match_1["n_compositions"].sum() + comp_match_2["n_compositions"].sum())
+                id_surrogate_share = float(comp_match_1["composition_share"].sum() + comp_match_2["composition_share"].sum())
+
+                rows.append(
+                    {
+                        "route_class": cls,
+                        "generator_completed": gen_name,
+                        "object_a": src,
+                        "object_b": tgt,
+                        "pair_key": canonical_pair_key(gen_name, src, tgt),
+                        "forward_label": pair_orientation_label(gen_name, src, tgt),
+                        "reverse_label": pair_orientation_label(gen_name, tgt, src),
+                        "forward_count": fwd_n,
+                        "reverse_count": rev_n,
+                        "total_count": total,
+                        "reverse_exists": reverse_exists,
+                        "symmetry_score": symmetry_score,
+                        "directional_bias": safe_div(fwd_n - rev_n, total),
+                        "identity_surrogate_count": id_surrogate_count,
+                        "identity_surrogate_share": id_surrogate_share,
+                    }
+                )
+
+    out = pd.DataFrame(rows)
+    if len(out) == 0:
+        return out
+
+    # remove degenerate self-pairs like O->O vs O->O
+    out = out[out["object_a"] != out["object_b"]].copy()
+
+    # deduplicate canonical pairs within each class
+    out["pair_order"] = out["pair_key"]
+    out = out.sort_values(["route_class", "total_count"], ascending=[True, False])
+    out = out.drop_duplicates(subset=["route_class", "pair_key"]).drop(columns=["pair_order"]).reset_index(drop=True)
+    return out
+
+
+def build_family_summary(pair_table: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+
+    for cls in CLASS_ORDER:
+        sub = pair_table[pair_table["route_class"] == cls].copy()
+
+        if len(sub) == 0:
+            rows.append(
+                {
+                    "route_class": cls,
+                    "n_pairs": 0,
+                    "mean_symmetry_score": np.nan,
+                    "mean_reverse_exists": np.nan,
+                    "mean_identity_surrogate_share": np.nan,
+                    "n_quasi_inverse_pairs": 0,
+                    "n_one_way_pairs": 0,
+                    "top_pair_1": np.nan,
+                    "top_pair_2": np.nan,
+                    "top_pair_3": np.nan,
+                }
+            )
+            continue
+
+        quasi = sub[
+            (sub["reverse_exists"] == 1)
+            & (sub["symmetry_score"] >= 0.40)
+        ]
+        one_way = sub[sub["reverse_exists"] == 0]
+
+        top = sub.sort_values("total_count", ascending=False).head(5)
+
+        rows.append(
+            {
+                "route_class": cls,
+                "n_pairs": int(len(sub)),
+                "mean_symmetry_score": float(sub["symmetry_score"].mean()),
+                "mean_reverse_exists": float(sub["reverse_exists"].mean()),
+                "mean_identity_surrogate_share": float(sub["identity_surrogate_share"].mean()),
+                "n_quasi_inverse_pairs": int(len(quasi)),
+                "n_one_way_pairs": int(len(one_way)),
+                "top_pair_1": (
+                    f"{top.iloc[0]['generator_completed']}:{top.iloc[0]['object_a']}↔{top.iloc[0]['object_b']}"
+                    if len(top) > 0 else np.nan
+                ),
+                "top_pair_2": (
+                    f"{top.iloc[1]['generator_completed']}:{top.iloc[1]['object_a']}↔{top.iloc[1]['object_b']}"
+                    if len(top) > 1 else np.nan
+                ),
+                "top_pair_3": (
+                    f"{top.iloc[2]['generator_completed']}:{top.iloc[2]['object_a']}↔{top.iloc[2]['object_b']}"
+                    if len(top) > 2 else np.nan
+                ),
+            }
+        )
+
+    out = pd.DataFrame(rows)
+    order = {k: i for i, k in enumerate(CLASS_ORDER)}
+    out["order"] = out["route_class"].map(lambda x: order.get(x, 999))
+    return out.sort_values("order").drop(columns=["order"]).reset_index(drop=True)
+
+
+def build_summary(pair_table: pd.DataFrame, family_summary: pd.DataFrame) -> str:
+    overall_pairs = len(pair_table)
+    quasi_total = int(
+        ((pair_table["reverse_exists"] == 1) & (pair_table["symmetry_score"] >= 0.40)).sum()
+    ) if len(pair_table) else 0
+    one_way_total = int((pair_table["reverse_exists"] == 0).sum()) if len(pair_table) else 0
+
+    lines = [
+        "=== OBS-032 Quasi-Inverses and Asymmetry Summary ===",
+        "",
+        f"n_candidate_pairs = {overall_pairs}",
+        f"n_quasi_inverse_pairs = {quasi_total}",
+        f"n_one_way_pairs = {one_way_total}",
+        "",
+        "Interpretive guide",
+        "- symmetry_score near 1 means forward/reverse are balanced",
+        "- reverse_exists=0 means no observed reverse partner",
+        "- identity_surrogate_share measures forward-then-reverse compositions as local identity proxies",
+        "",
+        "Family summaries",
+    ]
+
+    for _, row in family_summary.iterrows():
+        lines.extend(
+            [
+                f"{row['route_class']}",
+                f"  n_pairs                      = {int(row['n_pairs'])}",
+                f"  mean_symmetry_score          = {float(row['mean_symmetry_score']):.4f}",
+                f"  mean_reverse_exists          = {float(row['mean_reverse_exists']):.4f}",
+                f"  mean_identity_surrogate_share= {float(row['mean_identity_surrogate_share']):.4f}",
+                f"  n_quasi_inverse_pairs        = {int(row['n_quasi_inverse_pairs'])}",
+                f"  n_one_way_pairs              = {int(row['n_one_way_pairs'])}",
+                f"  top_pair_1                   = {row['top_pair_1']}",
+                f"  top_pair_2                   = {row['top_pair_2']}",
+                f"  top_pair_3                   = {row['top_pair_3']}",
+                "",
+            ]
+        )
+
+    # add top globally asymmetric pairs
+    if len(pair_table):
+        asym = pair_table.sort_values(["reverse_exists", "symmetry_score", "total_count"], ascending=[True, True, False]).head(8)
+        lines.append("Top asymmetric / one-way candidates")
+        for _, row in asym.iterrows():
+            lines.append(
+                f"  {row['route_class']} | {row['generator_completed']}:{row['object_a']}↔{row['object_b']} "
+                f"| forward={row['forward_count']:.0f}, reverse={row['reverse_count']:.0f}, "
+                f"symmetry={row['symmetry_score']:.4f}, id_share={row['identity_surrogate_share']:.4f}"
+            )
+
+    return "\n".join(lines)
+
+
+def render_figure(pair_table: pd.DataFrame, family_summary: pd.DataFrame, outpath: Path, cfg: Config) -> None:
+    fig = plt.figure(figsize=(16.5, 10), constrained_layout=True)
+    gs = fig.add_gridspec(2, 3, width_ratios=[1.2, 1.0, 1.0], height_ratios=[1.0, 1.0])
+
+    ax_sym = fig.add_subplot(gs[0, 0])
+    ax_rev = fig.add_subplot(gs[0, 1])
+    ax_id = fig.add_subplot(gs[0, 2])
+    ax_top = fig.add_subplot(gs[1, 0:2])
+    ax_diag = fig.add_subplot(gs[1, 2])
+
+    x = np.arange(len(family_summary))
+    width = 0.34
+
+    ax_sym.bar(x, family_summary["mean_symmetry_score"])
+    ax_sym.set_xticks(x)
+    ax_sym.set_xticklabels(family_summary["route_class"], rotation=12)
+    ax_sym.set_title("Mean symmetry score", fontsize=14, pad=8)
+    ax_sym.grid(alpha=0.15, axis="y")
+
+    ax_rev.bar(x - width / 2, family_summary["mean_reverse_exists"], width, label="reverse exists")
+    ax_rev.bar(x + width / 2, family_summary["n_quasi_inverse_pairs"] / family_summary["n_pairs"].replace(0, np.nan), width, label="quasi-inverse fraction")
+    ax_rev.set_xticks(x)
+    ax_rev.set_xticklabels(family_summary["route_class"], rotation=12)
+    ax_rev.set_title("Reverse partners / quasi-inverses", fontsize=14, pad=8)
+    ax_rev.grid(alpha=0.15, axis="y")
+    ax_rev.legend()
+
+    ax_id.bar(x, family_summary["mean_identity_surrogate_share"])
+    ax_id.set_xticks(x)
+    ax_id.set_xticklabels(family_summary["route_class"], rotation=12)
+    ax_id.set_title("Identity-surrogate composition share", fontsize=14, pad=8)
+    ax_id.grid(alpha=0.15, axis="y")
+
+    # top pairs
+    ax_top.axis("off")
+    y = 0.95
+    for cls in CLASS_ORDER:
+        sub = pair_table[pair_table["route_class"] == cls].sort_values("total_count", ascending=False).head(4)
+        ax_top.text(0.02, y, cls, fontsize=12, fontweight="bold")
+        y -= 0.06
+        for _, row in sub.iterrows():
+            txt = (
+                f"{row['generator_completed']}:{row['object_a']}↔{row['object_b']} | "
+                f"f={row['forward_count']:.0f}, r={row['reverse_count']:.0f}, "
+                f"sym={row['symmetry_score']:.2f}, id={row['identity_surrogate_share']:.3f}"
+            )
+            ax_top.text(0.04, y, txt, fontsize=9.5, family="monospace")
+            y -= 0.045
+        y -= 0.04
+    ax_top.set_title("Top quasi-inverse / asymmetric pairs", fontsize=14, pad=8)
+
+    overall_mean_sym = float(pair_table["symmetry_score"].mean()) if len(pair_table) else float("nan")
+    overall_rev = float(pair_table["reverse_exists"].mean()) if len(pair_table) else float("nan")
+    overall_id = float(pair_table["identity_surrogate_share"].mean()) if len(pair_table) else float("nan")
+
+    ax_diag.axis("off")
+    text = (
+        "OBS-032 diagnostics\n\n"
+        f"overall mean symmetry:\n{overall_mean_sym:.3f}\n\n"
+        f"overall reverse-exists rate:\n{overall_rev:.3f}\n\n"
+        f"overall identity-surrogate share:\n{overall_id:.3f}\n\n"
+        "Interpretation:\n"
+        "high symmetry suggests\n"
+        "quasi-reversible local\n"
+        "structure; low symmetry\n"
+        "suggests one-way dynamics."
+    )
+    ax_diag.text(
+        0.02, 0.98, text,
+        va="top", ha="left", fontsize=10.2, family="monospace",
+        bbox=dict(boxstyle="round,pad=0.35", fc="white", ec="0.85", alpha=0.95),
+    )
+
+    fig.suptitle("PAM Observatory — OBS-032 quasi-inverses and asymmetry", fontsize=21)
+    fig.savefig(outpath, dpi=220)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Measure quasi-inverses and asymmetry in the seam proto-groupoid.")
+    parser.add_argument("--generators-csv", default=Config.generators_csv)
+    parser.add_argument("--compositions-csv", default=Config.compositions_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--min-share", type=float, default=Config.min_share)
+    parser.add_argument("--top-k-pairs", type=int, default=Config.top_k_pairs)
+    args = parser.parse_args()
+
+    cfg = Config(
+        generators_csv=args.generators_csv,
+        compositions_csv=args.compositions_csv,
+        outdir=args.outdir,
+        min_share=args.min_share,
+        top_k_pairs=args.top_k_pairs,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    generators = load_csv(cfg.generators_csv)
+    compositions = load_csv(cfg.compositions_csv)
+
+    pair_table = build_pair_table(generators, compositions)
+    family_summary = build_family_summary(pair_table)
+
+    pair_csv = outdir / "quasi_inverse_pairs.csv"
+    fam_csv = outdir / "quasi_inverse_family_summary.csv"
+    txt_path = outdir / "obs032_quasi_inverses_and_asymmetry_summary.txt"
+    png_path = outdir / "obs032_quasi_inverses_and_asymmetry_figure.png"
+
+    pair_table.to_csv(pair_csv, index=False)
+    family_summary.to_csv(fam_csv, index=False)
+    txt_path.write_text(build_summary(pair_table, family_summary), encoding="utf-8")
+    render_figure(pair_table, family_summary, png_path, cfg)
+
+    print(pair_csv)
+    print(fam_csv)
+    print(txt_path)
+    print(png_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/studies/obs033_reversible_core_vs_directed_escape.py
+++ b/experiments/studies/obs033_reversible_core_vs_directed_escape.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""
+OBS-033 — Reversible core vs directed escape in the seam proto-groupoid.
+
+Purpose
+-------
+Partition the seam proto-groupoid into two sectors:
+
+1. reversible core
+   - quasi-inverse shuttle-like generator pairs
+   - seam-internal local symmetry remnants
+
+2. directed escape sector
+   - one-way release / persistence / transition arrows
+   - irreversible seam departure and off-seam continuation
+
+This study turns the asymmetry result of OBS-032 into an explicit structural
+decomposition.
+
+Inputs
+------
+outputs/obs032_quasi_inverses_and_asymmetry/quasi_inverse_pairs.csv
+outputs/obs031_proto_groupoid_of_seam_dynamics/proto_groupoid_generators.csv
+outputs/obs031_proto_groupoid_of_seam_dynamics/proto_groupoid_compositions.csv
+
+Outputs
+-------
+outputs/obs033_reversible_core_vs_directed_escape/
+  reversible_core_pairs.csv
+  directed_escape_pairs.csv
+  reversible_vs_directed_family_summary.csv
+  obs033_reversible_core_vs_directed_escape_summary.txt
+  obs033_reversible_core_vs_directed_escape_figure.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class Config:
+    quasi_pairs_csv: str = (
+        "outputs/obs032_quasi_inverses_and_asymmetry/quasi_inverse_pairs.csv"
+    )
+    generators_csv: str = (
+        "outputs/obs031_proto_groupoid_of_seam_dynamics/proto_groupoid_generators.csv"
+    )
+    compositions_csv: str = (
+        "outputs/obs031_proto_groupoid_of_seam_dynamics/proto_groupoid_compositions.csv"
+    )
+    outdir: str = "outputs/obs033_reversible_core_vs_directed_escape"
+    quasi_inverse_threshold: float = 0.40
+    min_pair_count: float = 1.0
+    top_k_pairs: int = 10
+
+
+CLASS_ORDER = [
+    "branch_exit",
+    "stable_seam_corridor",
+    "reorganization_heavy",
+]
+
+
+def load_csv(path: str | Path) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    text_cols = {
+        "route_class",
+        "pair_key",
+        "forward_label",
+        "reverse_label",
+        "generator_completed",
+        "source_object",
+        "target_object",
+        "generator_1",
+        "generator_2",
+        "composition_typed",
+        "composition",
+        "object_a",
+        "object_b",
+        "sector",
+    }
+    for col in df.columns:
+        if col not in text_cols:
+            try:
+                df[col] = pd.to_numeric(df[col], errors="coerce")
+            except Exception:
+                pass
+    return df
+
+def classify_pair_sector(row: pd.Series, cfg: Config) -> str:
+    sym = pd.to_numeric(row.get("symmetry_score"), errors="coerce")
+    rev = pd.to_numeric(row.get("reverse_exists"), errors="coerce")
+    total = pd.to_numeric(row.get("total_count"), errors="coerce")
+
+    if pd.isna(total) or total < cfg.min_pair_count:
+        return "other"
+
+    if rev == 1 and pd.notna(sym) and sym >= cfg.quasi_inverse_threshold:
+        return "reversible_core"
+
+    return "directed_escape"
+
+
+def build_pair_sectors(pair_table: pd.DataFrame, cfg: Config) -> tuple[pd.DataFrame, pd.DataFrame]:
+    work = pair_table.copy()
+    work["sector"] = work.apply(lambda row: classify_pair_sector(row, cfg), axis=1)
+
+    rev = work[work["sector"] == "reversible_core"].copy().reset_index(drop=True)
+    direct = work[work["sector"] == "directed_escape"].copy().reset_index(drop=True)
+    return rev, direct
+
+
+def build_family_summary(rev: pd.DataFrame, direct: pd.DataFrame, generators: pd.DataFrame, compositions: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+
+    gsub = generators[generators["route_class"] != "overall"].copy()
+    csub = compositions[compositions["route_class"] != "overall"].copy()
+
+    for cls in CLASS_ORDER:
+        r = rev[rev["route_class"] == cls].copy()
+        d = direct[direct["route_class"] == cls].copy()
+        g = gsub[gsub["route_class"] == cls].copy()
+        c = csub[csub["route_class"] == cls].copy()
+
+        total_pair_weight = float(r["total_count"].sum() + d["total_count"].sum())
+        reversible_pair_share = (float(r["total_count"].sum()) / total_pair_weight) if total_pair_weight > 0 else 0.0
+        directed_pair_share = (float(d["total_count"].sum()) / total_pair_weight) if total_pair_weight > 0 else 0.0
+
+        # Generator-sector proxy by generator names that appeared in reversible pairs
+        rev_generators = set(r["generator_completed"].dropna().astype(str))
+        direct_generators = set(d["generator_completed"].dropna().astype(str))
+
+        g_total = float(g["n_instances"].sum()) if len(g) else 0.0
+        rev_gen_share = float(g[g["generator_completed"].astype(str).isin(rev_generators)]["n_instances"].sum()) / g_total if g_total > 0 else 0.0
+        direct_gen_share = float(g[g["generator_completed"].astype(str).isin(direct_generators)]["n_instances"].sum()) / g_total if g_total > 0 else 0.0
+
+        # Composition-sector proxy
+        rev_comp_share = 0.0
+        direct_comp_share = 0.0
+        if len(c):
+            rev_mask = c["generator_1"].astype(str).isin(rev_generators) & c["generator_2"].astype(str).isin(rev_generators)
+            direct_mask = c["generator_1"].astype(str).isin(direct_generators) | c["generator_2"].astype(str).isin(direct_generators)
+            comp_total = float(c["n_compositions"].sum())
+            if comp_total > 0:
+                rev_comp_share = float(c.loc[rev_mask, "n_compositions"].sum()) / comp_total
+                direct_comp_share = float(c.loc[direct_mask, "n_compositions"].sum()) / comp_total
+
+        top_rev = r.sort_values("total_count", ascending=False).head(3).copy()
+        top_dir = d.sort_values("total_count", ascending=False).head(3).copy()
+
+        for frame in (top_rev, top_dir):
+            if "object_a" in frame.columns:
+                frame["object_a"] = frame["object_a"].fillna("?").astype(str)
+            if "object_b" in frame.columns:
+                frame["object_b"] = frame["object_b"].fillna("?").astype(str)
+
+        rows.append(
+            {
+                "route_class": cls,
+                "n_reversible_pairs": int(len(r)),
+                "n_directed_pairs": int(len(d)),
+                "reversible_pair_share": reversible_pair_share,
+                "directed_pair_share": directed_pair_share,
+                "reversible_generator_share": rev_gen_share,
+                "directed_generator_share": direct_gen_share,
+                "reversible_composition_share": rev_comp_share,
+                "directed_composition_share": direct_comp_share,
+                "top_reversible_pair_1": (
+                    f"{top_rev.iloc[0]['generator_completed']}:{top_rev.iloc[0]['object_a']}↔{top_rev.iloc[0]['object_b']}"
+                    if len(top_rev) > 0 else np.nan
+                ),
+                "top_reversible_pair_2": (
+                    f"{top_rev.iloc[1]['generator_completed']}:{top_rev.iloc[1]['object_a']}↔{top_rev.iloc[1]['object_b']}"
+                    if len(top_rev) > 1 else np.nan
+                ),
+                "top_directed_pair_1": (
+                    f"{top_dir.iloc[0]['generator_completed']}:{top_dir.iloc[0]['object_a']}↔{top_dir.iloc[0]['object_b']}"
+                    if len(top_dir) > 0 else np.nan
+                ),
+                "top_directed_pair_2": (
+                    f"{top_dir.iloc[1]['generator_completed']}:{top_dir.iloc[1]['object_a']}↔{top_dir.iloc[1]['object_b']}"
+                    if len(top_dir) > 1 else np.nan
+                ),
+            }
+        )
+
+    out = pd.DataFrame(rows)
+    order = {k: i for i, k in enumerate(CLASS_ORDER)}
+    out["order"] = out["route_class"].map(lambda x: order.get(x, 999))
+    return out.sort_values("order").drop(columns=["order"]).reset_index(drop=True)
+
+
+def build_summary(rev: pd.DataFrame, direct: pd.DataFrame, fam: pd.DataFrame) -> str:
+    total_rev = int(len(rev))
+    total_dir = int(len(direct))
+    total_weight = float(rev["total_count"].sum() + direct["total_count"].sum())
+    rev_weight_share = float(rev["total_count"].sum() / total_weight) if total_weight > 0 else 0.0
+    dir_weight_share = float(direct["total_count"].sum() / total_weight) if total_weight > 0 else 0.0
+
+    lines = [
+        "=== OBS-033 Reversible Core vs Directed Escape Summary ===",
+        "",
+        f"n_reversible_pairs = {total_rev}",
+        f"n_directed_pairs = {total_dir}",
+        f"reversible_pair_weight_share = {rev_weight_share:.4f}",
+        f"directed_pair_weight_share = {dir_weight_share:.4f}",
+        "",
+        "Interpretive guide",
+        "- reversible core consists of quasi-inverse pairs with reverse partners and moderate symmetry",
+        "- directed escape sector consists of one-way or strongly biased pairs",
+        "- generator/composition shares estimate how much of each family lives in each sector",
+        "",
+        "Family sector summaries",
+    ]
+
+    for _, row in fam.iterrows():
+        lines.extend(
+            [
+                f"{row['route_class']}",
+                f"  n_reversible_pairs          = {int(row['n_reversible_pairs'])}",
+                f"  n_directed_pairs            = {int(row['n_directed_pairs'])}",
+                f"  reversible_pair_share       = {float(row['reversible_pair_share']):.4f}",
+                f"  directed_pair_share         = {float(row['directed_pair_share']):.4f}",
+                f"  reversible_generator_share  = {float(row['reversible_generator_share']):.4f}",
+                f"  directed_generator_share    = {float(row['directed_generator_share']):.4f}",
+                f"  reversible_composition_share= {float(row['reversible_composition_share']):.4f}",
+                f"  directed_composition_share  = {float(row['directed_composition_share']):.4f}",
+                f"  top_reversible_pair_1       = {row['top_reversible_pair_1']}",
+                f"  top_reversible_pair_2       = {row['top_reversible_pair_2']}",
+                f"  top_directed_pair_1         = {row['top_directed_pair_1']}",
+                f"  top_directed_pair_2         = {row['top_directed_pair_2']}",
+                "",
+            ]
+        )
+
+    if total_rev:
+        top_rev = rev.sort_values("total_count", ascending=False).head(8)
+        lines.append("Top reversible-core pairs")
+        for _, row in top_rev.iterrows():
+            lines.append(
+                f"  {row['route_class']} | {row['generator_completed']}:{row['object_a']}↔{row['object_b']} "
+                f"| count={row['total_count']:.0f}, symmetry={row['symmetry_score']:.4f}"
+            )
+    if total_dir:
+        top_dir = direct.sort_values("total_count", ascending=False).head(8)
+        lines.append("")
+        lines.append("Top directed-escape pairs")
+        for _, row in top_dir.iterrows():
+            lines.append(
+                f"  {row['route_class']} | {row['generator_completed']}:{row['object_a']}↔{row['object_b']} "
+                f"| count={row['total_count']:.0f}, forward={row['forward_count']:.0f}, reverse={row['reverse_count']:.0f}"
+            )
+
+    return "\n".join(lines)
+
+
+def render_figure(rev: pd.DataFrame, direct: pd.DataFrame, fam: pd.DataFrame, outpath: Path, cfg: Config) -> None:
+    fig = plt.figure(figsize=(16.5, 10), constrained_layout=True)
+    gs = fig.add_gridspec(2, 3, width_ratios=[1.15, 1.15, 1.0], height_ratios=[1.0, 1.0])
+
+    ax_pairs = fig.add_subplot(gs[0, 0])
+    ax_gens = fig.add_subplot(gs[0, 1])
+    ax_comps = fig.add_subplot(gs[0, 2])
+    ax_top = fig.add_subplot(gs[1, 0:2])
+    ax_diag = fig.add_subplot(gs[1, 2])
+
+    x = np.arange(len(fam))
+    width = 0.34
+
+    ax_pairs.bar(x - width / 2, fam["reversible_pair_share"], width, label="reversible core")
+    ax_pairs.bar(x + width / 2, fam["directed_pair_share"], width, label="directed escape")
+    ax_pairs.set_xticks(x)
+    ax_pairs.set_xticklabels(fam["route_class"], rotation=12)
+    ax_pairs.set_title("Pair-sector weight share", fontsize=14, pad=8)
+    ax_pairs.grid(alpha=0.15, axis="y")
+    ax_pairs.legend()
+
+    ax_gens.bar(x - width / 2, fam["reversible_generator_share"], width, label="reversible gen share")
+    ax_gens.bar(x + width / 2, fam["directed_generator_share"], width, label="directed gen share")
+    ax_gens.set_xticks(x)
+    ax_gens.set_xticklabels(fam["route_class"], rotation=12)
+    ax_gens.set_title("Generator-sector share", fontsize=14, pad=8)
+    ax_gens.grid(alpha=0.15, axis="y")
+    ax_gens.legend()
+
+    ax_comps.bar(x - width / 2, fam["reversible_composition_share"], width, label="reversible comp share")
+    ax_comps.bar(x + width / 2, fam["directed_composition_share"], width, label="directed comp share")
+    ax_comps.set_xticks(x)
+    ax_comps.set_xticklabels(fam["route_class"], rotation=12)
+    ax_comps.set_title("Composition-sector share", fontsize=14, pad=8)
+    ax_comps.grid(alpha=0.15, axis="y")
+    ax_comps.legend()
+
+    ax_top.axis("off")
+    y = 0.95
+    for _, row in fam.iterrows():
+        ax_top.text(0.02, y, str(row["route_class"]), fontsize=12, fontweight="bold")
+        y -= 0.06
+        ax_top.text(0.04, y, f"rev1: {row['top_reversible_pair_1']}", fontsize=10, family="monospace")
+        y -= 0.045
+        ax_top.text(0.04, y, f"rev2: {row['top_reversible_pair_2']}", fontsize=10, family="monospace")
+        y -= 0.045
+        ax_top.text(0.04, y, f"dir1: {row['top_directed_pair_1']}", fontsize=10, family="monospace")
+        y -= 0.045
+        ax_top.text(0.04, y, f"dir2: {row['top_directed_pair_2']}", fontsize=10, family="monospace")
+        y -= 0.07
+    ax_top.set_title("Representative sector pairs", fontsize=14, pad=8)
+
+    total_weight = float(rev["total_count"].sum() + direct["total_count"].sum())
+    rev_share = float(rev["total_count"].sum() / total_weight) if total_weight > 0 else 0.0
+    dir_share = float(direct["total_count"].sum() / total_weight) if total_weight > 0 else 0.0
+
+    ax_diag.axis("off")
+    text = (
+        "OBS-033 diagnostics\n\n"
+        f"reversible weight share:\n{rev_share:.3f}\n\n"
+        f"directed weight share:\n{dir_share:.3f}\n\n"
+        f"n reversible pairs:\n{len(rev)}\n\n"
+        f"n directed pairs:\n{len(direct)}\n\n"
+        "Interpretation:\n"
+        "the seam algebra splits\n"
+        "into a small reversible\n"
+        "core and a dominant\n"
+        "directed escape sector."
+    )
+    ax_diag.text(
+        0.02, 0.98, text,
+        va="top", ha="left", fontsize=10.2, family="monospace",
+        bbox=dict(boxstyle="round,pad=0.35", fc="white", ec="0.85", alpha=0.95),
+    )
+
+    fig.suptitle("PAM Observatory — OBS-033 reversible core vs directed escape", fontsize=21)
+    fig.savefig(outpath, dpi=220)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Partition the seam proto-groupoid into reversible core vs directed escape.")
+    parser.add_argument("--quasi-pairs-csv", default=Config.quasi_pairs_csv)
+    parser.add_argument("--generators-csv", default=Config.generators_csv)
+    parser.add_argument("--compositions-csv", default=Config.compositions_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--quasi-inverse-threshold", type=float, default=Config.quasi_inverse_threshold)
+    parser.add_argument("--min-pair-count", type=float, default=Config.min_pair_count)
+    parser.add_argument("--top-k-pairs", type=int, default=Config.top_k_pairs)
+    args = parser.parse_args()
+
+    cfg = Config(
+        quasi_pairs_csv=args.quasi_pairs_csv,
+        generators_csv=args.generators_csv,
+        compositions_csv=args.compositions_csv,
+        outdir=args.outdir,
+        quasi_inverse_threshold=args.quasi_inverse_threshold,
+        min_pair_count=args.min_pair_count,
+        top_k_pairs=args.top_k_pairs,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    pair_table = load_csv(cfg.quasi_pairs_csv)
+    generators = load_csv(cfg.generators_csv)
+    compositions = load_csv(cfg.compositions_csv)
+
+    rev, direct = build_pair_sectors(pair_table, cfg)
+    fam = build_family_summary(rev, direct, generators, compositions)
+
+    rev_csv = outdir / "reversible_core_pairs.csv"
+    dir_csv = outdir / "directed_escape_pairs.csv"
+    fam_csv = outdir / "reversible_vs_directed_family_summary.csv"
+    txt_path = outdir / "obs033_reversible_core_vs_directed_escape_summary.txt"
+    png_path = outdir / "obs033_reversible_core_vs_directed_escape_figure.png"
+
+    rev.to_csv(rev_csv, index=False)
+    direct.to_csv(dir_csv, index=False)
+    fam.to_csv(fam_csv, index=False)
+    txt_path.write_text(build_summary(rev, direct, fam), encoding="utf-8")
+    render_figure(rev, direct, fam, png_path, cfg)
+
+    print(rev_csv)
+    print(dir_csv)
+    print(fam_csv)
+    print(txt_path)
+    print(png_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is a stacked PR. Please review against the current base branch, not against `main`.

## Summary

This PR adds the seam-dynamics algebra layer on top of the canonical seam bundle.

It introduces:
- seam escape-channel analysis
- typed seam transition algebra
- motif extraction and motif generator compression
- generator-basis completion
- proto-groupoid construction for seam dynamics
- quasi-inverse / asymmetry analysis
- reversible-core vs directed-escape sector decomposition

## Included studies

- `obs029_seam_escape_channels.py`
- `obs030_seam_transition_algebra.py`
- `obs030b_seam_transition_motifs.py`
- `obs030c_motif_generator_algebra.py`
- `obs030d_resolve_other_generators.py`
- `obs030e_complete_generator_basis.py`
- `obs031_proto_groupoid_of_seam_dynamics.py`
- `obs032_quasi_inverses_and_asymmetry.py`
- `obs033_reversible_core_vs_directed_escape.py`

## Why this PR

This layer turns the seam from a static regime into a typed transition system.

It freezes:
- escape-channel structure
- motif-level seam dynamics
- generator compression
- proto-groupoid framing
- reversible-core vs directed-escape split

## Notes

- This PR is stacked on top of the seam-bundle foundation PR.
- Best reviewed in OBS order, since each study feeds the next.