### PR TITLE
docs: add concept docs for TIP, TIM, and topological identity

### DIFF
--- a/docs/concepts/tim.md
+++ b/docs/concepts/tim.md
@@ -1,0 +1,387 @@
+# TIM — Transformation Invariance Metric
+
+## Purpose
+
+TIM is PAM’s second-order transformation-stability instrument.
+
+If TIP measures how a text aligns with a declared invariant frame, TIM measures how stable that alignment remains when the text is transformed, truncated, rescaled, or otherwise re-viewed.
+
+The core idea is:
+
+**an invariant claim becomes stronger when it survives controlled transformation.**
+
+TIM exists to operationalize that claim.
+
+---
+
+## Why TIM exists
+
+Recursive language systems do not only produce local semantic structure. They also produce structures that may or may not survive:
+
+- truncation
+- rescaling
+- head/tail cropping
+- windowing
+- downsampling
+- alternate sequence views
+
+A text may appear strongly aligned with an invariant in one view and lose that alignment in another. So local invariant measurement alone is not enough.
+
+TIM was introduced to answer questions such as:
+
+- does this invariant signature persist under controlled view changes?
+- how stable is local structure across transformed views?
+- is a text’s apparent invariant character robust or fragile?
+- can we measure transformation-level consistency as a scientific observable?
+
+That makes TIM a second-order instrument: it does not only score a text, it scores the **stability of the text’s TIP profile under transformation**.
+
+---
+
+## TIM as a second-order instrument
+
+A useful shorthand is:
+
+- **TIP** asks: what invariant signature does this text express?
+- **TIM** asks: how stable is that signature under controlled transformation?
+
+This relationship is central.
+
+TIM is not an independent replacement for TIP. It is built on top of TIP and depends on TIP outputs as its first-order substrate.
+
+That is why the two concept docs belong together.
+
+---
+
+## The core TIM idea
+
+TIM treats a text not as a single frozen object, but as something that can be viewed through multiple controlled transformations.
+
+Examples include:
+
+- truncating the text
+- taking head-only or tail-only slices
+- applying sliding windows
+- downsampling sentence structure
+- comparing shorter and longer views of the same source
+
+For each transformed view, TIP is applied again.
+
+TIM then compares the resulting sequence of TIP outputs to determine how much of the original invariant structure survives.
+
+This means TIM measures not merely semantic similarity, but **invariant stability across transformed views**.
+
+---
+
+## What TIM measures
+
+TIM measures transformation stability.
+
+That stability may include:
+
+- signature preservation
+- score preservation
+- coherence preservation
+- pathwise similarity between transformed signature sequences
+- aggregate stability under a chosen family of transformations
+
+So TIM is not mainly asking whether two texts are similar.
+
+It is asking whether one text remains recognizably aligned with the same invariant structure when its presentation is changed in controlled ways.
+
+---
+
+## Transformation families
+
+TIM operates by generating multiple transformed views of a single source text.
+
+Typical transformation families include:
+
+- truncation
+- head / tail slicing
+- downsampling
+- fixed-length windows
+- alternate partial reads
+
+The exact set of transformations is less important than the principle:
+
+TIM tests whether an invariant signature is robust to **structured loss or reframing of available information**.
+
+This makes it especially useful in recursive systems, where instability often first appears as a breakdown of structural persistence under altered context.
+
+---
+
+## Signature stability
+
+One of TIM’s most important roles is measuring signature stability.
+
+If TIP maps a text to a signature, and transformed views produce a sequence of related signatures, TIM can ask:
+
+- are the same invariant coordinates still active?
+- do the strongest coordinates remain strongest?
+- does the text preserve its qualitative structural identity under view change?
+- does the signature collapse, fragment, or drift?
+
+This makes TIM a stability metric over TIP signatures.
+
+That is why it belongs conceptually above TIP in the measurement hierarchy.
+
+---
+
+## TIM and pathwise comparison
+
+TIM is not limited to comparing two isolated scores.
+
+Because transformed views often form an ordered sequence, TIM can compare **paths of signatures** across transformations.
+
+This is why sequence-alignment ideas matter.
+
+In practice, TIM may use a lightweight path-similarity logic resembling:
+
+- ordered comparison across transformed views
+- cumulative mismatch
+- DTW-like or alignment-like similarity between signature traces
+
+The important conceptual point is:
+
+TIM is sensitive not only to endpoint similarity, but to the **trajectory of invariant structure across transformation**.
+
+That gives it more depth than a simple one-shot stability score.
+
+---
+
+## TIM report objects
+
+TIM typically returns a structured report rather than a single bare scalar.
+
+A TIM report may include:
+
+- transformed-view summaries
+- TIP signatures per view
+- alignment or mismatch measures across views
+- aggregate stability score
+- intermediate diagnostic values
+
+This is important architecturally.
+
+TIM is a scientific instrument, so it should produce inspectable measurement structure, not only an opaque score.
+
+That makes it suitable for:
+- downstream observables
+- debugging
+- scientific inspection
+- and documentation-facing interpretation
+
+---
+
+## What TIM is not
+
+It is useful to state clearly what TIM is **not**.
+
+TIM is not:
+
+- a generic text similarity metric
+- a generic robustness benchmark
+- a replacement for TIP
+- a universal notion of truth preservation
+- a full dynamical observatory by itself
+
+Instead, TIM is a transformation-stability instrument built specifically to test invariant persistence under controlled view changes.
+
+---
+
+## Relationship to TIP
+
+TIM depends on TIP at a conceptual and operational level.
+
+Without TIP:
+
+- there is no invariant signature substrate
+- there is no first-order alignment signal
+- there is no structure whose persistence TIM could evaluate
+
+This means TIM should always be read as downstream of TIP.
+
+A clean mental model is:
+
+1. TIP measures local invariant structure
+2. TIM asks whether that structure survives transformation
+
+This is one of the clearest hierarchy relations in the repository.
+
+---
+
+## Why TIM matters scientifically
+
+TIM matters because local alignment alone can be misleading.
+
+A text may appear strongly aligned with an invariant frame in one presentation but reveal its fragility when:
+
+- compressed
+- truncated
+- split into windows
+- or partially removed from context
+
+TIM detects that fragility.
+
+This makes it especially useful for studying:
+
+- recursive drift
+- structural decay
+- robustness of semantic organization
+- persistence of invariant-sensitive signals across degraded or rescaled views
+
+In this way, TIM strengthens the scientific meaning of an invariant claim.
+
+An invariant is more credible when it survives transformation.
+
+---
+
+## TIM and recursive systems
+
+Recursive systems are particularly vulnerable to subtle forms of structural instability.
+
+A local score may remain superficially high even while the deeper organization of a text becomes unstable across partial views.
+
+TIM is useful here because it detects whether the text’s invariant structure is:
+
+- stable across reduced views
+- fragile under partial information
+- or progressively collapsing as context is altered
+
+This makes TIM particularly valuable in recursive language-system research.
+
+It gives the repository a way to distinguish:
+
+- local alignment
+from
+- structural persistence
+
+That distinction is essential in systems where drift can be gradual and distributed.
+
+---
+
+## TIM and observables
+
+While TIP feeds the observables layer directly, TIM is best understood as an advanced measurement instrument that can support higher-order analyses of stability, robustness, and structural persistence.
+
+TIM outputs can in principle support observables such as:
+
+- stability distributions across a population
+- robustness stratification across corpora or runs
+- relationship between local invariant strength and transformation persistence
+- collapse or drift diagnostics under recursive iteration
+
+Even when not used everywhere in the current observatory, TIM matters conceptually because it expands the measurement language of PAM beyond first-order alignment.
+
+---
+
+## TIM and scientific restraint
+
+One of TIM’s virtues is that it encodes a form of scientific restraint.
+
+Instead of accepting an invariant judgment at face value, TIM asks whether the judgment survives a family of controlled tests.
+
+This fits the broader style of PAM:
+
+- derive rather than assume
+- compare representations
+- ask what survives transformation
+- treat invariants as claims to be tested, not decorations to be asserted
+
+That makes TIM one of the most philosophically aligned instruments in the repository.
+
+---
+
+## Output interpretation
+
+A high TIM score should be read as:
+
+- strong stability of invariant structure across the chosen transformation family
+
+A low TIM score should be read as:
+
+- fragility, drift, or inconsistency of invariant structure under those transformations
+
+This interpretation is always conditional on:
+
+- the chosen invariant specification
+- the chosen TIP mode
+- the chosen transformation family
+- the chosen comparison rule
+
+So TIM does not yield a universal “truth score.” It yields a structured stability judgment under a declared measurement setup.
+
+---
+
+## Limitations
+
+TIM also has real limits.
+
+Its results depend on:
+
+- the quality and relevance of the underlying TIP instrument
+- the chosen transformations
+- the sequencing of transformed views
+- the comparison or alignment rule
+- the meaning of stability in the current scientific context
+
+This means TIM should be used carefully.
+
+A low TIM score can indicate real structural fragility, but it can also reflect a poorly chosen transformation family or a mismatch between the measurement setup and the intended invariant.
+
+As with TIP, this is not a flaw. It is part of instrument honesty.
+
+---
+
+## Why the name matters
+
+The name “Transformation Invariance Metric” is meant literally.
+
+TIM measures how much invariant structure remains under transformation.
+
+It is not only a metric of text similarity. It is a metric of **invariance persistence**.
+
+That is why it is best understood as a scientific instrument rather than only a score function.
+
+---
+
+## Relationship to the rest of PAM
+
+TIP and TIM together form the repository’s core measurement pair.
+
+- TIP provides first-order invariant perception
+- TIM provides second-order transformation-stability assessment
+
+These instruments sit beneath the larger observatory layers.
+
+They are conceptually upstream of:
+
+- observables
+- geometric organization
+- phase structure
+- topology
+- interface-facing inspection
+
+That is why they deserve dedicated concept docs rather than being buried as utilities.
+
+---
+
+## Summary
+
+TIM is PAM’s second-order transformation-stability instrument.
+
+Its key roles are:
+
+- generate transformed views of a text
+- apply TIP across those views
+- compare invariant signatures across transformations
+- estimate persistence, fragility, or drift of invariant structure
+- return structured stability reports
+- strengthen the scientific meaning of invariant claims by testing their survival under controlled transformation
+
+The central principle is:
+
+**TIM measures whether the invariant structure detected by TIP remains stable when the text is viewed under controlled transformation.**
+
+That is why TIM is the natural second-order companion to TIP.

