### PR TITLE
docs: align repository docs with obs043 dynamical layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,26 @@ For details, see:
 
 ---
 
+## Response-Guided Dynamical Layer
+
+The repository now also includes a first response-guided dynamical layer derived from the response tensor field.
+
+This layer currently includes:
+
+- `experiments/studies/obs043_response_flow.py`
+- `experiments/studies/obs043b_response_flow_path_families.py`
+- `docs/05_project/canonical_response_guided_flow.md`
+
+At current observatory status, this layer supports:
+- seam-engaged embedded flow paths
+- relaxed vs strict flow-regime comparison
+- seam-bundle scalar modulation tests
+- first-pass route-family decomposition
+
+This layer is established at first pass, but remains methodologically discretized and is not yet promoted into the canonical runtime package.
+
+---
+
 ## Conceptual Layers
 
 ### Engine
@@ -271,6 +291,7 @@ Useful repository anchors:
 - canonical pipeline stages and runner implemented
 - downstream canonical family/gateway layer implemented and validated
 - corpora externalized into observatory data storage
+- first response-guided dynamical flow layer implemented and documented
 
 ---
 

--- a/docs/05_project/README.md
+++ b/docs/05_project/README.md
@@ -13,10 +13,11 @@ It is the home for:
 
 ## Current role
 
-The repository has:
+The repository now has:
 
 - a canonical implemented runtime for the downstream observatory pipeline
 - a downstream canonical family/gateway layer implemented in `scripts/canonical/`
+- a first repository-facing canonical dynamical-layer object for OBS-043
 - validated canonical artifacts under `outputs/canonical/`
 
 Primary runtime entrypoints:
@@ -69,6 +70,27 @@ These documents are intended to:
 - improve public-facing transparency as the repository catches up to the science
 - mark what is implemented, what is validated, and what remains provisional
 
+## Canonical dynamical layer
+
+The repository now also includes a first canonical dynamical-layer object:
+
+- [`canonical_response_guided_flow.md`](./canonical_response_guided_flow.md)
+
+This document formalizes the response-guided flow construction introduced in OBS-043:
+- dominant response-eigenvector direction field
+- embedded discrete flow paths
+- seam engagement
+- phase crossing
+- seam-bundle scalar modulation
+- current route-family refinement
+
+Related study scripts include:
+
+- `experiments/studies/obs043_response_flow.py`
+- `experiments/studies/obs043b_response_flow_path_families.py`
+
+This dynamical layer is now scientifically established at first pass, but remains methodologically discretized and is not yet promoted into `src/pam/`.
+
 ## Current architectural status
 
 The canonical family/gateway layer is now:
@@ -110,6 +132,8 @@ Canonical family-layer documents include:
 - `canonicalization_implementation_plan.md`
 
 A current status note for the implemented canonical layer should also live in this section.
+
+- [`canonical_response_guided_flow.md`](./canonical_response_guided_flow.md)
 
 ## Guidance
 

--- a/docs/05_project/canonical_response_guided_flow.md
+++ b/docs/05_project/canonical_response_guided_flow.md
@@ -463,3 +463,54 @@ This object directly supports later observatory directions such as:
 - attractor / basin / cycle analysis
 
 It should therefore be treated as a stable canonical object for the current observatory phase, even though its present implementation remains first-pass and discretized.
+
+## 15. OBS-043 Current Route-Family Refinement
+
+Follow-on analysis of the OBS-043 flow outputs resolves response-guided flow into a first-pass route-family taxonomy.
+
+Current route families are:
+- `seam_hugging`
+- `release_directed`
+- `short_trapped`
+- `mixed`
+
+A key refinement is that:
+- **cross-phase is not treated as a route family**
+- it is treated as a **path attribute**
+
+This correction matters because early classification attempts over-assigned seam-hugging paths into a separate `cross_phase` class, obscuring the actual route structure.
+
+### Current empirical reading
+
+The current first-pass reading is:
+- `short_trapped` is the largest single route family under the present discretized integrator
+- `release_directed` is a stable minority family
+- `seam_hugging` is also a stable family once cross-phase is treated as an attribute rather than an overriding class
+
+### Scalar modulation refinement
+
+Neighborhood directional mismatch produces the clearest route-family-level modulation currently observed.
+
+Its most important effect is:
+- preservation of seam-engaged route families
+- reduction of cross-phase release behavior
+- modest shortening of path extent
+
+This supports the current interpretation that neighborhood directional mismatch behaves more like a routing cost than a seam-repulsion barrier.
+
+### Current limitation
+
+The route-family picture remains conditioned by the current discrete node-hopping integrator.
+
+In particular:
+- all tested regimes still terminate by forward-neighbor exhaustion
+- the current taxonomy should therefore be read as a first-pass discretized routing classification rather than a final continuous-flow decomposition
+
+### Current stabilized reading
+
+Response-guided flow now has:
+- a canonical object definition
+- a first dynamical observatory interpretation
+- and a first route-family decomposition
+
+This is the current repository-facing stabilized state of OBS-043.

--- a/docs/README.md
+++ b/docs/README.md
@@ -104,6 +104,15 @@ It records what is implemented, what is validated, and what remains provisional.
 
 ---
 
+### Canonical dynamical layer
+
+- [`05_project/canonical_response_guided_flow.md`](05_project/canonical_response_guided_flow.md)  
+  Formal definition and current stabilized status of response-guided flow as the first observatory dynamical-layer object
+
+This document records the OBS-043 extension from static seam/response structure into seam-engaged response-guided flow, including the current first-pass route-family refinement.
+
+---
+
 ## Canonical Runtime
 
 The repository now has a single canonical full-pipeline entrypoint:


### PR DESCRIPTION
## What this PR does

Updates repository documentation to reflect the current stabilized state of OBS-043.

Main changes:

- updates `docs/05_project/canonical_response_guided_flow.md`
- updates `docs/05_project/README.md`
- updates `docs/README.md`
- updates the root `README.md`

## Why this matters

OBS-043 is now established as a real observatory layer extension.

The repository already contains:
- `obs043_response_flow.py`
- `obs043b_response_flow_path_families.py`
- `canonical_response_guided_flow.md`

This PR makes the documentation reflect that state.

## Main documentation refinement

The updated docs now state clearly that the repository includes:

- a first response-guided dynamical flow layer
- a canonical repository-facing formal object definition
- a first route-family refinement over response-flow outputs

## Scope

This PR is docs-only.

It does not:
- change the OBS-043 study scripts
- introduce OBS-044
- promote flow code into `src/pam/`

## Reviewer guidance

Please review this PR as a documentation catch-up checkpoint before the next major observatory milestone.