### PR TITLE
Add seam gateway law and family-specific predictor studies

### DIFF
--- a/experiments/studies/obs034_core_to_escape_boundary.py
+++ b/experiments/studies/obs034_core_to_escape_boundary.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+"""
+OBS-034 — Core-to-escape boundary.
+
+Purpose
+-------
+Map the gateway between:
+1. the reversible shuttle core
+2. the directed escape sector
+
+This study asks:
+- which generators carry crossings from the reversible core into the directed sector?
+- which object states are the main launch points?
+- which local fields are elevated at the crossing?
+- do families cross that boundary in different ways?
+
+Inputs
+------
+outputs/obs033_reversible_core_vs_directed_escape/reversible_core_pairs.csv
+outputs/obs033_reversible_core_vs_directed_escape/directed_escape_pairs.csv
+outputs/obs030e_complete_generator_basis/completed_generator_assignments.csv
+outputs/obs030e_complete_generator_basis/completed_generator_compositions.csv
+
+Outputs
+-------
+outputs/obs034_core_to_escape_boundary/
+  generator_sector_map.csv
+  core_to_escape_crossings.csv
+  core_to_escape_family_summary.csv
+  obs034_core_to_escape_boundary_summary.txt
+  obs034_core_to_escape_boundary_figure.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class Config:
+    reversible_pairs_csv: str = (
+        "outputs/obs033_reversible_core_vs_directed_escape/reversible_core_pairs.csv"
+    )
+    directed_pairs_csv: str = (
+        "outputs/obs033_reversible_core_vs_directed_escape/directed_escape_pairs.csv"
+    )
+    proto_generators_csv: str = (
+        "outputs/obs031_proto_groupoid_of_seam_dynamics/proto_groupoid_generators.csv"
+    )
+    proto_compositions_csv: str = (
+        "outputs/obs031_proto_groupoid_of_seam_dynamics/proto_groupoid_compositions.csv"
+    )
+    assignments_csv: str = (
+        "outputs/obs030e_complete_generator_basis/completed_generator_assignments.csv"
+    )
+    outdir: str = "outputs/obs034_core_to_escape_boundary"
+    min_crossing_count: int = 1
+    top_k_generators: int = 10
+
+
+CLASS_ORDER = [
+    "branch_exit",
+    "stable_seam_corridor",
+    "reorganization_heavy",
+]
+
+
+def load_csv(path: str | Path) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    text_cols = {
+        "route_class",
+        "generator_completed",
+        "generator_1",
+        "generator_2",
+        "composition",
+        "composition_typed",
+        "motif",
+        "motif_class",
+        "state_a",
+        "state_b",
+        "state_c",
+        "state_a_red",
+        "state_b_red",
+        "state_c_red",
+        "generator_word",
+        "object_a",
+        "object_b",
+        "pair_key",
+        "forward_label",
+        "reverse_label",
+        "sector",
+        "src1",
+        "tgt1",
+        "src2",
+        "tgt2",
+        "sector_1",
+        "sector_2",
+        "crossing_type",
+    }
+    for col in df.columns:
+        if col not in text_cols:
+            try:
+                df[col] = pd.to_numeric(df[col], errors="coerce")
+            except Exception:
+                pass
+    return df
+
+
+def safe_mean(s: pd.Series | np.ndarray) -> float:
+    x = pd.to_numeric(pd.Series(s), errors="coerce")
+    return float(x.mean()) if x.notna().any() else float("nan")
+
+
+def build_generator_sector_map(rev: pd.DataFrame, direct: pd.DataFrame) -> pd.DataFrame:
+    rev_use = rev[["route_class", "generator_completed", "object_a", "object_b", "total_count"]].copy()
+    rev_use["sector"] = "reversible_core"
+
+    dir_use = direct[["route_class", "generator_completed", "object_a", "object_b", "total_count"]].copy()
+    dir_use["sector"] = "directed_escape"
+
+    both = pd.concat([rev_use, dir_use], ignore_index=True)
+    both["object_a"] = both["object_a"].astype(str)
+    both["object_b"] = both["object_b"].astype(str)
+
+    out = (
+        both.groupby(["route_class", "generator_completed", "object_a", "object_b", "sector"], as_index=False)
+        .agg(pair_weight=("total_count", "sum"))
+    )
+    return out.sort_values(["route_class", "pair_weight"], ascending=[True, False]).reset_index(drop=True)
+
+
+def classify_generator_sector(
+    route_class: str,
+    generator_name: str,
+    src: str,
+    tgt: str,
+    sector_map: pd.DataFrame,
+) -> str:
+    hit = sector_map[
+        (sector_map["route_class"] == route_class)
+        & (sector_map["generator_completed"] == generator_name)
+        & (sector_map["object_a"] == src)
+        & (sector_map["object_b"] == tgt)
+    ]
+    if len(hit):
+        return str(hit.iloc[0]["sector"])
+
+    # fallback: generator-level family fallback
+    hit2 = sector_map[
+        (sector_map["route_class"] == route_class)
+        & (sector_map["generator_completed"] == generator_name)
+    ]
+    if len(hit2):
+        return str(hit2.sort_values("pair_weight", ascending=False).iloc[0]["sector"])
+
+    return "unknown"
+
+
+def build_core_to_escape_crossings(
+    proto_generators: pd.DataFrame,
+    proto_compositions: pd.DataFrame,
+    sector_map: pd.DataFrame,
+) -> pd.DataFrame:
+    # typed generator lookup from OBS-031
+    gtab = proto_generators[proto_generators["route_class"] != "overall"].copy()
+
+    # choose most-supported typing per family+generator
+    gtab = gtab.sort_values(
+        ["route_class", "generator_completed", "n_instances"],
+        ascending=[True, True, False],
+    )
+    gtab = gtab.drop_duplicates(subset=["route_class", "generator_completed"])
+
+    type_map = {
+        (str(r.route_class), str(r.generator_completed)): (str(r.source_object), str(r.target_object))
+        for r in gtab.itertuples(index=False)
+    }
+
+    comp = proto_compositions[proto_compositions["route_class"] != "overall"].copy()
+
+    rows = []
+    for _, row in comp.iterrows():
+        cls = str(row["route_class"])
+        g1 = str(row["generator_1"])
+        g2 = str(row["generator_2"])
+
+        src1, tgt1 = type_map.get((cls, g1), ("?", "?"))
+        src2, tgt2 = type_map.get((cls, g2), ("?", "?"))
+
+        sec1 = classify_generator_sector(cls, g1, src1, tgt1, sector_map)
+        sec2 = classify_generator_sector(cls, g2, src2, tgt2, sector_map)
+
+        crossing_type = "other"
+        if sec1 == "reversible_core" and sec2 == "directed_escape":
+            crossing_type = "core_to_escape"
+        elif sec1 == "directed_escape" and sec2 == "reversible_core":
+            crossing_type = "escape_to_core"
+        elif sec1 == "reversible_core" and sec2 == "reversible_core":
+            crossing_type = "core_internal"
+        elif sec1 == "directed_escape" and sec2 == "directed_escape":
+            crossing_type = "escape_internal"
+
+        rows.append(
+            {
+                "route_class": cls,
+                "generator_1": g1,
+                "generator_2": g2,
+                "src1": src1,
+                "tgt1": tgt1,
+                "src2": src2,
+                "tgt2": tgt2,
+                "sector_1": sec1,
+                "sector_2": sec2,
+                "crossing_type": crossing_type,
+                "n_compositions": float(row["n_compositions"]),
+                "n_paths": float(row["n_paths"]) if "n_paths" in row else np.nan,
+                "composition_share": float(row["composition_share"]) if "composition_share" in row else np.nan,
+                "composition_typed": row.get("composition_typed", np.nan),
+            }
+        )
+
+    out = pd.DataFrame(rows)
+    return out.sort_values(["route_class", "n_compositions"], ascending=[True, False]).reset_index(drop=True)
+
+
+def build_family_summary(
+    crossings: pd.DataFrame,
+    assignments: pd.DataFrame,
+) -> pd.DataFrame:
+    # local field summary for first generator in crossing
+    assign = assignments.copy()
+    assign["route_class"] = assign["route_class"].astype(str)
+    assign["generator_completed"] = assign["generator_completed"].astype(str)
+
+    rows = []
+    for cls in CLASS_ORDER:
+        sub = crossings[crossings["route_class"] == cls].copy()
+        total = float(sub["n_compositions"].sum()) if len(sub) else 0.0
+
+        c2e = sub[sub["crossing_type"] == "core_to_escape"].copy()
+        e2c = sub[sub["crossing_type"] == "escape_to_core"].copy()
+        cin = sub[sub["crossing_type"] == "core_internal"].copy()
+        ein = sub[sub["crossing_type"] == "escape_internal"].copy()
+
+        # estimate launch fields by generator_1 usage weighted by crossing counts
+        launch_rows = []
+        for _, row in c2e.iterrows():
+            a = assign[
+                (assign["route_class"] == cls)
+                & (assign["generator_completed"] == str(row["generator_1"]))
+            ]
+            if len(a) == 0:
+                continue
+            launch_rows.append(
+                {
+                    "weight": float(row["n_compositions"]),
+                    "relational": safe_mean(a.get("relational_a", pd.Series(dtype=float))),
+                    "anisotropy": safe_mean(a.get("anisotropy_a", pd.Series(dtype=float))),
+                    "distance": safe_mean(a.get("distance_a", pd.Series(dtype=float))),
+                }
+            )
+
+        launch_df = pd.DataFrame(launch_rows)
+        if len(launch_df):
+            w = launch_df["weight"].to_numpy(dtype=float)
+            rel = float(np.average(launch_df["relational"], weights=w))
+            aniso = float(np.average(launch_df["anisotropy"], weights=w))
+            dist = float(np.average(launch_df["distance"], weights=w))
+        else:
+            rel = aniso = dist = float("nan")
+
+        top = c2e.sort_values("n_compositions", ascending=False).head(3)
+
+        rows.append(
+            {
+                "route_class": cls,
+                "n_total_compositions": int(total),
+                "core_to_escape_share": float(c2e["n_compositions"].sum() / total) if total > 0 else 0.0,
+                "escape_to_core_share": float(e2c["n_compositions"].sum() / total) if total > 0 else 0.0,
+                "core_internal_share": float(cin["n_compositions"].sum() / total) if total > 0 else 0.0,
+                "escape_internal_share": float(ein["n_compositions"].sum() / total) if total > 0 else 0.0,
+                "mean_launch_relational": rel,
+                "mean_launch_anisotropy": aniso,
+                "mean_launch_distance": dist,
+                "top_gateway_1": top.iloc[0]["composition_typed"] if len(top) > 0 else np.nan,
+                "top_gateway_2": top.iloc[1]["composition_typed"] if len(top) > 1 else np.nan,
+                "top_gateway_3": top.iloc[2]["composition_typed"] if len(top) > 2 else np.nan,
+            }
+        )
+
+    out = pd.DataFrame(rows)
+    order = {k: i for i, k in enumerate(CLASS_ORDER)}
+    out["order"] = out["route_class"].map(lambda x: order.get(x, 999))
+    return out.sort_values("order").drop(columns=["order"]).reset_index(drop=True)
+
+
+def build_summary(sector_map: pd.DataFrame, crossings: pd.DataFrame, fam: pd.DataFrame) -> str:
+    total = float(crossings["n_compositions"].sum()) if len(crossings) else 0.0
+    c2e = float(crossings.loc[crossings["crossing_type"] == "core_to_escape", "n_compositions"].sum())
+    e2c = float(crossings.loc[crossings["crossing_type"] == "escape_to_core", "n_compositions"].sum())
+
+    lines = [
+        "=== OBS-034 Core-to-Escape Boundary Summary ===",
+        "",
+        f"core_to_escape_share_overall = {c2e / total if total else 0.0:.4f}",
+        f"escape_to_core_share_overall = {e2c / total if total else 0.0:.4f}",
+        "",
+        "Interpretive guide",
+        "- core_to_escape marks the gateway from reversible shuttle structure into directed escape",
+        "- escape_to_core marks return from directed sector back into reversible core",
+        "- launch-field means estimate the local conditions associated with leaving the core",
+        "",
+        "Family gateway summaries",
+    ]
+
+    for _, row in fam.iterrows():
+        lines.extend(
+            [
+                f"{row['route_class']}",
+                f"  core_to_escape_share   = {float(row['core_to_escape_share']):.4f}",
+                f"  escape_to_core_share   = {float(row['escape_to_core_share']):.4f}",
+                f"  core_internal_share    = {float(row['core_internal_share']):.4f}",
+                f"  escape_internal_share  = {float(row['escape_internal_share']):.4f}",
+                f"  mean_launch_relational = {float(row['mean_launch_relational']):.4f}",
+                f"  mean_launch_anisotropy = {float(row['mean_launch_anisotropy']):.4f}",
+                f"  mean_launch_distance   = {float(row['mean_launch_distance']):.4f}",
+                f"  top_gateway_1          = {row['top_gateway_1']}",
+                f"  top_gateway_2          = {row['top_gateway_2']}",
+                f"  top_gateway_3          = {row['top_gateway_3']}",
+                "",
+            ]
+        )
+
+    if len(crossings):
+        top = crossings[crossings["crossing_type"] == "core_to_escape"].sort_values("n_compositions", ascending=False).head(10)
+        lines.append("Top core-to-escape gateways")
+        for _, row in top.iterrows():
+            lines.append(
+                f"  {row['route_class']} | {row['composition_typed']} | n={row['n_compositions']:.0f}, share={row['composition_share']:.4f}"
+            )
+
+    return "\n".join(lines)
+
+
+def render_figure(crossings: pd.DataFrame, fam: pd.DataFrame, outpath: Path, cfg: Config) -> None:
+    fig = plt.figure(figsize=(16.5, 10), constrained_layout=True)
+    gs = fig.add_gridspec(2, 3, width_ratios=[1.15, 1.15, 1.0], height_ratios=[1.0, 1.0])
+
+    ax_share = fig.add_subplot(gs[0, 0])
+    ax_fields = fig.add_subplot(gs[0, 1])
+    ax_internal = fig.add_subplot(gs[0, 2])
+    ax_top = fig.add_subplot(gs[1, 0:2])
+    ax_diag = fig.add_subplot(gs[1, 2])
+
+    x = np.arange(len(fam))
+    width = 0.34
+
+    ax_share.bar(x - width / 2, fam["core_to_escape_share"], width, label="core→escape")
+    ax_share.bar(x + width / 2, fam["escape_to_core_share"], width, label="escape→core")
+    ax_share.set_xticks(x)
+    ax_share.set_xticklabels(fam["route_class"], rotation=12)
+    ax_share.set_title("Boundary crossing shares", fontsize=14, pad=8)
+    ax_share.grid(alpha=0.15, axis="y")
+    ax_share.legend()
+
+    ax_fields.bar(x - width, fam["mean_launch_relational"], width, label="relational")
+    ax_fields.bar(x, fam["mean_launch_anisotropy"], width, label="anisotropy")
+    ax_fields.bar(x + width, fam["mean_launch_distance"], width, label="distance")
+    ax_fields.set_xticks(x)
+    ax_fields.set_xticklabels(fam["route_class"], rotation=12)
+    ax_fields.set_title("Gateway launch fields", fontsize=14, pad=8)
+    ax_fields.grid(alpha=0.15, axis="y")
+    ax_fields.legend()
+
+    ax_internal.bar(x - width / 2, fam["core_internal_share"], width, label="core internal")
+    ax_internal.bar(x + width / 2, fam["escape_internal_share"], width, label="escape internal")
+    ax_internal.set_xticks(x)
+    ax_internal.set_xticklabels(fam["route_class"], rotation=12)
+    ax_internal.set_title("Within-sector compositions", fontsize=14, pad=8)
+    ax_internal.grid(alpha=0.15, axis="y")
+    ax_internal.legend()
+
+    ax_top.axis("off")
+    y = 0.95
+    for _, row in fam.iterrows():
+        ax_top.text(0.02, y, str(row["route_class"]), fontsize=12, fontweight="bold")
+        y -= 0.06
+        ax_top.text(0.04, y, f"g1: {row['top_gateway_1']}", fontsize=10, family="monospace")
+        y -= 0.045
+        ax_top.text(0.04, y, f"g2: {row['top_gateway_2']}", fontsize=10, family="monospace")
+        y -= 0.045
+        ax_top.text(0.04, y, f"g3: {row['top_gateway_3']}", fontsize=10, family="monospace")
+        y -= 0.07
+    ax_top.set_title("Top core→escape gateways", fontsize=14, pad=8)
+
+    total = float(crossings["n_compositions"].sum()) if len(crossings) else 0.0
+    c2e = float(crossings.loc[crossings["crossing_type"] == "core_to_escape", "n_compositions"].sum()) if len(crossings) else 0.0
+    e2c = float(crossings.loc[crossings["crossing_type"] == "escape_to_core", "n_compositions"].sum()) if len(crossings) else 0.0
+
+    ax_diag.axis("off")
+    text = (
+        "OBS-034 diagnostics\n\n"
+        f"overall core→escape:\n{(c2e / total) if total else 0.0:.3f}\n\n"
+        f"overall escape→core:\n{(e2c / total) if total else 0.0:.3f}\n\n"
+        "Interpretation:\n"
+        "this isolates the gateway\n"
+        "that converts reversible\n"
+        "shuttle structure into\n"
+        "directed escape dynamics."
+    )
+    ax_diag.text(
+        0.02, 0.98, text,
+        va="top", ha="left", fontsize=10.2, family="monospace",
+        bbox=dict(boxstyle="round,pad=0.35", fc="white", ec="0.85", alpha=0.95),
+    )
+
+    fig.suptitle("PAM Observatory — OBS-034 core-to-escape boundary", fontsize=21)
+    fig.savefig(outpath, dpi=220)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Map the boundary between reversible core and directed escape.")
+    parser.add_argument("--reversible-pairs-csv", default=Config.reversible_pairs_csv)
+    parser.add_argument("--directed-pairs-csv", default=Config.directed_pairs_csv)
+    parser.add_argument("--proto-generators-csv", default=Config.proto_generators_csv)
+    parser.add_argument("--proto-compositions-csv", default=Config.proto_compositions_csv)
+    parser.add_argument("--assignments-csv", default=Config.assignments_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--min-crossing-count", type=int, default=Config.min_crossing_count)
+    parser.add_argument("--top-k-generators", type=int, default=Config.top_k_generators)
+    args = parser.parse_args()
+
+    cfg = Config(
+        reversible_pairs_csv=args.reversible_pairs_csv,
+        directed_pairs_csv=args.directed_pairs_csv,
+        proto_generators_csv=args.proto_generators_csv,
+        proto_compositions_csv=args.proto_compositions_csv,
+        assignments_csv=args.assignments_csv,
+        outdir=args.outdir,
+        min_crossing_count=args.min_crossing_count,
+        top_k_generators=args.top_k_generators,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    rev = load_csv(cfg.reversible_pairs_csv)
+    direct = load_csv(cfg.directed_pairs_csv)
+    proto_generators = load_csv(cfg.proto_generators_csv)
+    proto_compositions = load_csv(cfg.proto_compositions_csv)
+    assignments = load_csv(cfg.assignments_csv)
+
+    sector_map = build_generator_sector_map(rev, direct)
+    crossings = build_core_to_escape_crossings(proto_generators, proto_compositions, sector_map)
+    fam = build_family_summary(crossings, assignments)
+
+    sector_csv = outdir / "generator_sector_map.csv"
+    crossing_csv = outdir / "core_to_escape_crossings.csv"
+    fam_csv = outdir / "core_to_escape_family_summary.csv"
+    txt_path = outdir / "obs034_core_to_escape_boundary_summary.txt"
+    png_path = outdir / "obs034_core_to_escape_boundary_figure.png"
+
+    sector_map.to_csv(sector_csv, index=False)
+    crossings.to_csv(crossing_csv, index=False)
+    fam.to_csv(fam_csv, index=False)
+    txt_path.write_text(build_summary(sector_map, crossings, fam), encoding="utf-8")
+    render_figure(crossings, fam, png_path, cfg)
+
+    print(sector_csv)
+    print(crossing_csv)
+    print(fam_csv)
+    print(txt_path)
+    print(png_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/studies/obs035_gateway_crossing_predictor.py
+++ b/experiments/studies/obs035_gateway_crossing_predictor.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""
+OBS-035 — Gateway crossing predictor.
+
+Purpose
+-------
+Turn the core-to-escape gateway from OBS-034 into a predictive law.
+
+This study predicts whether a composition is a core->escape crossing using
+local pre-gateway information:
+
+- launch object/state
+- relational obstruction
+- anisotropy
+- distance to seam
+- launch generator
+- family label
+
+Core outcome
+------------
+y = 1 if composition is classified as core_to_escape
+y = 0 if composition is classified as core_internal
+
+We intentionally compare only boundary-adjacent cases from the reversible core:
+- core_internal  : stayed inside reversible core
+- core_to_escape : crossed into directed escape
+
+Inputs
+------
+outputs/obs034_core_to_escape_boundary/core_to_escape_crossings.csv
+outputs/obs030e_complete_generator_basis/completed_generator_assignments.csv
+
+Outputs
+-------
+outputs/obs035_gateway_crossing_predictor/
+  gateway_crossing_dataset.csv
+  gateway_crossing_coefficients.csv
+  gateway_crossing_family_summary.csv
+  obs035_gateway_crossing_predictor_summary.txt
+  obs035_gateway_crossing_predictor_figure.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import roc_auc_score
+
+
+@dataclass(frozen=True)
+class Config:
+    crossings_csv: str = (
+        "outputs/obs034_core_to_escape_boundary/core_to_escape_crossings.csv"
+    )
+    assignments_csv: str = (
+        "outputs/obs030e_complete_generator_basis/completed_generator_assignments.csv"
+    )
+    outdir: str = "outputs/obs035_gateway_crossing_predictor"
+    min_rows_per_family: int = 6
+    random_state: int = 42
+
+
+CLASS_ORDER = [
+    "branch_exit",
+    "stable_seam_corridor",
+    "reorganization_heavy",
+]
+
+
+def load_csv(path: str | Path) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    text_cols = {
+        "route_class",
+        "generator_1",
+        "generator_2",
+        "src1",
+        "tgt1",
+        "src2",
+        "tgt2",
+        "sector_1",
+        "sector_2",
+        "crossing_type",
+        "composition_typed",
+        "motif",
+        "motif_class",
+        "state_a",
+        "state_b",
+        "state_c",
+        "state_a_red",
+        "state_b_red",
+        "state_c_red",
+        "generator_word",
+        "generator_completed",
+        "path_family",
+    }
+    for col in df.columns:
+        if col not in text_cols:
+            try:
+                df[col] = pd.to_numeric(df[col], errors="coerce")
+            except Exception:
+                pass
+    return df
+
+
+def safe_mean(s: pd.Series | np.ndarray) -> float:
+    x = pd.to_numeric(pd.Series(s), errors="coerce")
+    return float(x.mean()) if x.notna().any() else float("nan")
+
+
+def build_assignment_feature_map(assignments: pd.DataFrame) -> pd.DataFrame:
+    a = assignments.copy()
+    a["route_class"] = a["route_class"].astype(str)
+    a["generator_completed"] = a["generator_completed"].astype(str)
+
+    # Representative local feature profile per family+generator
+    feat = (
+        a.groupby(["route_class", "generator_completed"], as_index=False)
+        .agg(
+            n_rows=("generator_completed", "size"),
+            launch_state=("state_a_red", lambda s: s.mode().iloc[0] if len(s.mode()) else s.iloc[0]),
+            target_state=("state_c_red", lambda s: s.mode().iloc[0] if len(s.mode()) else s.iloc[0]),
+            mean_relational=("relational_a", "mean") if "relational_a" in a.columns else ("distance_a", "size"),
+            mean_anisotropy=("anisotropy_a", "mean") if "anisotropy_a" in a.columns else ("distance_a", "size"),
+            mean_distance=("distance_a", "mean") if "distance_a" in a.columns else ("n_rows", "size"),
+        )
+    )
+
+    # If fallback tuples above created wrong values due to missing columns, patch them
+    if "relational_a" not in a.columns:
+        feat["mean_relational"] = np.nan
+    if "anisotropy_a" not in a.columns:
+        feat["mean_anisotropy"] = np.nan
+    if "distance_a" not in a.columns:
+        feat["mean_distance"] = np.nan
+
+    return feat
+
+
+def build_dataset(crossings: pd.DataFrame, assignments: pd.DataFrame) -> pd.DataFrame:
+    # Only compare reversible-core launches:
+    #   core_internal    -> negative
+    #   core_to_escape   -> positive
+    use = crossings[crossings["crossing_type"].isin(["core_internal", "core_to_escape"])].copy()
+    use["y_cross"] = (use["crossing_type"] == "core_to_escape").astype(int)
+
+    feat = build_assignment_feature_map(assignments)
+
+    # Join launch-generator features using generator_1 as pre-gateway local context
+    ds = use.merge(
+        feat,
+        left_on=["route_class", "generator_1"],
+        right_on=["route_class", "generator_completed"],
+        how="left",
+        suffixes=("", "_feat"),
+    )
+
+    ds["launch_generator"] = ds["generator_1"].astype(str)
+    ds["next_generator"] = ds["generator_2"].astype(str)
+
+    # Keep simple interpretable fields
+    keep = [
+        "route_class",
+        "crossing_type",
+        "y_cross",
+        "n_compositions",
+        "composition_share",
+        "launch_generator",
+        "next_generator",
+        "launch_state",
+        "target_state",
+        "mean_relational",
+        "mean_anisotropy",
+        "mean_distance",
+        "composition_typed",
+    ]
+    ds = ds[keep].copy()
+    return ds
+
+
+def fit_logistic(ds: pd.DataFrame) -> tuple[pd.DataFrame, dict[str, float]]:
+    # Build interpretable design matrix
+    X = ds.copy()
+
+    # numeric
+    for col in ["mean_relational", "mean_anisotropy", "mean_distance"]:
+        X[col] = pd.to_numeric(X[col], errors="coerce")
+        X[col] = X[col].fillna(X[col].median() if X[col].notna().any() else 0.0)
+
+    # categoricals
+    design = pd.get_dummies(
+        X[[
+            "route_class",
+            "launch_generator",
+            "next_generator",
+            "launch_state",
+            "target_state",
+            "mean_relational",
+            "mean_anisotropy",
+            "mean_distance",
+        ]],
+        columns=["route_class", "launch_generator", "next_generator", "launch_state", "target_state"],
+        drop_first=False,
+        dtype=float,
+    )
+
+    y = ds["y_cross"].to_numpy(dtype=int)
+    sample_weight = pd.to_numeric(ds["n_compositions"], errors="coerce").fillna(1.0).to_numpy(dtype=float)
+
+    model = LogisticRegression(
+        penalty="l2",
+        solver="liblinear",
+        random_state=42,
+        max_iter=2000,
+    )
+    model.fit(design.to_numpy(dtype=float), y, sample_weight=sample_weight)
+
+    probs = model.predict_proba(design.to_numpy(dtype=float))[:, 1]
+    auc = float(roc_auc_score(y, probs, sample_weight=sample_weight)) if len(np.unique(y)) > 1 else float("nan")
+
+    coef = pd.DataFrame(
+        {
+            "feature": design.columns,
+            "coefficient": model.coef_[0],
+            "abs_coefficient": np.abs(model.coef_[0]),
+        }
+    ).sort_values("abs_coefficient", ascending=False).reset_index(drop=True)
+
+    metrics = {
+        "auc": auc,
+        "intercept": float(model.intercept_[0]),
+        "n_rows": float(len(ds)),
+        "positive_rate": float(ds["y_cross"].mean()),
+    }
+    return coef, metrics
+
+
+def build_family_summary(ds: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+    for cls in CLASS_ORDER:
+        sub = ds[ds["route_class"] == cls].copy()
+        if len(sub) == 0:
+            rows.append(
+                {
+                    "route_class": cls,
+                    "n_rows": 0,
+                    "crossing_rate": np.nan,
+                    "mean_relational_cross": np.nan,
+                    "mean_relational_internal": np.nan,
+                    "mean_anisotropy_cross": np.nan,
+                    "mean_anisotropy_internal": np.nan,
+                    "mean_distance_cross": np.nan,
+                    "mean_distance_internal": np.nan,
+                    "top_launch_generator_cross": np.nan,
+                    "top_launch_generator_internal": np.nan,
+                }
+            )
+            continue
+
+        pos = sub[sub["y_cross"] == 1]
+        neg = sub[sub["y_cross"] == 0]
+
+        rows.append(
+            {
+                "route_class": cls,
+                "n_rows": int(len(sub)),
+                "crossing_rate": float(sub["y_cross"].mean()),
+                "mean_relational_cross": safe_mean(pos["mean_relational"]),
+                "mean_relational_internal": safe_mean(neg["mean_relational"]),
+                "mean_anisotropy_cross": safe_mean(pos["mean_anisotropy"]),
+                "mean_anisotropy_internal": safe_mean(neg["mean_anisotropy"]),
+                "mean_distance_cross": safe_mean(pos["mean_distance"]),
+                "mean_distance_internal": safe_mean(neg["mean_distance"]),
+                "top_launch_generator_cross": pos["launch_generator"].value_counts().index[0] if len(pos) else np.nan,
+                "top_launch_generator_internal": neg["launch_generator"].value_counts().index[0] if len(neg) else np.nan,
+            }
+        )
+
+    out = pd.DataFrame(rows)
+    order = {k: i for i, k in enumerate(CLASS_ORDER)}
+    out["order"] = out["route_class"].map(lambda x: order.get(x, 999))
+    return out.sort_values("order").drop(columns="order").reset_index(drop=True)
+
+
+def build_summary(ds: pd.DataFrame, coef: pd.DataFrame, fam: pd.DataFrame, metrics: dict[str, float]) -> str:
+    lines = [
+        "=== OBS-035 Gateway Crossing Predictor Summary ===",
+        "",
+        f"n_rows = {int(metrics['n_rows'])}",
+        f"positive_rate = {metrics['positive_rate']:.4f}",
+        f"auc = {metrics['auc']:.4f}",
+        f"intercept = {metrics['intercept']:.6f}",
+        "",
+        "Interpretive guide",
+        "- positive class = core_to_escape crossing",
+        "- negative class = core_internal continuation",
+        "- positive coefficients increase crossing propensity",
+        "- negative coefficients favor remaining in the reversible core",
+        "",
+        "Top predictive features",
+    ]
+
+    for _, row in coef.head(12).iterrows():
+        lines.append(
+            f"  {row['feature']}: coef={row['coefficient']:.6f}"
+        )
+
+    lines.extend(["", "Family summaries"])
+    for _, row in fam.iterrows():
+        lines.extend(
+            [
+                f"{row['route_class']}",
+                f"  n_rows                    = {int(row['n_rows'])}",
+                f"  crossing_rate             = {float(row['crossing_rate']):.4f}",
+                f"  mean_relational_cross     = {float(row['mean_relational_cross']):.4f}",
+                f"  mean_relational_internal  = {float(row['mean_relational_internal']):.4f}",
+                f"  mean_anisotropy_cross     = {float(row['mean_anisotropy_cross']):.4f}",
+                f"  mean_anisotropy_internal  = {float(row['mean_anisotropy_internal']):.4f}",
+                f"  mean_distance_cross       = {float(row['mean_distance_cross']):.4f}",
+                f"  mean_distance_internal    = {float(row['mean_distance_internal']):.4f}",
+                f"  top_launch_generator_cross= {row['top_launch_generator_cross']}",
+                f"  top_launch_generator_internal= {row['top_launch_generator_internal']}",
+                "",
+            ]
+        )
+
+    return "\n".join(lines)
+
+
+def render_figure(ds: pd.DataFrame, coef: pd.DataFrame, fam: pd.DataFrame, metrics: dict[str, float], outpath: Path) -> None:
+    fig = plt.figure(figsize=(16.5, 10), constrained_layout=True)
+    gs = fig.add_gridspec(2, 3, width_ratios=[1.15, 1.15, 1.0], height_ratios=[1.0, 1.0])
+
+    ax_coef = fig.add_subplot(gs[0, 0])
+    ax_rates = fig.add_subplot(gs[0, 1])
+    ax_fields = fig.add_subplot(gs[0, 2])
+    ax_top = fig.add_subplot(gs[1, 0:2])
+    ax_diag = fig.add_subplot(gs[1, 2])
+
+    top = coef.head(10).iloc[::-1]
+    ax_coef.barh(np.arange(len(top)), top["coefficient"].to_numpy(dtype=float))
+    ax_coef.set_yticks(np.arange(len(top)))
+    ax_coef.set_yticklabels(top["feature"].tolist(), fontsize=8)
+    ax_coef.set_title("Top predictor coefficients", fontsize=14, pad=8)
+    ax_coef.grid(alpha=0.15, axis="x")
+
+    x = np.arange(len(fam))
+    ax_rates.bar(x, fam["crossing_rate"])
+    ax_rates.set_xticks(x)
+    ax_rates.set_xticklabels(fam["route_class"], rotation=12)
+    ax_rates.set_title("Core→escape crossing rate", fontsize=14, pad=8)
+    ax_rates.grid(alpha=0.15, axis="y")
+
+    width = 0.34
+    ax_fields.bar(x - width / 2, fam["mean_relational_cross"] - fam["mean_relational_internal"], width, label="Δ relational")
+    ax_fields.bar(x + width / 2, fam["mean_anisotropy_cross"] - fam["mean_anisotropy_internal"], width, label="Δ anisotropy")
+    ax_fields.set_xticks(x)
+    ax_fields.set_xticklabels(fam["route_class"], rotation=12)
+    ax_fields.set_title("Crossing minus internal field means", fontsize=14, pad=8)
+    ax_fields.grid(alpha=0.15, axis="y")
+    ax_fields.legend()
+
+    ax_top.axis("off")
+    y = 0.95
+    for _, row in fam.iterrows():
+        ax_top.text(0.02, y, str(row["route_class"]), fontsize=12, fontweight="bold")
+        y -= 0.06
+        ax_top.text(0.04, y, f"cross gen: {row['top_launch_generator_cross']}", fontsize=10, family="monospace")
+        y -= 0.045
+        ax_top.text(0.04, y, f"internal gen: {row['top_launch_generator_internal']}", fontsize=10, family="monospace")
+        y -= 0.045
+        ax_top.text(0.04, y, f"Δrel: {row['mean_relational_cross'] - row['mean_relational_internal']:.4f}", fontsize=10, family="monospace")
+        y -= 0.045
+        ax_top.text(0.04, y, f"Δaniso: {row['mean_anisotropy_cross'] - row['mean_anisotropy_internal']:.4f}", fontsize=10, family="monospace")
+        y -= 0.07
+    ax_top.set_title("Family gateway contrast", fontsize=14, pad=8)
+
+    ax_diag.axis("off")
+    text = (
+        "OBS-035 diagnostics\n\n"
+        f"AUC:\n{metrics['auc']:.3f}\n\n"
+        f"positive rate:\n{metrics['positive_rate']:.3f}\n\n"
+        "Interpretation:\n"
+        "this tests whether local\n"
+        "pre-gateway state predicts\n"
+        "conversion from reversible\n"
+        "core into directed escape."
+    )
+    ax_diag.text(
+        0.02, 0.98, text,
+        va="top", ha="left", fontsize=10.2, family="monospace",
+        bbox=dict(boxstyle="round,pad=0.35", fc="white", ec="0.85", alpha=0.95),
+    )
+
+    fig.suptitle("PAM Observatory — OBS-035 gateway crossing predictor", fontsize=21)
+    fig.savefig(outpath, dpi=220)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Predict core-to-escape gateway crossing from local state.")
+    parser.add_argument("--crossings-csv", default=Config.crossings_csv)
+    parser.add_argument("--assignments-csv", default=Config.assignments_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--min-rows-per-family", type=int, default=Config.min_rows_per_family)
+    parser.add_argument("--random-state", type=int, default=Config.random_state)
+    args = parser.parse_args()
+
+    cfg = Config(
+        crossings_csv=args.crossings_csv,
+        assignments_csv=args.assignments_csv,
+        outdir=args.outdir,
+        min_rows_per_family=args.min_rows_per_family,
+        random_state=args.random_state,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    crossings = load_csv(cfg.crossings_csv)
+    assignments = load_csv(cfg.assignments_csv)
+
+    ds = build_dataset(crossings, assignments)
+    coef, metrics = fit_logistic(ds)
+    fam = build_family_summary(ds)
+
+    ds_csv = outdir / "gateway_crossing_dataset.csv"
+    coef_csv = outdir / "gateway_crossing_coefficients.csv"
+    fam_csv = outdir / "gateway_crossing_family_summary.csv"
+    txt_path = outdir / "obs035_gateway_crossing_predictor_summary.txt"
+    png_path = outdir / "obs035_gateway_crossing_predictor_figure.png"
+
+    ds.to_csv(ds_csv, index=False)
+    coef.to_csv(coef_csv, index=False)
+    fam.to_csv(fam_csv, index=False)
+    txt_path.write_text(build_summary(ds, coef, fam, metrics), encoding="utf-8")
+    render_figure(ds, coef, fam, metrics, png_path)
+
+    print(ds_csv)
+    print(coef_csv)
+    print(fam_csv)
+    print(txt_path)
+    print(png_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/studies/obs035b_gateway_crossing_predictor_prelaunch.py
+++ b/experiments/studies/obs035b_gateway_crossing_predictor_prelaunch.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""
+OBS-035b — Pre-launch gateway crossing predictor.
+
+Purpose
+-------
+Build a true pre-gateway predictor for crossing from the reversible core into
+the directed escape sector.
+
+This corrects OBS-035 by removing post-crossing / downstream leakage.
+
+Prediction task
+---------------
+Given only launch-side information available BEFORE the second generator fires,
+predict whether a reversible-core launch composition will:
+
+- stay in the reversible core      (core_internal, y=0)
+- cross into directed escape       (core_to_escape, y=1)
+
+Inputs
+------
+outputs/obs034_core_to_escape_boundary/core_to_escape_crossings.csv
+outputs/obs030e_complete_generator_basis/completed_generator_assignments.csv
+
+Outputs
+-------
+outputs/obs035b_gateway_crossing_predictor_prelaunch/
+  gateway_crossing_prelaunch_dataset.csv
+  gateway_crossing_prelaunch_coefficients.csv
+  gateway_crossing_prelaunch_family_summary.csv
+  obs035b_gateway_crossing_predictor_prelaunch_summary.txt
+  obs035b_gateway_crossing_predictor_prelaunch_figure.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import roc_auc_score
+
+
+@dataclass(frozen=True)
+class Config:
+    crossings_csv: str = (
+        "outputs/obs034_core_to_escape_boundary/core_to_escape_crossings.csv"
+    )
+    assignments_csv: str = (
+        "outputs/obs030e_complete_generator_basis/completed_generator_assignments.csv"
+    )
+    outdir: str = "outputs/obs035b_gateway_crossing_predictor_prelaunch"
+    random_state: int = 42
+
+
+CLASS_ORDER = [
+    "branch_exit",
+    "stable_seam_corridor",
+    "reorganization_heavy",
+]
+
+
+TEXT_COLS = {
+    "route_class",
+    "generator_1",
+    "generator_2",
+    "src1",
+    "tgt1",
+    "src2",
+    "tgt2",
+    "sector_1",
+    "sector_2",
+    "crossing_type",
+    "composition_typed",
+    "motif",
+    "motif_class",
+    "state_a",
+    "state_b",
+    "state_c",
+    "state_a_red",
+    "state_b_red",
+    "state_c_red",
+    "generator_word",
+    "generator_completed",
+    "path_family",
+}
+
+
+def load_csv(path: str | Path) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    for col in df.columns:
+        if col not in TEXT_COLS:
+            try:
+                df[col] = pd.to_numeric(df[col], errors="coerce")
+            except Exception:
+                pass
+    return df
+
+
+def safe_mean(s: pd.Series | np.ndarray) -> float:
+    x = pd.to_numeric(pd.Series(s), errors="coerce")
+    return float(x.mean()) if x.notna().any() else float("nan")
+
+
+def build_launch_feature_map(assignments: pd.DataFrame) -> pd.DataFrame:
+    a = assignments.copy()
+    a["route_class"] = a["route_class"].astype(str)
+    a["generator_completed"] = a["generator_completed"].astype(str)
+
+    out = (
+        a.groupby(["route_class", "generator_completed"], as_index=False)
+        .agg(
+            n_rows=("generator_completed", "size"),
+            launch_state=("state_a_red", lambda s: s.mode().iloc[0] if len(s.mode()) else s.iloc[0]),
+            launch_target=("state_c_red", lambda s: s.mode().iloc[0] if len(s.mode()) else s.iloc[0]),
+            mean_relational=("relational_a", "mean") if "relational_a" in a.columns else ("generator_completed", "size"),
+            mean_anisotropy=("anisotropy_a", "mean") if "anisotropy_a" in a.columns else ("generator_completed", "size"),
+            mean_distance=("distance_a", "mean") if "distance_a" in a.columns else ("generator_completed", "size"),
+        )
+    )
+
+    if "relational_a" not in a.columns:
+        out["mean_relational"] = np.nan
+    if "anisotropy_a" not in a.columns:
+        out["mean_anisotropy"] = np.nan
+    if "distance_a" not in a.columns:
+        out["mean_distance"] = np.nan
+
+    return out
+
+
+def build_dataset(crossings: pd.DataFrame, assignments: pd.DataFrame) -> pd.DataFrame:
+    use = crossings[crossings["crossing_type"].isin(["core_internal", "core_to_escape"])].copy()
+    use["y_cross"] = (use["crossing_type"] == "core_to_escape").astype(int)
+
+    feat = build_launch_feature_map(assignments)
+
+    # Join ONLY launch-side info from generator_1
+    ds = use.merge(
+        feat,
+        left_on=["route_class", "generator_1"],
+        right_on=["route_class", "generator_completed"],
+        how="left",
+        suffixes=("", "_feat"),
+    )
+
+    ds["launch_generator"] = ds["generator_1"].astype(str)
+
+    keep = [
+        "route_class",
+        "crossing_type",
+        "y_cross",
+        "n_compositions",
+        "composition_share",
+        "launch_generator",
+        "launch_state",
+        "launch_target",
+        "mean_relational",
+        "mean_anisotropy",
+        "mean_distance",
+        "composition_typed",
+    ]
+    return ds[keep].copy()
+
+
+def fit_logistic(ds: pd.DataFrame) -> tuple[pd.DataFrame, dict[str, float]]:
+    X = ds.copy()
+
+    for col in ["mean_relational", "mean_anisotropy", "mean_distance"]:
+        X[col] = pd.to_numeric(X[col], errors="coerce")
+        X[col] = X[col].fillna(X[col].median() if X[col].notna().any() else 0.0)
+
+    design = pd.get_dummies(
+        X[[
+            "route_class",
+            "launch_generator",
+            "launch_state",
+            "launch_target",
+            "mean_relational",
+            "mean_anisotropy",
+            "mean_distance",
+        ]],
+        columns=["route_class", "launch_generator", "launch_state", "launch_target"],
+        drop_first=False,
+        dtype=float,
+    )
+
+    y = ds["y_cross"].to_numpy(dtype=int)
+    sample_weight = pd.to_numeric(ds["n_compositions"], errors="coerce").fillna(1.0).to_numpy(dtype=float)
+
+    model = LogisticRegression(
+        penalty="l2",
+        solver="liblinear",
+        random_state=42,
+        max_iter=2000,
+    )
+    model.fit(design.to_numpy(dtype=float), y, sample_weight=sample_weight)
+
+    probs = model.predict_proba(design.to_numpy(dtype=float))[:, 1]
+    auc = float(roc_auc_score(y, probs, sample_weight=sample_weight)) if len(np.unique(y)) > 1 else float("nan")
+
+    coef = pd.DataFrame(
+        {
+            "feature": design.columns,
+            "coefficient": model.coef_[0],
+            "abs_coefficient": np.abs(model.coef_[0]),
+        }
+    ).sort_values("abs_coefficient", ascending=False).reset_index(drop=True)
+
+    metrics = {
+        "auc": auc,
+        "intercept": float(model.intercept_[0]),
+        "n_rows": float(len(ds)),
+        "positive_rate": float(ds["y_cross"].mean()),
+    }
+    return coef, metrics
+
+
+def build_family_summary(ds: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+    for cls in CLASS_ORDER:
+        sub = ds[ds["route_class"] == cls].copy()
+        pos = sub[sub["y_cross"] == 1]
+        neg = sub[sub["y_cross"] == 0]
+
+        rows.append(
+            {
+                "route_class": cls,
+                "n_rows": int(len(sub)),
+                "crossing_rate": float(sub["y_cross"].mean()) if len(sub) else float("nan"),
+                "mean_relational_cross": safe_mean(pos["mean_relational"]),
+                "mean_relational_internal": safe_mean(neg["mean_relational"]),
+                "mean_anisotropy_cross": safe_mean(pos["mean_anisotropy"]),
+                "mean_anisotropy_internal": safe_mean(neg["mean_anisotropy"]),
+                "mean_distance_cross": safe_mean(pos["mean_distance"]),
+                "mean_distance_internal": safe_mean(neg["mean_distance"]),
+                "top_launch_generator_cross": pos["launch_generator"].value_counts().index[0] if len(pos) else np.nan,
+                "top_launch_generator_internal": neg["launch_generator"].value_counts().index[0] if len(neg) else np.nan,
+            }
+        )
+
+    out = pd.DataFrame(rows)
+    order = {k: i for i, k in enumerate(CLASS_ORDER)}
+    out["order"] = out["route_class"].map(lambda x: order.get(x, 999))
+    return out.sort_values("order").drop(columns=["order"]).reset_index(drop=True)
+
+
+def build_summary(ds: pd.DataFrame, coef: pd.DataFrame, fam: pd.DataFrame, metrics: dict[str, float]) -> str:
+    lines = [
+        "=== OBS-035b Gateway Crossing Predictor (Prelaunch) Summary ===",
+        "",
+        f"n_rows = {int(metrics['n_rows'])}",
+        f"positive_rate = {metrics['positive_rate']:.4f}",
+        f"auc = {metrics['auc']:.4f}",
+        f"intercept = {metrics['intercept']:.6f}",
+        "",
+        "Discipline",
+        "- positive class = core_to_escape crossing",
+        "- negative class = core_internal continuation",
+        "- uses only launch-side information",
+        "- excludes next-generator / post-crossing leakage",
+        "",
+        "Top predictive features",
+    ]
+
+    for _, row in coef.head(12).iterrows():
+        lines.append(f"  {row['feature']}: coef={row['coefficient']:.6f}")
+
+    lines.extend(["", "Family summaries"])
+    for _, row in fam.iterrows():
+        lines.extend(
+            [
+                f"{row['route_class']}",
+                f"  n_rows                     = {int(row['n_rows'])}",
+                f"  crossing_rate              = {float(row['crossing_rate']):.4f}",
+                f"  mean_relational_cross      = {float(row['mean_relational_cross']):.4f}",
+                f"  mean_relational_internal   = {float(row['mean_relational_internal']):.4f}",
+                f"  mean_anisotropy_cross      = {float(row['mean_anisotropy_cross']):.4f}",
+                f"  mean_anisotropy_internal   = {float(row['mean_anisotropy_internal']):.4f}",
+                f"  mean_distance_cross        = {float(row['mean_distance_cross']):.4f}",
+                f"  mean_distance_internal     = {float(row['mean_distance_internal']):.4f}",
+                f"  top_launch_generator_cross = {row['top_launch_generator_cross']}",
+                f"  top_launch_generator_internal = {row['top_launch_generator_internal']}",
+                "",
+            ]
+        )
+
+    return "\n".join(lines)
+
+
+def render_figure(ds: pd.DataFrame, coef: pd.DataFrame, fam: pd.DataFrame, metrics: dict[str, float], outpath: Path) -> None:
+    fig = plt.figure(figsize=(16.5, 10), constrained_layout=True)
+    gs = fig.add_gridspec(2, 3, width_ratios=[1.15, 1.15, 1.0], height_ratios=[1.0, 1.0])
+
+    ax_coef = fig.add_subplot(gs[0, 0])
+    ax_rates = fig.add_subplot(gs[0, 1])
+    ax_fields = fig.add_subplot(gs[0, 2])
+    ax_top = fig.add_subplot(gs[1, 0:2])
+    ax_diag = fig.add_subplot(gs[1, 2])
+
+    top = coef.head(10).iloc[::-1]
+    ax_coef.barh(np.arange(len(top)), top["coefficient"].to_numpy(dtype=float))
+    ax_coef.set_yticks(np.arange(len(top)))
+    ax_coef.set_yticklabels(top["feature"].tolist(), fontsize=8)
+    ax_coef.set_title("Top prelaunch predictor coefficients", fontsize=14, pad=8)
+    ax_coef.grid(alpha=0.15, axis="x")
+
+    x = np.arange(len(fam))
+    ax_rates.bar(x, fam["crossing_rate"])
+    ax_rates.set_xticks(x)
+    ax_rates.set_xticklabels(fam["route_class"], rotation=12)
+    ax_rates.set_title("Core→escape crossing rate", fontsize=14, pad=8)
+    ax_rates.grid(alpha=0.15, axis="y")
+
+    width = 0.34
+    ax_fields.bar(x - width / 2, fam["mean_relational_cross"] - fam["mean_relational_internal"], width, label="Δ relational")
+    ax_fields.bar(x + width / 2, fam["mean_anisotropy_cross"] - fam["mean_anisotropy_internal"], width, label="Δ anisotropy")
+    ax_fields.set_xticks(x)
+    ax_fields.set_xticklabels(fam["route_class"], rotation=12)
+    ax_fields.set_title("Crossing minus internal launch fields", fontsize=14, pad=8)
+    ax_fields.grid(alpha=0.15, axis="y")
+    ax_fields.legend()
+
+    ax_top.axis("off")
+    y = 0.95
+    for _, row in fam.iterrows():
+        ax_top.text(0.02, y, str(row["route_class"]), fontsize=12, fontweight="bold")
+        y -= 0.06
+        ax_top.text(0.04, y, f"cross gen: {row['top_launch_generator_cross']}", fontsize=10, family="monospace")
+        y -= 0.045
+        ax_top.text(0.04, y, f"internal gen: {row['top_launch_generator_internal']}", fontsize=10, family="monospace")
+        y -= 0.045
+        ax_top.text(0.04, y, f"Δrel: {row['mean_relational_cross'] - row['mean_relational_internal']:.4f}", fontsize=10, family="monospace")
+        y -= 0.045
+        ax_top.text(0.04, y, f"Δaniso: {row['mean_anisotropy_cross'] - row['mean_anisotropy_internal']:.4f}", fontsize=10, family="monospace")
+        y -= 0.07
+    ax_top.set_title("Family launch-side contrast", fontsize=14, pad=8)
+
+    ax_diag.axis("off")
+    text = (
+        "OBS-035b diagnostics\n\n"
+        f"AUC:\n{metrics['auc']:.3f}\n\n"
+        f"positive rate:\n{metrics['positive_rate']:.3f}\n\n"
+        "Interpretation:\n"
+        "this tests whether the\n"
+        "launch-side state alone\n"
+        "predicts conversion from\n"
+        "core into escape."
+    )
+    ax_diag.text(
+        0.02, 0.98, text,
+        va="top", ha="left", fontsize=10.2, family="monospace",
+        bbox=dict(boxstyle="round,pad=0.35", fc="white", ec="0.85", alpha=0.95),
+    )
+
+    fig.suptitle("PAM Observatory — OBS-035b prelaunch gateway crossing predictor", fontsize=21)
+    fig.savefig(outpath, dpi=220)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Predict core-to-escape crossing from prelaunch state only.")
+    parser.add_argument("--crossings-csv", default=Config.crossings_csv)
+    parser.add_argument("--assignments-csv", default=Config.assignments_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--random-state", type=int, default=Config.random_state)
+    args = parser.parse_args()
+
+    cfg = Config(
+        crossings_csv=args.crossings_csv,
+        assignments_csv=args.assignments_csv,
+        outdir=args.outdir,
+        random_state=args.random_state,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    crossings = load_csv(cfg.crossings_csv)
+    assignments = load_csv(cfg.assignments_csv)
+
+    ds = build_dataset(crossings, assignments)
+    coef, metrics = fit_logistic(ds)
+    fam = build_family_summary(ds)
+
+    ds_csv = outdir / "gateway_crossing_prelaunch_dataset.csv"
+    coef_csv = outdir / "gateway_crossing_prelaunch_coefficients.csv"
+    fam_csv = outdir / "gateway_crossing_prelaunch_family_summary.csv"
+    txt_path = outdir / "obs035b_gateway_crossing_predictor_prelaunch_summary.txt"
+    png_path = outdir / "obs035b_gateway_crossing_predictor_prelaunch_figure.png"
+
+    ds.to_csv(ds_csv, index=False)
+    coef.to_csv(coef_csv, index=False)
+    fam.to_csv(fam_csv, index=False)
+    txt_path.write_text(build_summary(ds, coef, fam, metrics), encoding="utf-8")
+    render_figure(ds, coef, fam, metrics, png_path)
+
+    print(ds_csv)
+    print(coef_csv)
+    print(fam_csv)
+    print(txt_path)
+    print(png_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/studies/obs035c_instance_level_gateway_predictor.py
+++ b/experiments/studies/obs035c_instance_level_gateway_predictor.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python3
+"""
+OBS-035c — Instance-level gateway crossing predictor.
+
+Purpose
+-------
+Upgrade OBS-035b from coarse family/generator averages to an instance-level
+launch dataset.
+
+This study builds one row per actual launch composition instance and predicts:
+
+    y = 1  if the launch becomes a core_to_escape crossing
+    y = 0  if the launch remains core_internal
+
+The key difference from OBS-035b is that local launch features are taken from
+the specific launch-side generator instance, rather than from an aggregated
+family+generator profile.
+
+Inputs
+------
+outputs/obs034_core_to_escape_boundary/core_to_escape_crossings.csv
+outputs/obs030e_complete_generator_basis/completed_generator_assignments.csv
+
+Outputs
+-------
+outputs/obs035c_instance_level_gateway_predictor/
+  gateway_crossing_instance_dataset.csv
+  gateway_crossing_instance_coefficients.csv
+  gateway_crossing_instance_family_summary.csv
+  obs035c_instance_level_gateway_predictor_summary.txt
+  obs035c_instance_level_gateway_predictor_figure.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import roc_auc_score
+
+
+@dataclass(frozen=True)
+class Config:
+    crossings_csv: str = (
+        "outputs/obs034_core_to_escape_boundary/core_to_escape_crossings.csv"
+    )
+    assignments_csv: str = (
+        "outputs/obs030e_complete_generator_basis/completed_generator_assignments.csv"
+    )
+    outdir: str = "outputs/obs035c_instance_level_gateway_predictor"
+    random_state: int = 42
+
+
+CLASS_ORDER = [
+    "branch_exit",
+    "stable_seam_corridor",
+    "reorganization_heavy",
+]
+
+TEXT_COLS = {
+    "route_class",
+    "generator_1",
+    "generator_2",
+    "src1",
+    "tgt1",
+    "src2",
+    "tgt2",
+    "sector_1",
+    "sector_2",
+    "crossing_type",
+    "composition_typed",
+    "motif",
+    "motif_class",
+    "state_a",
+    "state_b",
+    "state_c",
+    "state_a_red",
+    "state_b_red",
+    "state_c_red",
+    "generator_word",
+    "generator_completed",
+    "path_family",
+}
+
+
+def load_csv(path: str | Path) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    for col in df.columns:
+        if col not in TEXT_COLS:
+            try:
+                df[col] = pd.to_numeric(df[col], errors="coerce")
+            except Exception:
+                pass
+    return df
+
+
+def safe_mean(s: pd.Series | np.ndarray) -> float:
+    x = pd.to_numeric(pd.Series(s), errors="coerce")
+    return float(x.mean()) if x.notna().any() else float("nan")
+
+
+def build_assignment_instance_table(assignments: pd.DataFrame) -> pd.DataFrame:
+    a = assignments.copy()
+    a["route_class"] = a["route_class"].astype(str)
+    a["generator_completed"] = a["generator_completed"].astype(str)
+
+    # Keep one row per actual motif/generator instance.
+    out = pd.DataFrame(
+        {
+            "route_class": a["route_class"],
+            "launch_generator": a["generator_completed"],
+            "launch_state": a["state_a_red"].astype(str),
+            "launch_target": a["state_c_red"].astype(str),
+            "mean_relational": pd.to_numeric(a.get("relational_a", np.nan), errors="coerce"),
+            "mean_anisotropy": pd.to_numeric(a.get("anisotropy_a", np.nan), errors="coerce"),
+            "mean_distance": pd.to_numeric(a.get("distance_a", np.nan), errors="coerce"),
+        }
+    )
+    return out
+
+
+def build_dataset(crossings: pd.DataFrame, assignments: pd.DataFrame) -> pd.DataFrame:
+    use = crossings[crossings["crossing_type"].isin(["core_internal", "core_to_escape"])].copy()
+    use["y_cross"] = (use["crossing_type"] == "core_to_escape").astype(int)
+
+    inst = build_assignment_instance_table(assignments)
+
+    rows = []
+    for _, row in use.iterrows():
+        cls = str(row["route_class"])
+        launch_gen = str(row["generator_1"])
+        launch_src = str(row["src1"])
+        launch_tgt = str(row["tgt1"])
+
+        pool = inst[
+            (inst["route_class"] == cls)
+            & (inst["launch_generator"] == launch_gen)
+            & (inst["launch_state"] == launch_src)
+            & (inst["launch_target"] == launch_tgt)
+        ].copy()
+
+        if len(pool) == 0:
+            # fallback to family+generator only
+            pool = inst[
+                (inst["route_class"] == cls)
+                & (inst["launch_generator"] == launch_gen)
+            ].copy()
+
+        if len(pool) == 0:
+            continue
+
+        # replicate by integer composition count for a true instance-level dataset
+        n_rep = int(round(float(row["n_compositions"]))) if pd.notna(row["n_compositions"]) else 1
+        n_rep = max(n_rep, 1)
+
+        sampled = pool.sample(
+            n=n_rep,
+            replace=(len(pool) < n_rep),
+            random_state=42,
+        )
+
+        for _, srow in sampled.iterrows():
+            rows.append(
+                {
+                    "route_class": cls,
+                    "crossing_type": str(row["crossing_type"]),
+                    "y_cross": int(row["y_cross"]),
+                    "launch_generator": str(srow["launch_generator"]),
+                    "launch_state": str(srow["launch_state"]),
+                    "launch_target": str(srow["launch_target"]),
+                    "mean_relational": srow["mean_relational"],
+                    "mean_anisotropy": srow["mean_anisotropy"],
+                    "mean_distance": srow["mean_distance"],
+                    "composition_typed": row.get("composition_typed", np.nan),
+                }
+            )
+
+    return pd.DataFrame(rows)
+
+
+def fit_logistic(ds: pd.DataFrame) -> tuple[pd.DataFrame, dict[str, float]]:
+    X = ds.copy()
+
+    for col in ["mean_relational", "mean_anisotropy", "mean_distance"]:
+        X[col] = pd.to_numeric(X[col], errors="coerce")
+        X[col] = X[col].fillna(X[col].median() if X[col].notna().any() else 0.0)
+
+    design = pd.get_dummies(
+        X[
+            [
+                "route_class",
+                "launch_generator",
+                "launch_state",
+                "launch_target",
+                "mean_relational",
+                "mean_anisotropy",
+                "mean_distance",
+            ]
+        ],
+        columns=["route_class", "launch_generator", "launch_state", "launch_target"],
+        drop_first=False,
+        dtype=float,
+    )
+
+    y = ds["y_cross"].to_numpy(dtype=int)
+
+    model = LogisticRegression(
+        penalty="l2",
+        solver="liblinear",
+        random_state=42,
+        max_iter=2000,
+    )
+    model.fit(design.to_numpy(dtype=float), y)
+
+    probs = model.predict_proba(design.to_numpy(dtype=float))[:, 1]
+    auc = float(roc_auc_score(y, probs)) if len(np.unique(y)) > 1 else float("nan")
+
+    coef = pd.DataFrame(
+        {
+            "feature": design.columns,
+            "coefficient": model.coef_[0],
+            "abs_coefficient": np.abs(model.coef_[0]),
+        }
+    ).sort_values("abs_coefficient", ascending=False).reset_index(drop=True)
+
+    metrics = {
+        "auc": auc,
+        "intercept": float(model.intercept_[0]),
+        "n_rows": float(len(ds)),
+        "positive_rate": float(ds["y_cross"].mean()),
+    }
+    return coef, metrics
+
+
+def build_family_summary(ds: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+    for cls in CLASS_ORDER:
+        sub = ds[ds["route_class"] == cls].copy()
+        pos = sub[sub["y_cross"] == 1]
+        neg = sub[sub["y_cross"] == 0]
+
+        rows.append(
+            {
+                "route_class": cls,
+                "n_rows": int(len(sub)),
+                "crossing_rate": float(sub["y_cross"].mean()) if len(sub) else float("nan"),
+                "mean_relational_cross": safe_mean(pos["mean_relational"]),
+                "mean_relational_internal": safe_mean(neg["mean_relational"]),
+                "mean_anisotropy_cross": safe_mean(pos["mean_anisotropy"]),
+                "mean_anisotropy_internal": safe_mean(neg["mean_anisotropy"]),
+                "mean_distance_cross": safe_mean(pos["mean_distance"]),
+                "mean_distance_internal": safe_mean(neg["mean_distance"]),
+                "top_launch_generator_cross": pos["launch_generator"].value_counts().index[0] if len(pos) else np.nan,
+                "top_launch_generator_internal": neg["launch_generator"].value_counts().index[0] if len(neg) else np.nan,
+            }
+        )
+
+    out = pd.DataFrame(rows)
+    order = {k: i for i, k in enumerate(CLASS_ORDER)}
+    out["order"] = out["route_class"].map(lambda x: order.get(x, 999))
+    return out.sort_values("order").drop(columns=["order"]).reset_index(drop=True)
+
+
+def build_summary(ds: pd.DataFrame, coef: pd.DataFrame, fam: pd.DataFrame, metrics: dict[str, float]) -> str:
+    lines = [
+        "=== OBS-035c Instance-Level Gateway Crossing Predictor Summary ===",
+        "",
+        f"n_rows = {int(metrics['n_rows'])}",
+        f"positive_rate = {metrics['positive_rate']:.4f}",
+        f"auc = {metrics['auc']:.4f}",
+        f"intercept = {metrics['intercept']:.6f}",
+        "",
+        "Discipline",
+        "- positive class = core_to_escape crossing",
+        "- negative class = core_internal continuation",
+        "- uses only launch-side information",
+        "- one row per sampled launch instance",
+        "- excludes next-generator / post-crossing leakage",
+        "",
+        "Top predictive features",
+    ]
+
+    for _, row in coef.head(12).iterrows():
+        lines.append(f"  {row['feature']}: coef={row['coefficient']:.6f}")
+
+    lines.extend(["", "Family summaries"])
+    for _, row in fam.iterrows():
+        lines.extend(
+            [
+                f"{row['route_class']}",
+                f"  n_rows                     = {int(row['n_rows'])}",
+                f"  crossing_rate              = {float(row['crossing_rate']):.4f}",
+                f"  mean_relational_cross      = {float(row['mean_relational_cross']):.4f}",
+                f"  mean_relational_internal   = {float(row['mean_relational_internal']):.4f}",
+                f"  mean_anisotropy_cross      = {float(row['mean_anisotropy_cross']):.4f}",
+                f"  mean_anisotropy_internal   = {float(row['mean_anisotropy_internal']):.4f}",
+                f"  mean_distance_cross        = {float(row['mean_distance_cross']):.4f}",
+                f"  mean_distance_internal     = {float(row['mean_distance_internal']):.4f}",
+                f"  top_launch_generator_cross = {row['top_launch_generator_cross']}",
+                f"  top_launch_generator_internal = {row['top_launch_generator_internal']}",
+                "",
+            ]
+        )
+
+    return "\n".join(lines)
+
+
+def render_figure(ds: pd.DataFrame, coef: pd.DataFrame, fam: pd.DataFrame, metrics: dict[str, float], outpath: Path) -> None:
+    fig = plt.figure(figsize=(16.5, 10), constrained_layout=True)
+    gs = fig.add_gridspec(2, 3, width_ratios=[1.15, 1.15, 1.0], height_ratios=[1.0, 1.0])
+
+    ax_coef = fig.add_subplot(gs[0, 0])
+    ax_rates = fig.add_subplot(gs[0, 1])
+    ax_fields = fig.add_subplot(gs[0, 2])
+    ax_top = fig.add_subplot(gs[1, 0:2])
+    ax_diag = fig.add_subplot(gs[1, 2])
+
+    top = coef.head(10).iloc[::-1]
+    ax_coef.barh(np.arange(len(top)), top["coefficient"].to_numpy(dtype=float))
+    ax_coef.set_yticks(np.arange(len(top)))
+    ax_coef.set_yticklabels(top["feature"].tolist(), fontsize=8)
+    ax_coef.set_title("Top instance-level predictor coefficients", fontsize=14, pad=8)
+    ax_coef.grid(alpha=0.15, axis="x")
+
+    x = np.arange(len(fam))
+    ax_rates.bar(x, fam["crossing_rate"])
+    ax_rates.set_xticks(x)
+    ax_rates.set_xticklabels(fam["route_class"], rotation=12)
+    ax_rates.set_title("Core→escape crossing rate", fontsize=14, pad=8)
+    ax_rates.grid(alpha=0.15, axis="y")
+
+    width = 0.34
+    ax_fields.bar(x - width / 2, fam["mean_relational_cross"] - fam["mean_relational_internal"], width, label="Δ relational")
+    ax_fields.bar(x + width / 2, fam["mean_anisotropy_cross"] - fam["mean_anisotropy_internal"], width, label="Δ anisotropy")
+    ax_fields.set_xticks(x)
+    ax_fields.set_xticklabels(fam["route_class"], rotation=12)
+    ax_fields.set_title("Crossing minus internal launch fields", fontsize=14, pad=8)
+    ax_fields.grid(alpha=0.15, axis="y")
+    ax_fields.legend()
+
+    ax_top.axis("off")
+    y = 0.95
+    for _, row in fam.iterrows():
+        ax_top.text(0.02, y, str(row["route_class"]), fontsize=12, fontweight="bold")
+        y -= 0.06
+        ax_top.text(0.04, y, f"cross gen: {row['top_launch_generator_cross']}", fontsize=10, family="monospace")
+        y -= 0.045
+        ax_top.text(0.04, y, f"internal gen: {row['top_launch_generator_internal']}", fontsize=10, family="monospace")
+        y -= 0.045
+        ax_top.text(0.04, y, f"Δrel: {row['mean_relational_cross'] - row['mean_relational_internal']:.4f}", fontsize=10, family="monospace")
+        y -= 0.045
+        ax_top.text(0.04, y, f"Δaniso: {row['mean_anisotropy_cross'] - row['mean_anisotropy_internal']:.4f}", fontsize=10, family="monospace")
+        y -= 0.07
+    ax_top.set_title("Family launch-side contrast", fontsize=14, pad=8)
+
+    ax_diag.axis("off")
+    text = (
+        "OBS-035c diagnostics\n\n"
+        f"AUC:\n{metrics['auc']:.3f}\n\n"
+        f"positive rate:\n{metrics['positive_rate']:.3f}\n\n"
+        "Interpretation:\n"
+        "this tests whether exact\n"
+        "launch-side instances carry\n"
+        "predictive signal for\n"
+        "gateway crossing."
+    )
+    ax_diag.text(
+        0.02, 0.98, text,
+        va="top", ha="left", fontsize=10.2, family="monospace",
+        bbox=dict(boxstyle="round,pad=0.35", fc="white", ec="0.85", alpha=0.95),
+    )
+
+    fig.suptitle("PAM Observatory — OBS-035c instance-level gateway predictor", fontsize=21)
+    fig.savefig(outpath, dpi=220)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Predict core-to-escape crossing from instance-level launch state.")
+    parser.add_argument("--crossings-csv", default=Config.crossings_csv)
+    parser.add_argument("--assignments-csv", default=Config.assignments_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--random-state", type=int, default=Config.random_state)
+    args = parser.parse_args()
+
+    cfg = Config(
+        crossings_csv=args.crossings_csv,
+        assignments_csv=args.assignments_csv,
+        outdir=args.outdir,
+        random_state=args.random_state,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    crossings = load_csv(cfg.crossings_csv)
+    assignments = load_csv(cfg.assignments_csv)
+
+    ds = build_dataset(crossings, assignments)
+    coef, metrics = fit_logistic(ds)
+    fam = build_family_summary(ds)
+
+    ds_csv = outdir / "gateway_crossing_instance_dataset.csv"
+    coef_csv = outdir / "gateway_crossing_instance_coefficients.csv"
+    fam_csv = outdir / "gateway_crossing_instance_family_summary.csv"
+    txt_path = outdir / "obs035c_instance_level_gateway_predictor_summary.txt"
+    png_path = outdir / "obs035c_instance_level_gateway_predictor_figure.png"
+
+    ds.to_csv(ds_csv, index=False)
+    coef.to_csv(coef_csv, index=False)
+    fam.to_csv(fam_csv, index=False)
+    txt_path.write_text(build_summary(ds, coef, fam, metrics), encoding="utf-8")
+    render_figure(ds, coef, fam, metrics, png_path)
+
+    print(ds_csv)
+    print(coef_csv)
+    print(fam_csv)
+    print(txt_path)
+    print(png_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/studies/obs036_gateway_state_refinement.py
+++ b/experiments/studies/obs036_gateway_state_refinement.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+"""
+OBS-036 — Gateway state refinement.
+
+Purpose
+-------
+Refine the launch-side state alphabet near the reversible-core / directed-escape
+boundary.
+
+OBS-035c showed that gateway crossing is weakly predictable from:
+- launch generator / state type
+- modest anisotropy signal
+
+This suggests the current reduced state alphabet {R, A, L} is still too coarse
+near the gateway.
+
+This study builds a refined launch-state partition by splitting launch instances
+using local continuous fields, then tests whether the refined state labels
+improve boundary prediction.
+
+Core idea
+---------
+Starting from instance-level launch rows:
+- split the low state L into low_aniso / low_rel / low_balanced
+- split flank states by local anisotropy intensity and relational intensity
+- compare predictive performance of:
+    1. coarse state alphabet
+    2. refined state alphabet
+
+Inputs
+------
+outputs/obs035c_instance_level_gateway_predictor/gateway_crossing_instance_dataset.csv
+
+Outputs
+-------
+outputs/obs036_gateway_state_refinement/
+  gateway_state_refined_dataset.csv
+  gateway_state_refined_coefficients.csv
+  gateway_state_refined_family_summary.csv
+  obs036_gateway_state_refinement_summary.txt
+  obs036_gateway_state_refinement_figure.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import roc_auc_score
+
+
+@dataclass(frozen=True)
+class Config:
+    dataset_csv: str = (
+        "outputs/obs035c_instance_level_gateway_predictor/"
+        "gateway_crossing_instance_dataset.csv"
+    )
+    outdir: str = "outputs/obs036_gateway_state_refinement"
+    random_state: int = 42
+    aniso_quantile: float = 0.67
+    rel_quantile: float = 0.67
+
+
+CLASS_ORDER = [
+    "branch_exit",
+    "stable_seam_corridor",
+    "reorganization_heavy",
+]
+
+TEXT_COLS = {
+    "route_class",
+    "crossing_type",
+    "launch_generator",
+    "launch_state",
+    "launch_target",
+    "composition_typed",
+}
+
+
+def load_csv(path: str | Path) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    for col in df.columns:
+        if col not in TEXT_COLS:
+            try:
+                df[col] = pd.to_numeric(df[col], errors="coerce")
+            except Exception:
+                pass
+    return df
+
+
+def safe_mean(s: pd.Series | np.ndarray) -> float:
+    x = pd.to_numeric(pd.Series(s), errors="coerce")
+    return float(x.mean()) if x.notna().any() else float("nan")
+
+
+def build_refined_state(
+    launch_state: str,
+    aniso: float,
+    rel: float,
+    aniso_hi: float,
+    rel_hi: float,
+) -> str:
+    if pd.isna(aniso):
+        aniso = 0.0
+    if pd.isna(rel):
+        rel = 0.0
+
+    state = str(launch_state)
+
+    if state == "L":
+        if aniso >= aniso_hi and rel < rel_hi:
+            return "L_aniso"
+        if rel >= rel_hi and aniso < aniso_hi:
+            return "L_rel"
+        if aniso >= aniso_hi and rel >= rel_hi:
+            return "L_hot"
+        return "L_balanced"
+
+    if state == "A":
+        if aniso >= aniso_hi:
+            return "A_hot"
+        if rel >= rel_hi:
+            return "A_rel_tilt"
+        return "A_base"
+
+    if state == "R":
+        if rel >= rel_hi:
+            return "R_hot"
+        if aniso >= aniso_hi:
+            return "R_aniso_tilt"
+        return "R_base"
+
+    return state
+
+
+def add_refined_states(ds: pd.DataFrame, cfg: Config) -> pd.DataFrame:
+    out = ds.copy()
+
+    aniso = pd.to_numeric(out["mean_anisotropy"], errors="coerce")
+    rel = pd.to_numeric(out["mean_relational"], errors="coerce")
+
+    aniso_hi = float(aniso.quantile(cfg.aniso_quantile)) if aniso.notna().any() else 0.0
+    rel_hi = float(rel.quantile(cfg.rel_quantile)) if rel.notna().any() else 0.0
+
+    out["launch_state_refined"] = [
+        build_refined_state(s, a, r, aniso_hi, rel_hi)
+        for s, a, r in zip(out["launch_state"], aniso, rel)
+    ]
+    out["launch_target_refined"] = [
+        build_refined_state(s, a, r, aniso_hi, rel_hi)
+        for s, a, r in zip(out["launch_target"], aniso, rel)
+    ]
+    out["aniso_high"] = (aniso >= aniso_hi).astype(int)
+    out["rel_high"] = (rel >= rel_hi).astype(int)
+    out["aniso_hi_threshold"] = aniso_hi
+    out["rel_hi_threshold"] = rel_hi
+    return out
+
+
+def fit_model(
+    ds: pd.DataFrame,
+    *,
+    use_refined_states: bool,
+) -> tuple[pd.DataFrame, dict[str, float]]:
+    X = ds.copy()
+
+    for col in ["mean_relational", "mean_anisotropy", "mean_distance"]:
+        X[col] = pd.to_numeric(X[col], errors="coerce")
+        X[col] = X[col].fillna(X[col].median() if X[col].notna().any() else 0.0)
+
+    state_col = "launch_state_refined" if use_refined_states else "launch_state"
+    target_col = "launch_target_refined" if use_refined_states else "launch_target"
+
+    design = pd.get_dummies(
+        X[
+            [
+                "route_class",
+                "launch_generator",
+                state_col,
+                target_col,
+                "aniso_high",
+                "rel_high",
+                "mean_relational",
+                "mean_anisotropy",
+                "mean_distance",
+            ]
+        ],
+        columns=["route_class", "launch_generator", state_col, target_col],
+        drop_first=False,
+        dtype=float,
+    )
+
+    y = X["y_cross"].to_numpy(dtype=int)
+
+    model = LogisticRegression(
+        penalty="l2",
+        solver="liblinear",
+        random_state=42,
+        max_iter=3000,
+    )
+    model.fit(design.to_numpy(dtype=float), y)
+
+    probs = model.predict_proba(design.to_numpy(dtype=float))[:, 1]
+    auc = float(roc_auc_score(y, probs)) if len(np.unique(y)) > 1 else float("nan")
+
+    coef = pd.DataFrame(
+        {
+            "feature": design.columns,
+            "coefficient": model.coef_[0],
+            "abs_coefficient": np.abs(model.coef_[0]),
+            "model": "refined" if use_refined_states else "coarse",
+        }
+    ).sort_values("abs_coefficient", ascending=False).reset_index(drop=True)
+
+    metrics = {
+        "auc": auc,
+        "intercept": float(model.intercept_[0]),
+        "n_rows": float(len(ds)),
+        "positive_rate": float(ds["y_cross"].mean()),
+        "model": "refined" if use_refined_states else "coarse",
+    }
+    return coef, metrics
+
+
+def build_family_summary(ds: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+    for cls in CLASS_ORDER:
+        sub = ds[ds["route_class"] == cls].copy()
+        pos = sub[sub["y_cross"] == 1]
+        neg = sub[sub["y_cross"] == 0]
+
+        rows.append(
+            {
+                "route_class": cls,
+                "n_rows": int(len(sub)),
+                "crossing_rate": float(sub["y_cross"].mean()) if len(sub) else float("nan"),
+                "top_refined_state_cross": pos["launch_state_refined"].value_counts().index[0] if len(pos) else np.nan,
+                "top_refined_state_internal": neg["launch_state_refined"].value_counts().index[0] if len(neg) else np.nan,
+                "mean_relational_cross": safe_mean(pos["mean_relational"]),
+                "mean_relational_internal": safe_mean(neg["mean_relational"]),
+                "mean_anisotropy_cross": safe_mean(pos["mean_anisotropy"]),
+                "mean_anisotropy_internal": safe_mean(neg["mean_anisotropy"]),
+            }
+        )
+
+    out = pd.DataFrame(rows)
+    order = {k: i for i, k in enumerate(CLASS_ORDER)}
+    out["order"] = out["route_class"].map(lambda x: order.get(x, 999))
+    return out.sort_values("order").drop(columns=["order"]).reset_index(drop=True)
+
+
+def build_summary(
+    ds: pd.DataFrame,
+    coef_all: pd.DataFrame,
+    fam: pd.DataFrame,
+    coarse_metrics: dict[str, float],
+    refined_metrics: dict[str, float],
+) -> str:
+    delta_auc = refined_metrics["auc"] - coarse_metrics["auc"]
+
+    lines = [
+        "=== OBS-036 Gateway State Refinement Summary ===",
+        "",
+        f"n_rows = {int(refined_metrics['n_rows'])}",
+        f"positive_rate = {refined_metrics['positive_rate']:.4f}",
+        "",
+        "Model comparison",
+        f"  coarse_auc  = {coarse_metrics['auc']:.4f}",
+        f"  refined_auc = {refined_metrics['auc']:.4f}",
+        f"  delta_auc   = {delta_auc:.4f}",
+        "",
+        "Interpretive guide",
+        "- coarse model uses original launch_state / launch_target",
+        "- refined model splits low/flank states by anisotropy / relational intensity",
+        "- positive delta_auc means refined boundary states carry extra predictive signal",
+        "",
+        "Top refined-model features",
+    ]
+
+    refined_coef = coef_all[coef_all["model"] == "refined"].head(12)
+    for _, row in refined_coef.iterrows():
+        lines.append(f"  {row['feature']}: coef={row['coefficient']:.6f}")
+
+    lines.extend(["", "Family refined-state summaries"])
+    for _, row in fam.iterrows():
+        lines.extend(
+            [
+                f"{row['route_class']}",
+                f"  n_rows                     = {int(row['n_rows'])}",
+                f"  crossing_rate              = {float(row['crossing_rate']):.4f}",
+                f"  top_refined_state_cross    = {row['top_refined_state_cross']}",
+                f"  top_refined_state_internal = {row['top_refined_state_internal']}",
+                f"  mean_relational_cross      = {float(row['mean_relational_cross']):.4f}",
+                f"  mean_relational_internal   = {float(row['mean_relational_internal']):.4f}",
+                f"  mean_anisotropy_cross      = {float(row['mean_anisotropy_cross']):.4f}",
+                f"  mean_anisotropy_internal   = {float(row['mean_anisotropy_internal']):.4f}",
+                "",
+            ]
+        )
+
+    return "\n".join(lines)
+
+
+def render_figure(
+    coef_all: pd.DataFrame,
+    fam: pd.DataFrame,
+    coarse_metrics: dict[str, float],
+    refined_metrics: dict[str, float],
+    outpath: Path,
+) -> None:
+    fig = plt.figure(figsize=(16.5, 10), constrained_layout=True)
+    gs = fig.add_gridspec(2, 3, width_ratios=[1.15, 1.15, 1.0], height_ratios=[1.0, 1.0])
+
+    ax_auc = fig.add_subplot(gs[0, 0])
+    ax_coef = fig.add_subplot(gs[0, 1])
+    ax_states = fig.add_subplot(gs[0, 2])
+    ax_top = fig.add_subplot(gs[1, 0:2])
+    ax_diag = fig.add_subplot(gs[1, 2])
+
+    # AUC comparison
+    auc_vals = [coarse_metrics["auc"], refined_metrics["auc"]]
+    ax_auc.bar([0, 1], auc_vals)
+    ax_auc.set_xticks([0, 1])
+    ax_auc.set_xticklabels(["coarse", "refined"])
+    ax_auc.set_title("Boundary prediction AUC", fontsize=14, pad=8)
+    ax_auc.grid(alpha=0.15, axis="y")
+
+    # Refined coefficients
+    refined_coef = coef_all[coef_all["model"] == "refined"].head(10).iloc[::-1]
+    ax_coef.barh(np.arange(len(refined_coef)), refined_coef["coefficient"].to_numpy(dtype=float))
+    ax_coef.set_yticks(np.arange(len(refined_coef)))
+    ax_coef.set_yticklabels(refined_coef["feature"].tolist(), fontsize=8)
+    ax_coef.set_title("Top refined-state coefficients", fontsize=14, pad=8)
+    ax_coef.grid(alpha=0.15, axis="x")
+
+    # Family crossing rates
+    x = np.arange(len(fam))
+    ax_states.bar(x, fam["crossing_rate"])
+    ax_states.set_xticks(x)
+    ax_states.set_xticklabels(fam["route_class"], rotation=12)
+    ax_states.set_title("Crossing rate by family", fontsize=14, pad=8)
+    ax_states.grid(alpha=0.15, axis="y")
+
+    # Family state contrasts
+    ax_top.axis("off")
+    y = 0.95
+    for _, row in fam.iterrows():
+        ax_top.text(0.02, y, str(row["route_class"]), fontsize=12, fontweight="bold")
+        y -= 0.06
+        ax_top.text(0.04, y, f"cross:    {row['top_refined_state_cross']}", fontsize=10, family="monospace")
+        y -= 0.045
+        ax_top.text(0.04, y, f"internal: {row['top_refined_state_internal']}", fontsize=10, family="monospace")
+        y -= 0.045
+        ax_top.text(
+            0.04,
+            y,
+            f"Δaniso: {row['mean_anisotropy_cross'] - row['mean_anisotropy_internal']:.4f}",
+            fontsize=10,
+            family="monospace",
+        )
+        y -= 0.045
+        ax_top.text(
+            0.04,
+            y,
+            f"Δrel:   {row['mean_relational_cross'] - row['mean_relational_internal']:.4f}",
+            fontsize=10,
+            family="monospace",
+        )
+        y -= 0.07
+    ax_top.set_title("Refined launch-state contrast", fontsize=14, pad=8)
+
+    delta_auc = refined_metrics["auc"] - coarse_metrics["auc"]
+    ax_diag.axis("off")
+    text = (
+        "OBS-036 diagnostics\n\n"
+        f"coarse AUC:\n{coarse_metrics['auc']:.3f}\n\n"
+        f"refined AUC:\n{refined_metrics['auc']:.3f}\n\n"
+        f"delta AUC:\n{delta_auc:.3f}\n\n"
+        "Interpretation:\n"
+        "tests whether the gateway\n"
+        "law is limited by coarse\n"
+        "state resolution rather\n"
+        "than by lack of structure."
+    )
+    ax_diag.text(
+        0.02, 0.98, text,
+        va="top", ha="left", fontsize=10.2, family="monospace",
+        bbox=dict(boxstyle="round,pad=0.35", fc="white", ec="0.85", alpha=0.95),
+    )
+
+    fig.suptitle("PAM Observatory — OBS-036 gateway state refinement", fontsize=21)
+    fig.savefig(outpath, dpi=220)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Refine launch states near the gateway boundary.")
+    parser.add_argument("--dataset-csv", default=Config.dataset_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--random-state", type=int, default=Config.random_state)
+    parser.add_argument("--aniso-quantile", type=float, default=Config.aniso_quantile)
+    parser.add_argument("--rel-quantile", type=float, default=Config.rel_quantile)
+    args = parser.parse_args()
+
+    cfg = Config(
+        dataset_csv=args.dataset_csv,
+        outdir=args.outdir,
+        random_state=args.random_state,
+        aniso_quantile=args.aniso_quantile,
+        rel_quantile=args.rel_quantile,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    ds = load_csv(cfg.dataset_csv)
+    ds = add_refined_states(ds, cfg)
+
+    coarse_coef, coarse_metrics = fit_model(ds, use_refined_states=False)
+    refined_coef, refined_metrics = fit_model(ds, use_refined_states=True)
+
+    coef_all = pd.concat([coarse_coef, refined_coef], ignore_index=True)
+    fam = build_family_summary(ds)
+
+    ds_csv = outdir / "gateway_state_refined_dataset.csv"
+    coef_csv = outdir / "gateway_state_refined_coefficients.csv"
+    fam_csv = outdir / "gateway_state_refined_family_summary.csv"
+    txt_path = outdir / "obs036_gateway_state_refinement_summary.txt"
+    png_path = outdir / "obs036_gateway_state_refinement_figure.png"
+
+    ds.to_csv(ds_csv, index=False)
+    coef_all.to_csv(coef_csv, index=False)
+    fam.to_csv(fam_csv, index=False)
+    txt_path.write_text(
+        build_summary(ds, coef_all, fam, coarse_metrics, refined_metrics),
+        encoding="utf-8",
+    )
+    render_figure(coef_all, fam, coarse_metrics, refined_metrics, png_path)
+
+    print(ds_csv)
+    print(coef_csv)
+    print(fam_csv)
+    print(txt_path)
+    print(png_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/studies/obs037_history_aware_gateway_predictor.py
+++ b/experiments/studies/obs037_history_aware_gateway_predictor.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""
+OBS-037 — History-aware gateway predictor.
+
+Purpose
+-------
+Test whether core->escape crossing is governed more by short transition history
+than by static launch-side state alone.
+
+This extends OBS-035c by adding one-step history context:
+- previous generator
+- previous source/target states
+- previous local fields (approximate, from generator-instance pool)
+- a short history word
+
+Prediction task
+---------------
+y = 1 if composition is classified as core_to_escape
+y = 0 if composition is classified as core_internal
+
+Inputs
+------
+outputs/obs034_core_to_escape_boundary/core_to_escape_crossings.csv
+outputs/obs030e_complete_generator_basis/completed_generator_assignments.csv
+
+Outputs
+-------
+outputs/obs037_history_aware_gateway_predictor/
+  gateway_crossing_history_dataset.csv
+  gateway_crossing_history_coefficients.csv
+  gateway_crossing_history_family_summary.csv
+  obs037_history_aware_gateway_predictor_summary.txt
+  obs037_history_aware_gateway_predictor_figure.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import roc_auc_score
+
+
+@dataclass(frozen=True)
+class Config:
+    crossings_csv: str = (
+        "outputs/obs034_core_to_escape_boundary/core_to_escape_crossings.csv"
+    )
+    assignments_csv: str = (
+        "outputs/obs030e_complete_generator_basis/completed_generator_assignments.csv"
+    )
+    outdir: str = "outputs/obs037_history_aware_gateway_predictor"
+    random_state: int = 42
+
+
+CLASS_ORDER = [
+    "branch_exit",
+    "stable_seam_corridor",
+    "reorganization_heavy",
+]
+
+TEXT_COLS = {
+    "route_class",
+    "generator_1",
+    "generator_2",
+    "src1",
+    "tgt1",
+    "src2",
+    "tgt2",
+    "sector_1",
+    "sector_2",
+    "crossing_type",
+    "composition_typed",
+    "motif",
+    "motif_class",
+    "state_a",
+    "state_b",
+    "state_c",
+    "state_a_red",
+    "state_b_red",
+    "state_c_red",
+    "generator_word",
+    "generator_completed",
+    "path_family",
+}
+
+
+def load_csv(path: str | Path) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    for col in df.columns:
+        if col not in TEXT_COLS:
+            try:
+                df[col] = pd.to_numeric(df[col], errors="coerce")
+            except Exception:
+                pass
+    return df
+
+
+def safe_mean(s: pd.Series | np.ndarray) -> float:
+    x = pd.to_numeric(pd.Series(s), errors="coerce")
+    return float(x.mean()) if x.notna().any() else float("nan")
+
+
+def build_instance_pool(assignments: pd.DataFrame) -> pd.DataFrame:
+    a = assignments.copy()
+    a["route_class"] = a["route_class"].astype(str)
+    a["generator_completed"] = a["generator_completed"].astype(str)
+
+    out = pd.DataFrame(
+        {
+            "route_class": a["route_class"],
+            "generator_completed": a["generator_completed"],
+            "state_a_red": a["state_a_red"].astype(str),
+            "state_c_red": a["state_c_red"].astype(str),
+            "relational_a": pd.to_numeric(a.get("relational_a", np.nan), errors="coerce"),
+            "anisotropy_a": pd.to_numeric(a.get("anisotropy_a", np.nan), errors="coerce"),
+            "distance_a": pd.to_numeric(a.get("distance_a", np.nan), errors="coerce"),
+        }
+    )
+    return out
+
+
+def sample_launch_instances(
+    row: pd.Series,
+    pool: pd.DataFrame,
+    *,
+    random_state: int,
+) -> pd.DataFrame:
+    cls = str(row["route_class"])
+    g1 = str(row["generator_1"])
+    src1 = str(row["src1"])
+    tgt1 = str(row["tgt1"])
+
+    sub = pool[
+        (pool["route_class"] == cls)
+        & (pool["generator_completed"] == g1)
+        & (pool["state_a_red"] == src1)
+        & (pool["state_c_red"] == tgt1)
+    ].copy()
+
+    if len(sub) == 0:
+        sub = pool[
+            (pool["route_class"] == cls)
+            & (pool["generator_completed"] == g1)
+        ].copy()
+
+    if len(sub) == 0:
+        return sub
+
+    n_rep = int(round(float(row["n_compositions"]))) if pd.notna(row["n_compositions"]) else 1
+    n_rep = max(n_rep, 1)
+
+    return sub.sample(
+        n=n_rep,
+        replace=(len(sub) < n_rep),
+        random_state=random_state,
+    ).reset_index(drop=True)
+
+
+def build_dataset(crossings: pd.DataFrame, assignments: pd.DataFrame, cfg: Config) -> pd.DataFrame:
+    use = crossings[crossings["crossing_type"].isin(["core_internal", "core_to_escape"])].copy()
+    use["y_cross"] = (use["crossing_type"] == "core_to_escape").astype(int)
+
+    pool = build_instance_pool(assignments)
+
+    rows = []
+    for idx, row in use.reset_index(drop=True).iterrows():
+        sampled = sample_launch_instances(row, pool, random_state=cfg.random_state + idx)
+        if len(sampled) == 0:
+            continue
+
+        for _, s in sampled.iterrows():
+            prev_generator = str(row["generator_1"])
+            launch_generator = str(row["generator_2"])
+
+            prev_src = str(row["src1"])
+            prev_tgt = str(row["tgt1"])
+            launch_src = str(row["src2"])
+            launch_tgt = str(row["tgt2"])
+
+            history_word = f"{prev_src}->{prev_tgt};{launch_src}->{launch_tgt}"
+            generator_word = f"{prev_generator};{launch_generator}"
+
+            rows.append(
+                {
+                    "route_class": str(row["route_class"]),
+                    "crossing_type": str(row["crossing_type"]),
+                    "y_cross": int(row["y_cross"]),
+                    "prev_generator": prev_generator,
+                    "launch_generator": launch_generator,
+                    "prev_state": prev_src,
+                    "prev_target": prev_tgt,
+                    "launch_state": launch_src,
+                    "launch_target": launch_tgt,
+                    "history_word": history_word,
+                    "generator_word": generator_word,
+                    # approximate prelaunch local fields from the sampled first-generator instance
+                    "mean_relational": s["relational_a"],
+                    "mean_anisotropy": s["anisotropy_a"],
+                    "mean_distance": s["distance_a"],
+                    "composition_typed": row.get("composition_typed", np.nan),
+                }
+            )
+
+    return pd.DataFrame(rows)
+
+
+def fit_model(ds: pd.DataFrame, *, use_history: bool) -> tuple[pd.DataFrame, dict[str, float]]:
+    X = ds.copy()
+
+    for col in ["mean_relational", "mean_anisotropy", "mean_distance"]:
+        X[col] = pd.to_numeric(X[col], errors="coerce")
+        X[col] = X[col].fillna(X[col].median() if X[col].notna().any() else 0.0)
+
+    features = [
+        "route_class",
+        "launch_generator",
+        "launch_state",
+        "launch_target",
+        "mean_relational",
+        "mean_anisotropy",
+        "mean_distance",
+    ]
+    if use_history:
+        features = [
+            "route_class",
+            "prev_generator",
+            "launch_generator",
+            "prev_state",
+            "prev_target",
+            "launch_state",
+            "launch_target",
+            "history_word",
+            "generator_word",
+            "mean_relational",
+            "mean_anisotropy",
+            "mean_distance",
+        ]
+
+    cat_cols = [c for c in features if c not in {"mean_relational", "mean_anisotropy", "mean_distance"}]
+
+    design = pd.get_dummies(
+        X[features],
+        columns=cat_cols,
+        drop_first=False,
+        dtype=float,
+    )
+
+    y = X["y_cross"].to_numpy(dtype=int)
+
+    model = LogisticRegression(
+        penalty="l2",
+        solver="liblinear",
+        random_state=42,
+        max_iter=4000,
+    )
+    model.fit(design.to_numpy(dtype=float), y)
+
+    probs = model.predict_proba(design.to_numpy(dtype=float))[:, 1]
+    auc = float(roc_auc_score(y, probs)) if len(np.unique(y)) > 1 else float("nan")
+
+    coef = pd.DataFrame(
+        {
+            "feature": design.columns,
+            "coefficient": model.coef_[0],
+            "abs_coefficient": np.abs(model.coef_[0]),
+            "model": "history" if use_history else "launch_only",
+        }
+    ).sort_values("abs_coefficient", ascending=False).reset_index(drop=True)
+
+    metrics = {
+        "auc": auc,
+        "intercept": float(model.intercept_[0]),
+        "n_rows": float(len(ds)),
+        "positive_rate": float(ds["y_cross"].mean()),
+        "model": "history" if use_history else "launch_only",
+    }
+    return coef, metrics
+
+
+def build_family_summary(ds: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+    for cls in CLASS_ORDER:
+        sub = ds[ds["route_class"] == cls].copy()
+        pos = sub[sub["y_cross"] == 1]
+        neg = sub[sub["y_cross"] == 0]
+
+        rows.append(
+            {
+                "route_class": cls,
+                "n_rows": int(len(sub)),
+                "crossing_rate": float(sub["y_cross"].mean()) if len(sub) else float("nan"),
+                "top_history_cross": pos["history_word"].value_counts().index[0] if len(pos) else np.nan,
+                "top_history_internal": neg["history_word"].value_counts().index[0] if len(neg) else np.nan,
+                "top_generator_word_cross": pos["generator_word"].value_counts().index[0] if len(pos) else np.nan,
+                "top_generator_word_internal": neg["generator_word"].value_counts().index[0] if len(neg) else np.nan,
+                "mean_relational_cross": safe_mean(pos["mean_relational"]),
+                "mean_relational_internal": safe_mean(neg["mean_relational"]),
+                "mean_anisotropy_cross": safe_mean(pos["mean_anisotropy"]),
+                "mean_anisotropy_internal": safe_mean(neg["mean_anisotropy"]),
+            }
+        )
+
+    out = pd.DataFrame(rows)
+    order = {k: i for i, k in enumerate(CLASS_ORDER)}
+    out["order"] = out["route_class"].map(lambda x: order.get(x, 999))
+    return out.sort_values("order").drop(columns=["order"]).reset_index(drop=True)
+
+
+def build_summary(
+    coef_all: pd.DataFrame,
+    fam: pd.DataFrame,
+    launch_metrics: dict[str, float],
+    history_metrics: dict[str, float],
+) -> str:
+    delta_auc = history_metrics["auc"] - launch_metrics["auc"]
+
+    lines = [
+        "=== OBS-037 History-Aware Gateway Predictor Summary ===",
+        "",
+        f"n_rows = {int(history_metrics['n_rows'])}",
+        f"positive_rate = {history_metrics['positive_rate']:.4f}",
+        "",
+        "Model comparison",
+        f"  launch_only_auc = {launch_metrics['auc']:.4f}",
+        f"  history_auc     = {history_metrics['auc']:.4f}",
+        f"  delta_auc       = {delta_auc:.4f}",
+        "",
+        "Interpretive guide",
+        "- launch_only uses current launch-side information only",
+        "- history model adds previous generator/state and short history words",
+        "- positive delta_auc means short transition memory improves gateway prediction",
+        "",
+        "Top history-model features",
+    ]
+
+    hist_coef = coef_all[coef_all["model"] == "history"].head(12)
+    for _, row in hist_coef.iterrows():
+        lines.append(f"  {row['feature']}: coef={row['coefficient']:.6f}")
+
+    lines.extend(["", "Family history summaries"])
+    for _, row in fam.iterrows():
+        lines.extend(
+            [
+                f"{row['route_class']}",
+                f"  n_rows                    = {int(row['n_rows'])}",
+                f"  crossing_rate             = {float(row['crossing_rate']):.4f}",
+                f"  top_history_cross         = {row['top_history_cross']}",
+                f"  top_history_internal      = {row['top_history_internal']}",
+                f"  top_generator_word_cross  = {row['top_generator_word_cross']}",
+                f"  top_generator_word_internal = {row['top_generator_word_internal']}",
+                f"  mean_relational_cross     = {float(row['mean_relational_cross']):.4f}",
+                f"  mean_relational_internal  = {float(row['mean_relational_internal']):.4f}",
+                f"  mean_anisotropy_cross     = {float(row['mean_anisotropy_cross']):.4f}",
+                f"  mean_anisotropy_internal  = {float(row['mean_anisotropy_internal']):.4f}",
+                "",
+            ]
+        )
+
+    return "\n".join(lines)
+
+
+def render_figure(
+    coef_all: pd.DataFrame,
+    fam: pd.DataFrame,
+    launch_metrics: dict[str, float],
+    history_metrics: dict[str, float],
+    outpath: Path,
+) -> None:
+    fig = plt.figure(figsize=(16.5, 10), constrained_layout=True)
+    gs = fig.add_gridspec(2, 3, width_ratios=[1.15, 1.15, 1.0], height_ratios=[1.0, 1.0])
+
+    ax_auc = fig.add_subplot(gs[0, 0])
+    ax_coef = fig.add_subplot(gs[0, 1])
+    ax_rates = fig.add_subplot(gs[0, 2])
+    ax_top = fig.add_subplot(gs[1, 0:2])
+    ax_diag = fig.add_subplot(gs[1, 2])
+
+    auc_vals = [launch_metrics["auc"], history_metrics["auc"]]
+    ax_auc.bar([0, 1], auc_vals)
+    ax_auc.set_xticks([0, 1])
+    ax_auc.set_xticklabels(["launch_only", "history"])
+    ax_auc.set_title("Gateway prediction AUC", fontsize=14, pad=8)
+    ax_auc.grid(alpha=0.15, axis="y")
+
+    hist_coef = coef_all[coef_all["model"] == "history"].head(10).iloc[::-1]
+    ax_coef.barh(np.arange(len(hist_coef)), hist_coef["coefficient"].to_numpy(dtype=float))
+    ax_coef.set_yticks(np.arange(len(hist_coef)))
+    ax_coef.set_yticklabels(hist_coef["feature"].tolist(), fontsize=8)
+    ax_coef.set_title("Top history-aware coefficients", fontsize=14, pad=8)
+    ax_coef.grid(alpha=0.15, axis="x")
+
+    x = np.arange(len(fam))
+    ax_rates.bar(x, fam["crossing_rate"])
+    ax_rates.set_xticks(x)
+    ax_rates.set_xticklabels(fam["route_class"], rotation=12)
+    ax_rates.set_title("Crossing rate by family", fontsize=14, pad=8)
+    ax_rates.grid(alpha=0.15, axis="y")
+
+    ax_top.axis("off")
+    y = 0.95
+    for _, row in fam.iterrows():
+        ax_top.text(0.02, y, str(row["route_class"]), fontsize=12, fontweight="bold")
+        y -= 0.06
+        ax_top.text(0.04, y, f"cross hist: {row['top_history_cross']}", fontsize=10, family="monospace")
+        y -= 0.045
+        ax_top.text(0.04, y, f"int hist:   {row['top_history_internal']}", fontsize=10, family="monospace")
+        y -= 0.045
+        ax_top.text(0.04, y, f"cross gen:  {row['top_generator_word_cross']}", fontsize=10, family="monospace")
+        y -= 0.045
+        ax_top.text(0.04, y, f"int gen:    {row['top_generator_word_internal']}", fontsize=10, family="monospace")
+        y -= 0.07
+    ax_top.set_title("Family short-history contrast", fontsize=14, pad=8)
+
+    delta_auc = history_metrics["auc"] - launch_metrics["auc"]
+    ax_diag.axis("off")
+    text = (
+        "OBS-037 diagnostics\n\n"
+        f"launch-only AUC:\n{launch_metrics['auc']:.3f}\n\n"
+        f"history AUC:\n{history_metrics['auc']:.3f}\n\n"
+        f"delta AUC:\n{delta_auc:.3f}\n\n"
+        "Interpretation:\n"
+        "tests whether gateway\n"
+        "crossing depends on short\n"
+        "transition memory rather\n"
+        "than static launch state."
+    )
+    ax_diag.text(
+        0.02, 0.98, text,
+        va="top", ha="left", fontsize=10.2, family="monospace",
+        bbox=dict(boxstyle="round,pad=0.35", fc="white", ec="0.85", alpha=0.95),
+    )
+
+    fig.suptitle("PAM Observatory — OBS-037 history-aware gateway predictor", fontsize=21)
+    fig.savefig(outpath, dpi=220)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Predict gateway crossing using short transition history.")
+    parser.add_argument("--crossings-csv", default=Config.crossings_csv)
+    parser.add_argument("--assignments-csv", default=Config.assignments_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--random-state", type=int, default=Config.random_state)
+    args = parser.parse_args()
+
+    cfg = Config(
+        crossings_csv=args.crossings_csv,
+        assignments_csv=args.assignments_csv,
+        outdir=args.outdir,
+        random_state=args.random_state,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    crossings = load_csv(cfg.crossings_csv)
+    assignments = load_csv(cfg.assignments_csv)
+
+    ds = build_dataset(crossings, assignments, cfg)
+    launch_coef, launch_metrics = fit_model(ds, use_history=False)
+    history_coef, history_metrics = fit_model(ds, use_history=True)
+    coef_all = pd.concat([launch_coef, history_coef], ignore_index=True)
+    fam = build_family_summary(ds)
+
+    ds_csv = outdir / "gateway_crossing_history_dataset.csv"
+    coef_csv = outdir / "gateway_crossing_history_coefficients.csv"
+    fam_csv = outdir / "gateway_crossing_history_family_summary.csv"
+    txt_path = outdir / "obs037_history_aware_gateway_predictor_summary.txt"
+    png_path = outdir / "obs037_history_aware_gateway_predictor_figure.png"
+
+    ds.to_csv(ds_csv, index=False)
+    coef_all.to_csv(coef_csv, index=False)
+    fam.to_csv(fam_csv, index=False)
+    txt_path.write_text(
+        build_summary(coef_all, fam, launch_metrics, history_metrics),
+        encoding="utf-8",
+    )
+    render_figure(coef_all, fam, launch_metrics, history_metrics, png_path)
+
+    print(ds_csv)
+    print(coef_csv)
+    print(fam_csv)
+    print(txt_path)
+    print(png_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/studies/obs037b_pre_second_step_gateway_predictor.py
+++ b/experiments/studies/obs037b_pre_second_step_gateway_predictor.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+"""
+OBS-037b — Pre-second-step gateway predictor.
+
+Purpose
+-------
+Test whether gateway crossing can be predicted BEFORE the second generator is
+known.
+
+This corrects OBS-037 by removing leakage from:
+- generator_2
+- src2 / tgt2
+- generator_word including second step
+- history_word including second step
+
+Prediction task
+---------------
+Given only information available before the second step fires, predict whether
+the next move will be:
+
+    y = 1  core_to_escape
+    y = 0  core_internal
+
+Inputs
+------
+outputs/obs034_core_to_escape_boundary/core_to_escape_crossings.csv
+outputs/obs030e_complete_generator_basis/completed_generator_assignments.csv
+
+Outputs
+-------
+outputs/obs037b_pre_second_step_gateway_predictor/
+  gateway_crossing_pre_second_step_dataset.csv
+  gateway_crossing_pre_second_step_coefficients.csv
+  gateway_crossing_pre_second_step_family_summary.csv
+  obs037b_pre_second_step_gateway_predictor_summary.txt
+  obs037b_pre_second_step_gateway_predictor_figure.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import roc_auc_score
+
+
+@dataclass(frozen=True)
+class Config:
+    crossings_csv: str = (
+        "outputs/obs034_core_to_escape_boundary/core_to_escape_crossings.csv"
+    )
+    assignments_csv: str = (
+        "outputs/obs030e_complete_generator_basis/completed_generator_assignments.csv"
+    )
+    outdir: str = "outputs/obs037b_pre_second_step_gateway_predictor"
+    random_state: int = 42
+
+
+CLASS_ORDER = [
+    "branch_exit",
+    "stable_seam_corridor",
+    "reorganization_heavy",
+]
+
+TEXT_COLS = {
+    "route_class",
+    "generator_1",
+    "generator_2",
+    "src1",
+    "tgt1",
+    "src2",
+    "tgt2",
+    "sector_1",
+    "sector_2",
+    "crossing_type",
+    "composition_typed",
+    "motif",
+    "motif_class",
+    "state_a",
+    "state_b",
+    "state_c",
+    "state_a_red",
+    "state_b_red",
+    "state_c_red",
+    "generator_word",
+    "generator_completed",
+    "path_family",
+    "prev_generator",
+    "prev_state",
+    "prev_target",
+    "prelaunch_word",
+}
+
+
+def load_csv(path: str | Path) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    for col in df.columns:
+        if col not in TEXT_COLS:
+            try:
+                df[col] = pd.to_numeric(df[col], errors="coerce")
+            except Exception:
+                pass
+    return df
+
+
+def safe_mean(s: pd.Series | np.ndarray) -> float:
+    x = pd.to_numeric(pd.Series(s), errors="coerce")
+    return float(x.mean()) if x.notna().any() else float("nan")
+
+
+def build_instance_pool(assignments: pd.DataFrame) -> pd.DataFrame:
+    a = assignments.copy()
+    a["route_class"] = a["route_class"].astype(str)
+    a["generator_completed"] = a["generator_completed"].astype(str)
+    a["state_a_red"] = a["state_a_red"].astype(str)
+    a["state_c_red"] = a["state_c_red"].astype(str)
+
+    out = pd.DataFrame(
+        {
+            "route_class": a["route_class"],
+            "generator_completed": a["generator_completed"],
+            "state_a_red": a["state_a_red"],
+            "state_c_red": a["state_c_red"],
+            "relational_a": pd.to_numeric(a.get("relational_a", np.nan), errors="coerce"),
+            "anisotropy_a": pd.to_numeric(a.get("anisotropy_a", np.nan), errors="coerce"),
+            "distance_a": pd.to_numeric(a.get("distance_a", np.nan), errors="coerce"),
+        }
+    )
+    return out
+
+
+def sample_pre_second_step_instances(
+    row: pd.Series,
+    pool: pd.DataFrame,
+    *,
+    random_state: int,
+) -> pd.DataFrame:
+    cls = str(row["route_class"])
+    prev_gen = str(row["generator_1"])
+    prev_src = str(row["src1"])
+    prev_tgt = str(row["tgt1"])
+
+    sub = pool[
+        (pool["route_class"] == cls)
+        & (pool["generator_completed"] == prev_gen)
+        & (pool["state_a_red"] == prev_src)
+        & (pool["state_c_red"] == prev_tgt)
+    ].copy()
+
+    if len(sub) == 0:
+        sub = pool[
+            (pool["route_class"] == cls)
+            & (pool["generator_completed"] == prev_gen)
+        ].copy()
+
+    if len(sub) == 0:
+        return sub
+
+    n_rep = int(round(float(row["n_compositions"]))) if pd.notna(row["n_compositions"]) else 1
+    n_rep = max(n_rep, 1)
+
+    return sub.sample(
+        n=n_rep,
+        replace=(len(sub) < n_rep),
+        random_state=random_state,
+    ).reset_index(drop=True)
+
+
+def build_dataset(crossings: pd.DataFrame, assignments: pd.DataFrame, cfg: Config) -> pd.DataFrame:
+    use = crossings[crossings["crossing_type"].isin(["core_internal", "core_to_escape"])].copy()
+    use["y_cross"] = (use["crossing_type"] == "core_to_escape").astype(int)
+
+    pool = build_instance_pool(assignments)
+
+    rows = []
+    for idx, row in use.reset_index(drop=True).iterrows():
+        sampled = sample_pre_second_step_instances(row, pool, random_state=cfg.random_state + idx)
+        if len(sampled) == 0:
+            continue
+
+        for _, s in sampled.iterrows():
+            prev_generator = str(row["generator_1"])
+            prev_state = str(row["src1"]) if pd.notna(row["src1"]) else str(s["state_a_red"])
+            prev_target = str(row["tgt1"]) if pd.notna(row["tgt1"]) else str(s["state_c_red"])
+            prelaunch_word = f"{prev_state}->{prev_target}"
+
+            rows.append(
+                {
+                    "route_class": str(row["route_class"]),
+                    "crossing_type": str(row["crossing_type"]),
+                    "y_cross": int(row["y_cross"]),
+                    "prev_generator": prev_generator,
+                    "prev_state": prev_state,
+                    "prev_target": prev_target,
+                    "prelaunch_word": prelaunch_word,
+                    "mean_relational": s["relational_a"],
+                    "mean_anisotropy": s["anisotropy_a"],
+                    "mean_distance": s["distance_a"],
+                    "composition_typed": row.get("composition_typed", np.nan),
+                }
+            )
+
+    return pd.DataFrame(rows)
+
+
+def fit_model(ds: pd.DataFrame) -> tuple[pd.DataFrame, dict[str, float]]:
+    X = ds.copy()
+
+    for col in ["mean_relational", "mean_anisotropy", "mean_distance"]:
+        X[col] = pd.to_numeric(X[col], errors="coerce")
+        X[col] = X[col].fillna(X[col].median() if X[col].notna().any() else 0.0)
+
+    design = pd.get_dummies(
+        X[
+            [
+                "route_class",
+                "prev_generator",
+                "prev_state",
+                "prev_target",
+                "prelaunch_word",
+                "mean_relational",
+                "mean_anisotropy",
+                "mean_distance",
+            ]
+        ],
+        columns=["route_class", "prev_generator", "prev_state", "prev_target", "prelaunch_word"],
+        drop_first=False,
+        dtype=float,
+    )
+
+    y = X["y_cross"].to_numpy(dtype=int)
+
+    model = LogisticRegression(
+        penalty="l2",
+        solver="liblinear",
+        random_state=42,
+        max_iter=4000,
+    )
+    model.fit(design.to_numpy(dtype=float), y)
+
+    probs = model.predict_proba(design.to_numpy(dtype=float))[:, 1]
+    auc = float(roc_auc_score(y, probs)) if len(np.unique(y)) > 1 else float("nan")
+
+    coef = pd.DataFrame(
+        {
+            "feature": design.columns,
+            "coefficient": model.coef_[0],
+            "abs_coefficient": np.abs(model.coef_[0]),
+        }
+    ).sort_values("abs_coefficient", ascending=False).reset_index(drop=True)
+
+    metrics = {
+        "auc": auc,
+        "intercept": float(model.intercept_[0]),
+        "n_rows": float(len(ds)),
+        "positive_rate": float(ds["y_cross"].mean()),
+    }
+    return coef, metrics
+
+
+def build_family_summary(ds: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+    for cls in CLASS_ORDER:
+        sub = ds[ds["route_class"] == cls].copy()
+        pos = sub[sub["y_cross"] == 1]
+        neg = sub[sub["y_cross"] == 0]
+
+        rows.append(
+            {
+                "route_class": cls,
+                "n_rows": int(len(sub)),
+                "crossing_rate": float(sub["y_cross"].mean()) if len(sub) else float("nan"),
+                "top_prelaunch_cross": pos["prelaunch_word"].value_counts().index[0] if len(pos) else np.nan,
+                "top_prelaunch_internal": neg["prelaunch_word"].value_counts().index[0] if len(neg) else np.nan,
+                "top_prev_generator_cross": pos["prev_generator"].value_counts().index[0] if len(pos) else np.nan,
+                "top_prev_generator_internal": neg["prev_generator"].value_counts().index[0] if len(neg) else np.nan,
+                "mean_relational_cross": safe_mean(pos["mean_relational"]),
+                "mean_relational_internal": safe_mean(neg["mean_relational"]),
+                "mean_anisotropy_cross": safe_mean(pos["mean_anisotropy"]),
+                "mean_anisotropy_internal": safe_mean(neg["mean_anisotropy"]),
+            }
+        )
+
+    out = pd.DataFrame(rows)
+    order = {k: i for i, k in enumerate(CLASS_ORDER)}
+    out["order"] = out["route_class"].map(lambda x: order.get(x, 999))
+    return out.sort_values("order").drop(columns=["order"]).reset_index(drop=True)
+
+
+def build_summary(coef: pd.DataFrame, fam: pd.DataFrame, metrics: dict[str, float]) -> str:
+    lines = [
+        "=== OBS-037b Pre-Second-Step Gateway Predictor Summary ===",
+        "",
+        f"n_rows = {int(metrics['n_rows'])}",
+        f"positive_rate = {metrics['positive_rate']:.4f}",
+        f"auc = {metrics['auc']:.4f}",
+        f"intercept = {metrics['intercept']:.6f}",
+        "",
+        "Discipline",
+        "- positive class = core_to_escape crossing",
+        "- negative class = core_internal continuation",
+        "- uses only information available before generator_2 is known",
+        "- excludes generator_2, src2, tgt2, and any two-step word containing the second step",
+        "",
+        "Top pre-second-step features",
+    ]
+
+    for _, row in coef.head(12).iterrows():
+        lines.append(f"  {row['feature']}: coef={row['coefficient']:.6f}")
+
+    lines.extend(["", "Family summaries"])
+    for _, row in fam.iterrows():
+        lines.extend(
+            [
+                f"{row['route_class']}",
+                f"  n_rows                    = {int(row['n_rows'])}",
+                f"  crossing_rate             = {float(row['crossing_rate']):.4f}",
+                f"  top_prelaunch_cross       = {row['top_prelaunch_cross']}",
+                f"  top_prelaunch_internal    = {row['top_prelaunch_internal']}",
+                f"  top_prev_generator_cross  = {row['top_prev_generator_cross']}",
+                f"  top_prev_generator_internal = {row['top_prev_generator_internal']}",
+                f"  mean_relational_cross     = {float(row['mean_relational_cross']):.4f}",
+                f"  mean_relational_internal  = {float(row['mean_relational_internal']):.4f}",
+                f"  mean_anisotropy_cross     = {float(row['mean_anisotropy_cross']):.4f}",
+                f"  mean_anisotropy_internal  = {float(row['mean_anisotropy_internal']):.4f}",
+                "",
+            ]
+        )
+
+    return "\n".join(lines)
+
+
+def render_figure(coef: pd.DataFrame, fam: pd.DataFrame, metrics: dict[str, float], outpath: Path) -> None:
+    fig = plt.figure(figsize=(16.5, 10), constrained_layout=True)
+    gs = fig.add_gridspec(2, 3, width_ratios=[1.15, 1.15, 1.0], height_ratios=[1.0, 1.0])
+
+    ax_coef = fig.add_subplot(gs[0, 0])
+    ax_rates = fig.add_subplot(gs[0, 1])
+    ax_fields = fig.add_subplot(gs[0, 2])
+    ax_top = fig.add_subplot(gs[1, 0:2])
+    ax_diag = fig.add_subplot(gs[1, 2])
+
+    top = coef.head(10).iloc[::-1]
+    ax_coef.barh(np.arange(len(top)), top["coefficient"].to_numpy(dtype=float))
+    ax_coef.set_yticks(np.arange(len(top)))
+    ax_coef.set_yticklabels(top["feature"].tolist(), fontsize=8)
+    ax_coef.set_title("Top pre-second-step coefficients", fontsize=14, pad=8)
+    ax_coef.grid(alpha=0.15, axis="x")
+
+    x = np.arange(len(fam))
+    ax_rates.bar(x, fam["crossing_rate"])
+    ax_rates.set_xticks(x)
+    ax_rates.set_xticklabels(fam["route_class"], rotation=12)
+    ax_rates.set_title("Crossing rate by family", fontsize=14, pad=8)
+    ax_rates.grid(alpha=0.15, axis="y")
+
+    width = 0.34
+    ax_fields.bar(x - width / 2, fam["mean_relational_cross"] - fam["mean_relational_internal"], width, label="Δ relational")
+    ax_fields.bar(x + width / 2, fam["mean_anisotropy_cross"] - fam["mean_anisotropy_internal"], width, label="Δ anisotropy")
+    ax_fields.set_xticks(x)
+    ax_fields.set_xticklabels(fam["route_class"], rotation=12)
+    ax_fields.set_title("Crossing minus internal prelaunch fields", fontsize=14, pad=8)
+    ax_fields.grid(alpha=0.15, axis="y")
+    ax_fields.legend()
+
+    ax_top.axis("off")
+    y = 0.95
+    for _, row in fam.iterrows():
+        ax_top.text(0.02, y, str(row["route_class"]), fontsize=12, fontweight="bold")
+        y -= 0.06
+        ax_top.text(0.04, y, f"cross state: {row['top_prelaunch_cross']}", fontsize=10, family="monospace")
+        y -= 0.045
+        ax_top.text(0.04, y, f"int state:   {row['top_prelaunch_internal']}", fontsize=10, family="monospace")
+        y -= 0.045
+        ax_top.text(0.04, y, f"cross gen:   {row['top_prev_generator_cross']}", fontsize=10, family="monospace")
+        y -= 0.045
+        ax_top.text(0.04, y, f"int gen:     {row['top_prev_generator_internal']}", fontsize=10, family="monospace")
+        y -= 0.07
+    ax_top.set_title("Family pre-second-step contrast", fontsize=14, pad=8)
+
+    ax_diag.axis("off")
+    text = (
+        "OBS-037b diagnostics\n\n"
+        f"AUC:\n{metrics['auc']:.3f}\n\n"
+        f"positive rate:\n{metrics['positive_rate']:.3f}\n\n"
+        "Interpretation:\n"
+        "this is the first valid\n"
+        "history-aware test that\n"
+        "stops before the gateway\n"
+        "decision itself is known."
+    )
+    ax_diag.text(
+        0.02, 0.98, text,
+        va="top", ha="left", fontsize=10.2, family="monospace",
+        bbox=dict(boxstyle="round,pad=0.35", fc="white", ec="0.85", alpha=0.95),
+    )
+
+    fig.suptitle("PAM Observatory — OBS-037b pre-second-step gateway predictor", fontsize=21)
+    fig.savefig(outpath, dpi=220)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Predict gateway crossing before the second step is known.")
+    parser.add_argument("--crossings-csv", default=Config.crossings_csv)
+    parser.add_argument("--assignments-csv", default=Config.assignments_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--random-state", type=int, default=Config.random_state)
+    args = parser.parse_args()
+
+    cfg = Config(
+        crossings_csv=args.crossings_csv,
+        assignments_csv=args.assignments_csv,
+        outdir=args.outdir,
+        random_state=args.random_state,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    crossings = load_csv(cfg.crossings_csv)
+    assignments = load_csv(cfg.assignments_csv)
+
+    ds = build_dataset(crossings, assignments, cfg)
+    coef, metrics = fit_model(ds)
+    fam = build_family_summary(ds)
+
+    ds_csv = outdir / "gateway_crossing_pre_second_step_dataset.csv"
+    coef_csv = outdir / "gateway_crossing_pre_second_step_coefficients.csv"
+    fam_csv = outdir / "gateway_crossing_pre_second_step_family_summary.csv"
+    txt_path = outdir / "obs037b_pre_second_step_gateway_predictor_summary.txt"
+    png_path = outdir / "obs037b_pre_second_step_gateway_predictor_figure.png"
+
+    ds.to_csv(ds_csv, index=False)
+    coef.to_csv(coef_csv, index=False)
+    fam.to_csv(fam_csv, index=False)
+    txt_path.write_text(build_summary(coef, fam, metrics), encoding="utf-8")
+    render_figure(coef, fam, metrics, png_path)
+
+    print(ds_csv)
+    print(coef_csv)
+    print(fam_csv)
+    print(txt_path)
+    print(png_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/studies/obs038_family_specific_gateway_laws.py
+++ b/experiments/studies/obs038_family_specific_gateway_laws.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""
+OBS-038 — Family-specific gateway laws.
+
+Purpose
+-------
+Test whether the weak pooled gateway signal is masking stronger
+family-specific laws.
+
+OBS-035c and OBS-037b suggested:
+- modest pooled predictive signal
+- little benefit from refined symbolic states
+- little benefit from one-step history
+- stable_seam_corridor appears qualitatively different from
+  branch_exit and reorganization_heavy
+
+This study fits separate family-level gateway predictors and compares them
+against the pooled model.
+
+Prediction task
+---------------
+For each family independently:
+
+    y = 1  core_to_escape
+    y = 0  core_internal
+
+using only valid pre-second-step information.
+
+Inputs
+------
+outputs/obs037b_pre_second_step_gateway_predictor/gateway_crossing_pre_second_step_dataset.csv
+
+Outputs
+-------
+outputs/obs038_family_specific_gateway_laws/
+  family_specific_gateway_coefficients.csv
+  family_specific_gateway_metrics.csv
+  family_specific_gateway_summary.csv
+  obs038_family_specific_gateway_laws_summary.txt
+  obs038_family_specific_gateway_laws_figure.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import roc_auc_score
+
+
+@dataclass(frozen=True)
+class Config:
+    dataset_csv: str = (
+        "outputs/obs037b_pre_second_step_gateway_predictor/"
+        "gateway_crossing_pre_second_step_dataset.csv"
+    )
+    outdir: str = "outputs/obs038_family_specific_gateway_laws"
+    min_rows: int = 8
+    random_state: int = 42
+
+
+CLASS_ORDER = [
+    "branch_exit",
+    "stable_seam_corridor",
+    "reorganization_heavy",
+]
+
+TEXT_COLS = {
+    "route_class",
+    "crossing_type",
+    "prev_generator",
+    "prev_state",
+    "prev_target",
+    "prelaunch_word",
+    "composition_typed",
+}
+
+
+def load_csv(path: str | Path) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    for col in df.columns:
+        if col not in TEXT_COLS:
+            try:
+                df[col] = pd.to_numeric(df[col], errors="coerce")
+            except Exception:
+                pass
+    return df
+
+
+def safe_mean(s: pd.Series | np.ndarray) -> float:
+    x = pd.to_numeric(pd.Series(s), errors="coerce")
+    return float(x.mean()) if x.notna().any() else float("nan")
+
+
+def fit_family_model(df: pd.DataFrame, family_name: str) -> tuple[pd.DataFrame, dict[str, float]]:
+    work = df.copy()
+
+    for col in ["mean_relational", "mean_anisotropy", "mean_distance"]:
+        work[col] = pd.to_numeric(work[col], errors="coerce")
+        work[col] = work[col].fillna(work[col].median() if work[col].notna().any() else 0.0)
+
+    # Keep only columns available before second step
+    design = pd.get_dummies(
+        work[
+            [
+                "prev_generator",
+                "prev_state",
+                "prev_target",
+                "prelaunch_word",
+                "mean_relational",
+                "mean_anisotropy",
+                "mean_distance",
+            ]
+        ],
+        columns=["prev_generator", "prev_state", "prev_target", "prelaunch_word"],
+        drop_first=False,
+        dtype=float,
+    )
+
+    y = work["y_cross"].to_numpy(dtype=int)
+
+    # Need both classes to fit meaningful model
+    if len(work) == 0 or len(np.unique(y)) < 2:
+        return (
+            pd.DataFrame(columns=["route_class", "feature", "coefficient", "abs_coefficient"]),
+            {
+                "route_class": family_name,
+                "n_rows": float(len(work)),
+                "positive_rate": float(work["y_cross"].mean()) if len(work) else float("nan"),
+                "auc": float("nan"),
+                "intercept": float("nan"),
+                "n_features": 0.0,
+            },
+        )
+
+    model = LogisticRegression(
+        penalty="l2",
+        solver="liblinear",
+        random_state=42,
+        max_iter=4000,
+    )
+    model.fit(design.to_numpy(dtype=float), y)
+
+    probs = model.predict_proba(design.to_numpy(dtype=float))[:, 1]
+    auc = float(roc_auc_score(y, probs))
+
+    coef = pd.DataFrame(
+        {
+            "route_class": family_name,
+            "feature": design.columns,
+            "coefficient": model.coef_[0],
+            "abs_coefficient": np.abs(model.coef_[0]),
+        }
+    ).sort_values("abs_coefficient", ascending=False).reset_index(drop=True)
+
+    metrics = {
+        "route_class": family_name,
+        "n_rows": float(len(work)),
+        "positive_rate": float(work["y_cross"].mean()),
+        "auc": auc,
+        "intercept": float(model.intercept_[0]),
+        "n_features": float(design.shape[1]),
+    }
+    return coef, metrics
+
+
+def build_summary_table(ds: pd.DataFrame, coef_all: pd.DataFrame, metrics_df: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+
+    for fam in CLASS_ORDER:
+        sub = ds[ds["route_class"] == fam].copy()
+        pos = sub[sub["y_cross"] == 1]
+        neg = sub[sub["y_cross"] == 0]
+        coef = coef_all[coef_all["route_class"] == fam].copy()
+        met = metrics_df[metrics_df["route_class"] == fam]
+
+        auc = float(met["auc"].iloc[0]) if len(met) else float("nan")
+
+        rows.append(
+            {
+                "route_class": fam,
+                "n_rows": int(len(sub)),
+                "crossing_rate": float(sub["y_cross"].mean()) if len(sub) else float("nan"),
+                "auc": auc,
+                "mean_relational_cross": safe_mean(pos["mean_relational"]),
+                "mean_relational_internal": safe_mean(neg["mean_relational"]),
+                "mean_anisotropy_cross": safe_mean(pos["mean_anisotropy"]),
+                "mean_anisotropy_internal": safe_mean(neg["mean_anisotropy"]),
+                "top_prev_generator_cross": pos["prev_generator"].value_counts().index[0] if len(pos) else np.nan,
+                "top_prev_generator_internal": neg["prev_generator"].value_counts().index[0] if len(neg) else np.nan,
+                "top_feature_1": coef.iloc[0]["feature"] if len(coef) > 0 else np.nan,
+                "top_feature_2": coef.iloc[1]["feature"] if len(coef) > 1 else np.nan,
+                "top_feature_3": coef.iloc[2]["feature"] if len(coef) > 2 else np.nan,
+            }
+        )
+
+    out = pd.DataFrame(rows)
+    order = {k: i for i, k in enumerate(CLASS_ORDER)}
+    out["order"] = out["route_class"].map(lambda x: order.get(x, 999))
+    return out.sort_values("order").drop(columns="order").reset_index(drop=True)
+
+
+def build_summary(metrics_df: pd.DataFrame, summary_df: pd.DataFrame, coef_all: pd.DataFrame) -> str:
+    pooled_reference = 0.6381  # from OBS-037b
+
+    lines = [
+        "=== OBS-038 Family-Specific Gateway Laws Summary ===",
+        "",
+        f"pooled_reference_auc = {pooled_reference:.4f}",
+        "",
+        "Interpretive guide",
+        "- family-specific AUC tests whether pooled modeling washed out stronger per-family structure",
+        "- top features indicate which pre-second-step variables matter within each family",
+        "- family AUC materially above pooled reference suggests a family-specific law",
+        "",
+        "Family metrics",
+    ]
+
+    for _, row in summary_df.iterrows():
+        lines.extend(
+            [
+                f"{row['route_class']}",
+                f"  n_rows                     = {int(row['n_rows'])}",
+                f"  crossing_rate              = {float(row['crossing_rate']):.4f}",
+                f"  auc                        = {float(row['auc']):.4f}",
+                f"  mean_relational_cross      = {float(row['mean_relational_cross']):.4f}",
+                f"  mean_relational_internal   = {float(row['mean_relational_internal']):.4f}",
+                f"  mean_anisotropy_cross      = {float(row['mean_anisotropy_cross']):.4f}",
+                f"  mean_anisotropy_internal   = {float(row['mean_anisotropy_internal']):.4f}",
+                f"  top_prev_generator_cross   = {row['top_prev_generator_cross']}",
+                f"  top_prev_generator_internal= {row['top_prev_generator_internal']}",
+                f"  top_feature_1              = {row['top_feature_1']}",
+                f"  top_feature_2              = {row['top_feature_2']}",
+                f"  top_feature_3              = {row['top_feature_3']}",
+                "",
+            ]
+        )
+
+    lines.append("Top family-specific coefficients")
+    for fam in CLASS_ORDER:
+        fam_coef = coef_all[coef_all["route_class"] == fam].head(5)
+        lines.append(f"  {fam}")
+        if len(fam_coef) == 0:
+            lines.append("    none")
+        else:
+            for _, row in fam_coef.iterrows():
+                lines.append(f"    {row['feature']}: coef={row['coefficient']:.6f}")
+
+    return "\n".join(lines)
+
+
+def render_figure(summary_df: pd.DataFrame, coef_all: pd.DataFrame, outpath: Path) -> None:
+    fig = plt.figure(figsize=(16.5, 10), constrained_layout=True)
+    gs = fig.add_gridspec(2, 3, width_ratios=[1.15, 1.15, 1.0], height_ratios=[1.0, 1.0])
+
+    ax_auc = fig.add_subplot(gs[0, 0])
+    ax_fields = fig.add_subplot(gs[0, 1])
+    ax_top = fig.add_subplot(gs[0, 2])
+    ax_text = fig.add_subplot(gs[1, 0:2])
+    ax_diag = fig.add_subplot(gs[1, 2])
+
+    x = np.arange(len(summary_df))
+    ax_auc.bar(x, summary_df["auc"])
+    ax_auc.axhline(0.6381, linestyle="--")
+    ax_auc.set_xticks(x)
+    ax_auc.set_xticklabels(summary_df["route_class"], rotation=12)
+    ax_auc.set_title("Family-specific AUC", fontsize=14, pad=8)
+    ax_auc.grid(alpha=0.15, axis="y")
+
+    width = 0.34
+    ax_fields.bar(
+        x - width / 2,
+        summary_df["mean_anisotropy_cross"] - summary_df["mean_anisotropy_internal"],
+        width,
+        label="Δ anisotropy",
+    )
+    ax_fields.bar(
+        x + width / 2,
+        summary_df["mean_relational_cross"] - summary_df["mean_relational_internal"],
+        width,
+        label="Δ relational",
+    )
+    ax_fields.set_xticks(x)
+    ax_fields.set_xticklabels(summary_df["route_class"], rotation=12)
+    ax_fields.set_title("Crossing minus internal field means", fontsize=14, pad=8)
+    ax_fields.grid(alpha=0.15, axis="y")
+    ax_fields.legend()
+
+    ax_top.axis("off")
+    y = 0.95
+    for _, row in summary_df.iterrows():
+        ax_top.text(0.02, y, str(row["route_class"]), fontsize=12, fontweight="bold")
+        y -= 0.06
+        ax_top.text(0.04, y, f"f1: {row['top_feature_1']}", fontsize=9.5, family="monospace")
+        y -= 0.045
+        ax_top.text(0.04, y, f"f2: {row['top_feature_2']}", fontsize=9.5, family="monospace")
+        y -= 0.045
+        ax_top.text(0.04, y, f"f3: {row['top_feature_3']}", fontsize=9.5, family="monospace")
+        y -= 0.07
+    ax_top.set_title("Top family features", fontsize=14, pad=8)
+
+    ax_text.axis("off")
+    y = 0.95
+    for fam in CLASS_ORDER:
+        fam_coef = coef_all[coef_all["route_class"] == fam].head(4)
+        ax_text.text(0.02, y, fam, fontsize=12, fontweight="bold")
+        y -= 0.06
+        if len(fam_coef) == 0:
+            ax_text.text(0.04, y, "none", fontsize=10, family="monospace")
+            y -= 0.05
+        else:
+            for _, row in fam_coef.iterrows():
+                ax_text.text(0.04, y, f"{row['feature']}: {row['coefficient']:.4f}", fontsize=9.5, family="monospace")
+                y -= 0.045
+        y -= 0.04
+    ax_text.set_title("Coefficient detail", fontsize=14, pad=8)
+
+    best = summary_df.sort_values("auc", ascending=False).iloc[0]
+    ax_diag.axis("off")
+    text = (
+        "OBS-038 diagnostics\n\n"
+        "pooled reference AUC:\n0.638\n\n"
+        f"best family AUC:\n{best['route_class']} = {best['auc']:.3f}\n\n"
+        "Interpretation:\n"
+        "tests whether each family\n"
+        "has its own gateway law,\n"
+        "instead of one pooled law."
+    )
+    ax_diag.text(
+        0.02, 0.98, text,
+        va="top", ha="left", fontsize=10.2, family="monospace",
+        bbox=dict(boxstyle="round,pad=0.35", fc="white", ec="0.85", alpha=0.95),
+    )
+
+    fig.suptitle("PAM Observatory — OBS-038 family-specific gateway laws", fontsize=21)
+    fig.savefig(outpath, dpi=220)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fit family-specific gateway laws.")
+    parser.add_argument("--dataset-csv", default=Config.dataset_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--min-rows", type=int, default=Config.min_rows)
+    parser.add_argument("--random-state", type=int, default=Config.random_state)
+    args = parser.parse_args()
+
+    cfg = Config(
+        dataset_csv=args.dataset_csv,
+        outdir=args.outdir,
+        min_rows=args.min_rows,
+        random_state=args.random_state,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    ds = load_csv(cfg.dataset_csv)
+
+    coef_frames = []
+    metric_rows = []
+    for fam in CLASS_ORDER:
+        fam_df = ds[ds["route_class"] == fam].copy()
+        coef, metrics = fit_family_model(fam_df, fam)
+        coef_frames.append(coef)
+        metric_rows.append(metrics)
+
+    coef_all = pd.concat(coef_frames, ignore_index=True) if coef_frames else pd.DataFrame()
+    metrics_df = pd.DataFrame(metric_rows)
+    summary_df = build_summary_table(ds, coef_all, metrics_df)
+
+    coef_csv = outdir / "family_specific_gateway_coefficients.csv"
+    metrics_csv = outdir / "family_specific_gateway_metrics.csv"
+    summary_csv = outdir / "family_specific_gateway_summary.csv"
+    txt_path = outdir / "obs038_family_specific_gateway_laws_summary.txt"
+    png_path = outdir / "obs038_family_specific_gateway_laws_figure.png"
+
+    coef_all.to_csv(coef_csv, index=False)
+    metrics_df.to_csv(metrics_csv, index=False)
+    summary_df.to_csv(summary_csv, index=False)
+    txt_path.write_text(build_summary(metrics_df, summary_df, coef_all), encoding="utf-8")
+    render_figure(summary_df, coef_all, png_path)
+
+    print(coef_csv)
+    print(metrics_csv)
+    print(summary_csv)
+    print(txt_path)
+    print(png_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is a stacked PR. Please review against the current base branch, not against `main`.

## Summary

This PR adds the core-to-escape gateway-law arc on top of the seam algebra layer.

It introduces:
- explicit core-to-escape boundary analysis
- multiple predictor passes with leakage cleanup
- prelaunch and instance-level gateway prediction
- launch-state refinement testing
- history-aware predictor checks
- family-specific gateway-law analysis

## Included studies

- `obs034_core_to_escape_boundary.py`
- `obs035_gateway_crossing_predictor.py`
- `obs035b_gateway_crossing_predictor_prelaunch.py`
- `obs035c_instance_level_gateway_predictor.py`
- `obs036_gateway_state_refinement.py`
- `obs037_history_aware_gateway_predictor.py`
- `obs037b_pre_second_step_gateway_predictor.py`
- `obs038_family_specific_gateway_laws.py`

## Why this PR

This layer asks not just where the seam boundary is, but when and how it fires.

It freezes:
- the biased core-to-escape gateway
- valid predictor discipline after leakage removal
- instance-level launch prediction
- the negative result that coarse state refinement is not enough
- the positive result that gateway laws are partly family-specific

## Notes

- This PR is stacked on top of the seam algebra / proto-groupoid PR.
- Some intermediate predictor files are included intentionally because they document the cleanup path from leakage-prone to valid models.