--- a/docs/concepts/tip.md
+++ b/docs/concepts/tip.md
@@ -1,0 +1,366 @@
+# TIP — The Invariant Perceptron
+
+## Purpose
+
+TIP is PAM’s first-order invariant measurement instrument.
+
+Its role is to evaluate texts relative to a declared set of invariants and to produce a structured signature describing how strongly those invariants are expressed. TIP is not primarily a generic classifier or embedding utility. It is a scientific instrument for probing invariant structure in meaning-bearing text.
+
+The central idea is simple:
+
+**a text can be measured by how it aligns with a chosen invariant frame.**
+
+TIP turns that idea into a reusable repository object.
+
+---
+
+## Why TIP exists
+
+PAM is concerned with recursive language systems, structured variation, and observables that survive representation changes better than raw surface form.
+
+To study such systems, the repository needs an instrument that can ask questions like:
+
+- does this text preserve a chosen invariant?
+- how stable is that preservation across a population?
+- what signature does a text express relative to an invariant set?
+- how coherent is that signature internally?
+
+TIP exists to answer those questions.
+
+It provides the microscopic measurement layer from which later observables can be built.
+
+---
+
+## The core objects
+
+At the center of TIP are two main ideas:
+
+- **InvariantSpec**
+- **InvariantPerceptron**
+
+### `InvariantSpec`
+
+An invariant specification defines the frame against which texts are measured.
+
+Conceptually, an invariant specification says:
+
+- what counts as the invariant family of interest
+- how it is described
+- what anchors, cues, or examples define it
+- what semantic direction TIP should measure
+
+An invariant is not “anything the model predicts.” It is a declared measurement target.
+
+This is why TIP is an instrument rather than only a learned scorer.
+
+### `InvariantPerceptron`
+
+The `InvariantPerceptron` is the instrument that applies an invariant specification to text.
+
+Its job is to produce:
+
+- invariant-alignment signals
+- signature-like outputs
+- coherence-like scores
+- or learned/heuristic judgments derived from the invariant frame
+
+It is a perceptron in the broad observational sense:
+- it perceives texts through an invariant frame
+
+not in the narrow historical single-layer-neural-network sense.
+
+---
+
+## What TIP measures
+
+TIP measures **alignment to an invariant frame**.
+
+That alignment may be expressed as:
+
+- a scalar score
+- a Boolean or thresholded signature coordinate
+- a multi-coordinate invariant signature
+- a coherence or consistency estimate across parts of a text
+
+The important point is that TIP is not trying to summarize a text in every possible way. It is measuring a very specific thing:
+
+- how the text sits relative to declared invariants
+
+This gives the repository a stable first-order measurement layer.
+
+---
+
+## TIP as a signature instrument
+
+One of TIP’s most important roles in PAM is signature production.
+
+A text can be mapped to a signature that records which invariant coordinates are expressed strongly enough to count as present, absent, or active.
+
+These signatures later become the substrate for higher-level observables such as:
+
+- entropy
+- microstructure
+- macrostate labeling
+- transition statistics
+- lag and regression analyses
+
+So TIP should not be thought of as the endpoint of analysis.
+
+It is the first observatory instrument whose outputs are later promoted into collective observables.
+
+---
+
+## Heuristic and learned modes
+
+TIP supports two broad operational styles.
+
+### Heuristic mode
+
+In heuristic mode, the invariant measurement is governed by explicit rules, anchors, or manually structured criteria.
+
+This makes the instrument:
+
+- interpretable
+- easy to inspect
+- easy to stabilize
+- suitable for early-stage scientific use
+
+Heuristic mode is especially useful when the repository wants to preserve a transparent measurement contract.
+
+### Learned mode
+
+In learned mode, the instrument can use learned scoring or embedding-based estimation to evaluate invariant alignment.
+
+This allows:
+
+- more flexible semantic recognition
+- smoother generalization beyond explicit keyword or anchor matches
+- richer treatment of semantic similarity
+
+The important design choice is that TIP supports both styles.
+
+That means the repository does not collapse invariant measurement into a single epistemology. It can use:
+
+- explicit instrument design
+- or learned semantic recognition
+
+depending on the needs of the analysis.
+
+---
+
+## Coherence as part of measurement
+
+TIP is not only about whether a text resembles an invariant anchor set.
+
+It also cares about internal consistency.
+
+This is why coherence-like measurements matter.
+
+A text may score strongly on a semantic direction while still expressing that direction in a fragmented, unstable, or internally inconsistent way. TIP therefore treats alignment and coherence as related but distinct aspects of invariant measurement.
+
+This matters especially in recursive systems, where superficially similar outputs may differ greatly in structural stability.
+
+---
+
+## What TIP is not
+
+It is useful to state clearly what TIP is **not**.
+
+TIP is not:
+
+- a generic sentiment model
+- a broad text embedding service
+- a full semantic parser
+- a universal classifier of all text properties
+- the observatory itself
+
+It is a specific measurement instrument.
+
+It measures texts through declared invariant frames and produces structured outputs that later observatory layers can aggregate.
+
+---
+
+## Relationship to the rest of PAM
+
+TIP sits at the beginning of the measurement stack.
+
+A useful mental model is:
+
+1. TIP measures invariant structure locally
+2. observables promote TIP outputs into collective quantities
+3. derived analyses study relations among those quantities
+4. geometry and later observatory layers organize larger-scale behavior
+
+This means TIP is the first-order microscopic instrument of the PAM stack.
+
+Without TIP, the later entropy, microstructure, and macrostate layers would have no invariant-sensitive substrate to build on.
+
+---
+
+## TIP and observables
+
+TIP signatures feed directly into the observables layer.
+
+This allows the repository to define quantities such as:
+
+- joint signature entropy
+- marginal signature entropy
+- dominant local signature windows
+- run lengths of signature regimes
+- boundary density
+- frozen vs mixed macrostate labels
+- transition rates between derived states
+
+This is one of the key reasons TIP matters so much architecturally.
+
+It does not merely score texts. It creates the raw material for a whole observatory of collective structure.
+
+---
+
+## TIP and the generative spine
+
+TIP also connects back into the generative side of the repository.
+
+In particular, injector logic can use TIP signatures to:
+
+- filter mutations
+- target desired signature classes
+- stabilize generation relative to invariant frames
+
+So TIP is not only a passive observer.
+
+In some parts of PAM, it becomes part of the control loop itself:
+- generation is steered partly through invariant-sensitive evaluation
+
+That gives TIP a special architectural role:
+
+- it is both an instrument
+- and, at times, a semantic selector inside the generative substrate
+
+---
+
+## TIP and invariants
+
+The word “invariant” should be read carefully.
+
+In PAM, an invariant is not necessarily a mathematically exact quantity preserved under all transformations.
+
+Instead, an invariant is an intended structural feature, semantic frame, or organizing property that the instrument is designed to track across controlled variation.
+
+So TIP’s invariants are:
+
+- operational
+- declared
+- scientifically chosen
+- and tested through measurement practice
+
+This is one reason the name “The Invariant Perceptron” works so well.
+
+TIP does not assume invariants as metaphysical absolutes. It perceives texts through explicitly chosen invariant commitments.
+
+---
+
+## Why the name matters
+
+The name “The Invariant Perceptron” is not decorative.
+
+It expresses the core design:
+
+- there is a chosen invariant frame
+- the instrument perceives texts relative to that frame
+- the resulting measurement is structured, reusable, and promotable into higher observables
+
+The name is meant to emphasize the scientific role of the object, not only its implementation details.
+
+---
+
+## Output style
+
+Depending on the mode and configuration, TIP may produce outputs such as:
+
+- alignment scores
+- thresholded signature coordinates
+- structured signature dictionaries
+- coherence measures
+- report objects suitable for downstream observables
+
+What matters is not the exact return type in every configuration, but the invariant measurement contract:
+
+**TIP returns a representation of how a text aligns with a declared invariant structure.**
+
+---
+
+## Scientific use
+
+TIP is best used when the repository needs a stable first-order instrument for asking:
+
+- what structural signal is present locally?
+- how does that signal vary across a population?
+- how much invariant structure survives perturbation?
+- what signatures should later observables aggregate?
+
+It is especially appropriate when the scientific question concerns:
+
+- structural preservation
+- semantic continuity
+- invariant-sensitive variation
+- recursive drift
+- or population-level organization of meaning-bearing outputs
+
+---
+
+## Limitations
+
+TIP also has real limits.
+
+Its outputs depend on:
+
+- the chosen invariant specification
+- the quality of anchors or semantic reference structure
+- the chosen thresholding or scoring conventions
+- the mode of operation (heuristic vs learned)
+
+This means TIP should not be mistaken for an oracle.
+
+It is a designed instrument, and its value depends on careful specification, calibration, and interpretation.
+
+That is not a weakness. It is part of scientific honesty.
+
+---
+
+## Relationship to TIM
+
+TIM is best understood as a second-order instrument built on TIP.
+
+If TIP asks:
+
+- what invariant signature does this text express?
+
+then TIM asks:
+
+- how stable is that signature under truncation, rescaling, or other transformation?
+
+So TIP is the first-order invariant perceiver, and TIM is the transformation-stability instrument built over it.
+
+This relationship is important enough that the two concepts should usually be read together.
+
+---
+
+## Summary
+
+TIP is PAM’s first-order invariant measurement instrument.
+
+Its key roles are:
+
+- define invariant-sensitive text measurement through `InvariantSpec`
+- apply that measurement through `InvariantPerceptron`
+- produce signature-like outputs
+- estimate alignment and coherence
+- feed the observables layer
+- and, in some contexts, support invariant-aware generative control
+
+The central principle is:
+
+**TIP measures how texts align with declared invariant frames, and turns that local alignment into reusable scientific signal.**
+
+That is why TIP is one of the foundational concept objects in the repository.

--- a/docs/concepts/topological_identity.md
+++ b/docs/concepts/topological_identity.md
@@ -1,0 +1,522 @@
+# Topological Identity
+
+## Purpose
+
+This document explains the **topological identity** program in PAM.
+
+Topological identity is the part of the observatory that asks:
+
+- what counts as the local structural identity of a state?
+- how should two local identities be compared?
+- can identity change be treated as a field over the manifold?
+- is identity transport path-dependent?
+- where does obstruction localize?
+
+This layer lives primarily in:
+
+- `src/pam/topology/identity.py`
+- `src/pam/topology/identity_proxy.py`
+- `src/pam/topology/identity_field.py`
+- `src/pam/topology/identity_metric.py`
+- `src/pam/topology/identity_metric_full.py`
+- `src/pam/topology/identity_transport.py`
+- `src/pam/topology/identity_obstruction.py`
+
+The central idea is:
+
+**identity is not treated as a scalar label, but as local relational organization.**
+
+---
+
+## Why this layer exists
+
+Geometry and phase already tell the observatory a great deal:
+
+- where the manifold bends
+- where the seam lies
+- how far states sit from transition structure
+- where operator-derived fields concentrate
+
+But geometry alone does not answer a deeper question:
+
+- when are two local states structurally “the same” or “different” in their organization?
+
+The topological identity layer exists to answer that question.
+
+It gives the observatory a way to treat local structural organization as a first-class object rather than only as a collection of scalar values.
+
+---
+
+## Identity is relational, not scalar
+
+One of the strongest design choices in PAM is that local identity is not reduced to:
+
+- one metric value
+- one phase sign
+- one family label
+- one hand-picked score
+
+Instead, identity is represented as **relational structure**.
+
+This means that a state’s identity depends on how local objects and transitions are arranged, not only on what a single coordinate says.
+
+That is why the identity program begins with graphs rather than scalar summaries.
+
+---
+
+## `IdentityGraph`: the local identity object
+
+The central object is the `IdentityGraph`.
+
+An `IdentityGraph` is a local relational representation of a state’s topological organization.
+
+Depending on the local construction, it may encode things such as:
+
+- basin-like objects
+- critical objects
+- adjacency relations
+- transition relations
+- directional or connectivity summaries
+
+The exact implementation details are less important than the conceptual role:
+
+an `IdentityGraph` is meant to represent the **minimal relational organization** of a local topological state.
+
+This is the core object of the identity layer.
+
+---
+
+## Why graphs are used
+
+Graphs are used because they preserve structural relations better than scalar proxies.
+
+A graph can express:
+
+- what kinds of local objects exist
+- how many there are
+- how they connect
+- how transitions enter or leave them
+- how local organization differs from one region to another
+
+This allows the observatory to talk about identity in a way that is:
+
+- local
+- structured
+- comparison-friendly
+- and less dependent on one arbitrary scalar reduction
+
+That is exactly what this layer needs.
+
+---
+
+## Identity distance
+
+Once local identity objects exist, the next question is:
+
+- how should two identities be compared?
+
+PAM answers this with a **structural identity distance**.
+
+This is not intended to be an exact graph-isomorphism theorem. Instead, it is an operational comparison between relational organizations.
+
+Typical ingredients of the comparison include:
+
+- node-signature histograms
+- adjacency-signature summaries
+- transition-signature summaries
+- degree-like local structure counts
+
+So identity distance should be understood as:
+
+**difference in local relational organization**, measured in an operationally stable way.
+
+This is one of the most important conceptual moves in the whole repository.
+
+---
+
+## Why structural multisets matter
+
+A particularly good design choice in PAM is that identity comparison is based on structural multisets and signature counters rather than exact named-node matching.
+
+That matters because it makes the comparison:
+
+- label-invariant
+- robust to local naming conventions
+- lightweight enough to compute operationally
+- still sensitive to real structural differences
+
+So the identity layer does not require expensive exact graph matching to become scientifically useful.
+
+It measures identity difference through structural summary distributions.
+
+---
+
+## Proxy versus object
+
+The repository makes an important distinction between:
+
+- the richer identity object
+- operational identity proxies
+
+This distinction is preserved through modules such as `identity_proxy.py`.
+
+That is scientifically important.
+
+Not every downstream analysis needs the full graph object, and not every quick diagnostic can afford the full identity-comparison machinery. Proxy objects therefore exist as lower-cost approximations.
+
+But the repository does not collapse the distinction.
+
+This is one of the strengths of the design:
+
+- the full object is acknowledged
+- the proxy is acknowledged
+- and the two are not confused
+
+That keeps the science honest.
+
+---
+
+## Identity as a field
+
+Once pairwise identity differences can be measured, PAM promotes identity change into a field.
+
+This is the role of `identity_field.py`.
+
+The idea is:
+
+- compare neighboring states
+- estimate how identity changes across local directions
+- record that change as a field-like object over the control manifold
+
+This means the observatory can ask not only:
+
+- what is the local identity here?
+
+but also:
+
+- how rapidly does identity change nearby?
+- where is identity variation large?
+- does identity change organize directionally?
+- are there local circulation-like patterns?
+
+This is where identity becomes more than a local object. It becomes a manifold-facing field.
+
+---
+
+## Identity magnitude
+
+One simple but important output of the identity field is **identity magnitude**.
+
+Identity magnitude is the local size of identity change across neighboring states.
+
+This can be read as:
+
+- how quickly relational organization changes here
+- how sensitive local identity is to nearby motion on the manifold
+- where the identity field is calm versus active
+
+This is often the first useful scalar summary of the identity layer.
+
+But it should still be understood as derived from relational comparison, not as a primitive quantity.
+
+---
+
+## Legacy spin and later refinements
+
+Earlier identity-field work in PAM used spin-like or curl-like summaries as a first operational handle on local circulation structure.
+
+These remain useful as historical or comparison objects, but later canonicalization shifted toward more explicit transport- and obstruction-facing quantities.
+
+That means legacy spin should be read as:
+
+- a useful precursor
+- a comparison field
+- not necessarily the final canonical identity object
+
+This distinction also appears in the TUI’s identity hierarchy.
+
+---
+
+## Identity metric layers
+
+The repository includes `identity_metric.py` and `identity_metric_full.py` because the identity program does not stop at local scalar summaries.
+
+Once identity distance exists, it becomes natural to ask:
+
+- is there a larger geometry of identity difference itself?
+- can identity distance organize the manifold in its own right?
+
+These modules push identity comparison toward a metric-like layer.
+
+Conceptually, this means identity is not treated as a one-off local descriptor. It is promoted toward a larger comparison geometry.
+
+That is an ambitious and important move.
+
+---
+
+## Identity transport
+
+Once identity can be compared locally, the next major question is:
+
+- does identity change depend on the path taken through the manifold?
+
+This is the role of `identity_transport.py`.
+
+Identity transport is the attempt to compare how local identity evolves when moved along different local routes.
+
+This is where PAM begins to ask holonomy-like questions in an operational way.
+
+The central idea is:
+
+- transport identity around local loops
+- compare the residual
+- ask whether different routes produce the same identity evolution or not
+
+This is one of the deepest transitions in the whole observatory.
+
+---
+
+## Loop residual and holonomy-like behavior
+
+A particularly important operational object is the local loop residual.
+
+For a small cell or loop in the control lattice, PAM compares identity transport along two different routes that connect the same endpoints.
+
+If the transported identity disagrees, there is a nonzero residual.
+
+This residual is not treated as a grand theorem of formal holonomy. It is treated as a **holonomy-like operational signal**:
+
+- identity transport is path-dependent here
+- local organization is not naively integrable
+- loop transport leaves structural residue
+
+That is the right level of scientific claim.
+
+It is bold enough to be meaningful, but restrained enough to remain honest.
+
+---
+
+## Obstruction
+
+Once loop residuals exist, the next question is:
+
+- where do these residuals concentrate?
+
+This is the role of `identity_obstruction.py`.
+
+Obstruction is the node-local concentration of loopwise identity path-dependence.
+
+It is built by aggregating loop residual information back onto nearby nodes, producing quantities such as:
+
+- mean holonomy
+- mean absolute holonomy
+- max absolute holonomy
+- signed or weighted residual summaries
+- unsigned obstruction magnitude
+
+The key idea is:
+
+**obstruction is not postulated; it is constructed from identity transport mismatch.**
+
+That makes obstruction one of the strongest derived objects in the observatory.
+
+---
+
+## Signed and unsigned obstruction
+
+The obstruction layer can be read in two ways.
+
+### Unsigned obstruction
+
+Unsigned obstruction measures the size of local transport-derived obstruction without regard to orientation.
+
+It answers:
+
+- where is identity transport strongly path-dependent?
+
+### Signed obstruction
+
+Signed obstruction keeps track of orientation or polarity in the local obstruction field.
+
+It answers:
+
+- how is local path-dependent identity structure oriented?
+- do neighboring regions organize with opposite obstruction sign?
+
+This is why signed obstruction is especially rich in grid-facing observatory views.
+
+It allows the identity layer to express not only intensity, but oriented structural organization.
+
+---
+
+## Absolute holonomy
+
+Absolute holonomy is one of the main canonical summaries of the identity-transport layer.
+
+It measures the local magnitude of loop transport residual without regard to sign.
+
+This makes it an especially useful bridge quantity:
+
+- more directly tied to transport than generic field magnitude
+- easier to compare spatially than a raw signed residual
+- useful as a canonical identity-mode overlay in the TUI
+
+Absolute holonomy and obstruction are closely related, but they are not identical in interpretation:
+
+- holonomy emphasizes loop-transport residual
+- obstruction emphasizes the localized concentration of that path dependence
+
+---
+
+## Why this matters scientifically
+
+The topological identity program matters because it lets PAM ask deeper structural questions than scalar field inspection alone can answer.
+
+For example:
+
+- are two nearby states geometrically close but topologically different?
+- are seam-adjacent regions also identity-unstable?
+- where does path dependence localize?
+- do transition corridors coincide with identity obstruction?
+- can local organization be transported coherently?
+
+These are genuinely structural questions.
+
+Without this layer, the observatory would have geometry and operators, but not yet a robust way to talk about local organizational identity and its failure of naive transport.
+
+---
+
+## Relationship to geometry and phase
+
+Topological identity is downstream of the geometry and phase layers.
+
+Geometry provides:
+- the manifold substrate
+- neighborhood structure
+- intrinsic distances
+- directional context
+
+Phase provides:
+- signed regime structure
+- seam organization
+- seam-local coordinates
+
+The identity layer then asks how local topological organization behaves on top of that substrate.
+
+So identity is not a replacement for geometry or phase. It is a deeper organizational layer built on them.
+
+---
+
+## Relationship to operators
+
+Identity also interacts naturally with operator-derived fields.
+
+For example, later observatory analysis can ask how identity magnitude, holonomy, or obstruction relate to:
+
+- Lazarus
+- criticality
+- seam distance
+- response-flow structure
+- route-family organization
+
+This is one reason the identity program matters so much.
+
+It is not isolated. It creates a new structural language that can be compared against the rest of the observatory.
+
+---
+
+## Relationship to the TUI
+
+The TUI exposes the identity layer in one of its clearest public forms.
+
+Identity mode in the TUI already reflects the canonical hierarchy of the identity program:
+
+- identity magnitude
+- absolute holonomy
+- unsigned obstruction
+- signed obstruction
+- legacy spin as comparison
+
+This is useful because it makes the topological identity program inspectable in practice, not only in code.
+
+The TUI also helps make clear that the identity layer is not merely another scalar map. It is a comparative structural console.
+
+---
+
+## What topological identity is not
+
+It is helpful to say what this layer is **not**.
+
+Topological identity is not:
+
+- a single class label
+- a generic graph-embedding trick
+- exact formal algebraic topology
+- a completed holonomy theory
+- a substitute for all other observatory layers
+
+Instead, it is an operational program for representing, comparing, transporting, and localizing structural organization on the observatory manifold.
+
+---
+
+## Limitations
+
+This layer also has real limits.
+
+Its outputs depend on:
+
+- the quality of local object extraction
+- the chosen identity summaries
+- the proxy/object distinction
+- the local loop or neighborhood construction
+- the aggregation rule used to produce obstruction-like fields
+
+So the identity program should be read as:
+
+- operational
+- inspectable
+- scientifically meaningful
+- but not identical to the strongest possible formal topological theory
+
+That is not a weakness. It is the right level of honesty for an observatory program.
+
+---
+
+## Why the name matters
+
+The phrase “topological identity” matters because it signals a real shift in how identity is understood.
+
+Identity is not being treated as:
+
+- label identity
+- or raw coordinate identity
+
+It is being treated as:
+
+- local structural organization
+- preserved or altered under manifold motion
+- comparable through relational summaries
+- and sometimes obstructed under loop transport
+
+That is a much richer notion of identity than most ordinary metric pipelines support.
+
+---
+
+## Summary
+
+Topological identity is PAM’s program for representing and comparing local structural organization on the manifold.
+
+Its key ideas are:
+
+- local identity is represented as a relational object (`IdentityGraph`)
+- identities are compared through structural distance rather than scalar labels
+- identity change can be promoted into a field over the manifold
+- pathwise identity transport can leave loop residuals
+- those residuals can be localized into holonomy- and obstruction-like observables
+- proxy and full-object distinctions are preserved explicitly
+
+The central principle is:
+
+**topological identity in PAM is not a label attached to a state, but a locally structured organization whose differences, transport, and path dependence can be measured.**
+
+That is why this layer is one of the deepest and most distinctive parts of the repository.


### PR DESCRIPTION
Summary

Adds first-class concept documentation for three of the repository’s most important higher-level objects:

* TIP
* TIM
* topological identity

What this includes

* docs/concepts/tip.md
* docs/concepts/tim.md
* docs/concepts/topological_identity.md

Why

These objects are central to the observatory architecture, but until now they were explained mostly through code and scattered project context rather than dedicated concept docs.

This PR makes their role explicit:

* TIP as the first-order invariant measurement instrument
* TIM as the second-order transformation-stability instrument built on TIP
* topological identity as the relational identity / transport / obstruction program

Scope

Documentation only. No scientific or implementation changes.