### PR TITLE
feat: canonicalize first-pass observatory artifact surfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ snapshots/
 
 # macOS
 .DS_Store
+
+observatory/derived/**
+!observatory/derived/
+!observatory/derived/README.md

--- a/src/pam/io/paths.py
+++ b/src/pam/io/paths.py
@@ -22,6 +22,10 @@ class OutputPaths:
     def manifests_dir(self) -> Path:
         return self.root / "manifests"
 
+    # -------------------------------------------------------------------------
+    # Core geometry / phase / topology / operators directories
+    # -------------------------------------------------------------------------
+
     @property
     def fim_dir(self) -> Path:
         return self.root / "fim"
@@ -82,12 +86,137 @@ class OutputPaths:
     def fim_initial_conditions_dir(self) -> Path:
         return self.root / "fim_initial_conditions"
 
+    # -------------------------------------------------------------------------
+    # First-pass legacy file contracts
+    # -------------------------------------------------------------------------
+
+    # Geometry
+    @property
+    def fim_surface_csv(self) -> Path:
+        return self.fim_dir / "fim_surface.csv"
+
+    @property
+    def fim_metadata_txt(self) -> Path:
+        return self.fim_dir / "fim_metadata.txt"
+
+    @property
+    def fisher_nodes_csv(self) -> Path:
+        return self.fim_distance_dir / "fisher_nodes.csv"
+
+    @property
+    def fisher_edges_csv(self) -> Path:
+        return self.fim_distance_dir / "fisher_edges.csv"
+
+    @property
+    def fisher_distance_matrix_csv(self) -> Path:
+        return self.fim_distance_dir / "fisher_distance_matrix.csv"
+
+    @property
+    def mds_coords_csv(self) -> Path:
+        return self.fim_mds_dir / "mds_coords.csv"
+
+    @property
+    def curvature_surface_csv(self) -> Path:
+        # Adjust if your geometry stage writes a different canonical curvature filename.
+        return self.fim_curvature_dir / "curvature_surface.csv"
+
+    # Phase
+    @property
+    def phase_boundary_backprojected_csv(self) -> Path:
+        return self.fim_phase_dir / "phase_boundary_mds_backprojected.csv"
+
+    @property
+    def phase_distance_to_seam_csv(self) -> Path:
+        return self.fim_phase_dir / "phase_distance_to_seam.csv"
+
+    @property
+    def signed_phase_coords_csv(self) -> Path:
+        return self.fim_phase_dir / "signed_phase_coords.csv"
+
+    # Operators
+    @property
+    def lazarus_scores_csv(self) -> Path:
+        return self.fim_lazarus_dir / "lazarus_scores.csv"
+
+    @property
+    def lazarus_summary_csv(self) -> Path:
+        return self.fim_lazarus_dir / "lazarus_summary.csv"
+
+    @property
+    def transition_rate_states_csv(self) -> Path:
+        return self.fim_transition_rate_dir / "transition_rate_states.csv"
+
+    @property
+    def transition_rate_labeled_csv(self) -> Path:
+        return self.fim_transition_rate_dir / "transition_rate_labeled.csv"
+
+    @property
+    def transition_rate_summary_csv(self) -> Path:
+        return self.fim_transition_rate_dir / "transition_rate_summary.csv"
+
+    # Topology
+    @property
+    def criticality_surface_csv(self) -> Path:
+        return self.fim_critical_dir / "criticality_surface.csv"
+
+    @property
+    def critical_points_csv(self) -> Path:
+        return self.fim_critical_dir / "critical_points.csv"
+
+    @property
+    def initial_conditions_outcome_summary_csv(self) -> Path:
+        return self.fim_initial_conditions_dir / "initial_conditions_outcome_summary.csv"
+
+    @property
+    def identity_dir(self) -> Path:
+        return self.root / "fim_identity"
+
+    @property
+    def identity_holonomy_dir(self) -> Path:
+        return self.root / "fim_identity_holonomy"
+
+    @property
+    def identity_obstruction_dir(self) -> Path:
+        return self.root / "fim_identity_obstruction"
+
+    @property
+    def identity_field_nodes_csv(self) -> Path:
+        return self.identity_dir / "identity_field_nodes.csv"
+
+    @property
+    def identity_field_edges_csv(self) -> Path:
+        return self.identity_dir / "identity_field_edges.csv"
+
+    @property
+    def identity_spin_csv(self) -> Path:
+        return self.identity_dir / "identity_spin.csv"
+
+    @property
+    def identity_holonomy_cells_csv(self) -> Path:
+        return self.identity_holonomy_dir / "identity_holonomy_cells.csv"
+
+    @property
+    def identity_holonomy_alignment_csv(self) -> Path:
+        return self.identity_holonomy_dir / "identity_holonomy_alignment.csv"
+
+    @property
+    def identity_obstruction_nodes_csv(self) -> Path:
+        return self.identity_obstruction_dir / "identity_obstruction_nodes.csv"
+
+    @property
+    def identity_obstruction_signed_nodes_csv(self) -> Path:
+        return self.identity_obstruction_dir / "identity_obstruction_signed_nodes.csv"
+
 
 @dataclass(frozen=True)
 class ObservatoryPaths:
-    """Future canonical artifact root. Placeholder-only for now."""
+    """Canonical observatory artifact root for promoted first-class surfaces."""
 
     root: Path
+
+    # -------------------------------------------------------------------------
+    # Top-level structure
+    # -------------------------------------------------------------------------
 
     @property
     def corpora_dir(self) -> Path:
@@ -100,6 +229,18 @@ class ObservatoryPaths:
     @property
     def derived_dir(self) -> Path:
         return self.root / "derived"
+
+    @property
+    def reports_dir(self) -> Path:
+        return self.root / "reports"
+
+    @property
+    def figures_dir(self) -> Path:
+        return self.root / "figures"
+
+    # -------------------------------------------------------------------------
+    # Derived layer directories
+    # -------------------------------------------------------------------------
 
     @property
     def geometry_dir(self) -> Path:
@@ -117,10 +258,178 @@ class ObservatoryPaths:
     def operators_dir(self) -> Path:
         return self.derived_dir / "operators"
 
-    @property
-    def reports_dir(self) -> Path:
-        return self.root / "reports"
+    # -------------------------------------------------------------------------
+    # Geometry
+    # -------------------------------------------------------------------------
 
     @property
-    def figures_dir(self) -> Path:
-        return self.root / "figures"
+    def geometry_metric_dir(self) -> Path:
+        return self.geometry_dir / "metric"
+
+    @property
+    def geometry_graph_dir(self) -> Path:
+        return self.geometry_dir / "graph"
+
+    @property
+    def geometry_distance_dir(self) -> Path:
+        return self.geometry_dir / "distance"
+
+    @property
+    def geometry_mds_dir(self) -> Path:
+        return self.geometry_dir / "mds"
+
+    @property
+    def geometry_curvature_dir(self) -> Path:
+        return self.geometry_dir / "curvature"
+
+    @property
+    def geometry_metric_surface_csv(self) -> Path:
+        return self.geometry_metric_dir / "fim_surface.csv"
+
+    @property
+    def geometry_metric_metadata_txt(self) -> Path:
+        return self.geometry_metric_dir / "fim_metadata.txt"
+
+    @property
+    def geometry_graph_nodes_csv(self) -> Path:
+        return self.geometry_graph_dir / "nodes.csv"
+
+    @property
+    def geometry_graph_edges_csv(self) -> Path:
+        return self.geometry_graph_dir / "edges.csv"
+
+    @property
+    def geometry_distance_matrix_csv(self) -> Path:
+        return self.geometry_distance_dir / "distance_matrix.csv"
+
+    @property
+    def geometry_mds_coords_csv(self) -> Path:
+        return self.geometry_mds_dir / "coords.csv"
+
+    @property
+    def geometry_curvature_surface_csv(self) -> Path:
+        return self.geometry_curvature_dir / "curvature_surface.csv"
+
+    # -------------------------------------------------------------------------
+    # Phase
+    # -------------------------------------------------------------------------
+
+    @property
+    def phase_boundary_dir(self) -> Path:
+        return self.phase_dir / "boundary"
+
+    @property
+    def phase_signed_phase_csv(self) -> Path:
+        return self.phase_dir / "signed_phase.csv"
+
+    @property
+    def phase_distance_to_seam_csv(self) -> Path:
+        return self.phase_dir / "distance_to_seam.csv"
+
+    @property
+    def phase_boundary_csv(self) -> Path:
+        return self.phase_boundary_dir / "seam_nodes.csv"
+
+    # -------------------------------------------------------------------------
+    # Operators
+    # -------------------------------------------------------------------------
+
+    @property
+    def operators_lazarus_dir(self) -> Path:
+        return self.operators_dir / "lazarus"
+
+    @property
+    def operators_transition_rate_dir(self) -> Path:
+        return self.operators_dir / "transition_rate"
+
+    @property
+    def operators_lazarus_scores_csv(self) -> Path:
+        return self.operators_lazarus_dir / "lazarus_scores.csv"
+
+    @property
+    def operators_lazarus_summary_csv(self) -> Path:
+        return self.operators_lazarus_dir / "lazarus_summary.csv"
+
+    @property
+    def operators_transition_rate_states_csv(self) -> Path:
+        return self.operators_transition_rate_dir / "transition_rate_states.csv"
+
+    @property
+    def operators_transition_rate_labeled_csv(self) -> Path:
+        return self.operators_transition_rate_dir / "transition_rate_labeled.csv"
+
+    @property
+    def operators_transition_rate_summary_csv(self) -> Path:
+        return self.operators_transition_rate_dir / "transition_rate_summary.csv"
+
+    # -------------------------------------------------------------------------
+    # Topology
+    # -------------------------------------------------------------------------
+
+    @property
+    def topology_criticality_dir(self) -> Path:
+        return self.topology_dir / "criticality"
+
+    @property
+    def topology_initial_conditions_dir(self) -> Path:
+        return self.topology_dir / "initial_conditions"
+
+    @property
+    def topology_identity_dir(self) -> Path:
+        return self.topology_dir / "identity"
+
+    @property
+    def topology_criticality_surface_csv(self) -> Path:
+        return self.topology_criticality_dir / "criticality_surface.csv"
+
+    @property
+    def topology_critical_points_csv(self) -> Path:
+        return self.topology_criticality_dir / "critical_points.csv"
+
+    @property
+    def topology_initial_conditions_summary_csv(self) -> Path:
+        return self.topology_initial_conditions_dir / "initial_conditions_outcome_summary.csv"
+
+    @property
+    def topology_identity_magnitude_csv(self) -> Path:
+        return self.topology_identity_dir / "identity_magnitude.csv"
+
+    @property
+    def topology_absolute_holonomy_csv(self) -> Path:
+        return self.topology_identity_dir / "absolute_holonomy.csv"
+
+    @property
+    def topology_unsigned_obstruction_csv(self) -> Path:
+        return self.topology_identity_dir / "unsigned_obstruction.csv"
+
+    @property
+    def topology_signed_obstruction_csv(self) -> Path:
+        return self.topology_identity_dir / "signed_obstruction.csv"
+
+    @property
+    def topology_identity_field_nodes_csv(self) -> Path:
+        return self.topology_identity_dir / "identity_field_nodes.csv"
+
+    @property
+    def topology_identity_field_edges_csv(self) -> Path:
+        return self.topology_identity_dir / "identity_field_edges.csv"
+
+    @property
+    def topology_identity_spin_csv(self) -> Path:
+        return self.topology_identity_dir / "identity_spin.csv"
+
+    @property
+    def topology_identity_holonomy_cells_csv(self) -> Path:
+        return self.topology_identity_dir / "identity_holonomy_cells.csv"
+
+    @property
+    def topology_identity_holonomy_alignment_csv(self) -> Path:
+        return self.topology_identity_dir / "identity_holonomy_alignment.csv"
+
+    @property
+    def topology_identity_obstruction_nodes_csv(self) -> Path:
+        return self.topology_identity_dir / "identity_obstruction_nodes.csv"
+
+    @property
+    def topology_identity_obstruction_signed_nodes_csv(self) -> Path:
+        return self.topology_identity_dir / "identity_obstruction_signed_nodes.csv"

--- a/src/pam/pipeline/artifacts.py
+++ b/src/pam/pipeline/artifacts.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+
+def ensure_parent_dir(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def mirror_file(src: Path, dst: Path) -> None:
+    if not src.exists():
+        raise FileNotFoundError(f"Cannot mirror missing file: {src}")
+    ensure_parent_dir(dst)
+    shutil.copy2(src, dst)
+
+
+def mirror_optional_file(src: Path, dst: Path) -> bool:
+    if not src.exists():
+        return False
+    ensure_parent_dir(dst)
+    shutil.copy2(src, dst)
+    return True

--- a/src/pam/pipeline/stages/geometry.py
+++ b/src/pam/pipeline/stages/geometry.py
@@ -5,6 +5,7 @@ from pam.geometry.distance_graph import run_distance_graph
 from pam.geometry.embedding import run_embedding
 from pam.geometry.fisher_metric import run_fisher_metric
 from pam.geometry.geodesics import run_geodesic, run_geodesic_fan
+from pam.pipeline.artifacts import mirror_file, mirror_optional_file
 from pam.pipeline.state import PipelineState
 
 
@@ -40,12 +41,17 @@ def run_geometry_stage(
 
     Notes
     -----
-    - This stage is file-first: it writes artifacts into the existing outputs root.
+    - This stage remains legacy-compatible by writing to outputs/ first.
+    - It mirrors first-pass canonical geometry artifacts into observatory/.
     - It returns an updated PipelineState with geometry metadata only.
     """
 
     if observables is None:
         observables = ["piF_tail", "H_joint_mean"]
+
+    # ------------------------------------------------------------------
+    # Legacy-active writes
+    # ------------------------------------------------------------------
 
     run_fisher_metric(
         index_csv=state.outputs.index_csv,
@@ -56,7 +62,7 @@ def run_geometry_stage(
     )
 
     run_distance_graph(
-        fim_csv=state.outputs.fim_dir / "fim_surface.csv",
+        fim_csv=state.outputs.fim_surface_csv,
         outdir=state.outputs.fim_distance_dir,
         neighbor_mode=neighbor_mode,
         cost_mode=cost_mode,
@@ -65,17 +71,17 @@ def run_geometry_stage(
     )
 
     run_embedding(
-        distance_csv=state.outputs.fim_distance_dir / "fisher_distance_matrix.csv",
-        nodes_csv=state.outputs.fim_distance_dir / "fisher_nodes.csv",
-        edges_csv=state.outputs.fim_distance_dir / "fisher_edges.csv",
-        fim_csv=state.outputs.fim_dir / "fim_surface.csv",
+        distance_csv=state.outputs.fisher_distance_matrix_csv,
+        nodes_csv=state.outputs.fisher_nodes_csv,
+        edges_csv=state.outputs.fisher_edges_csv,
+        fim_csv=state.outputs.fim_surface_csv,
         outdir=state.outputs.fim_mds_dir,
         color_by=color_by,
     )
 
-    nodes_csv = state.outputs.fim_distance_dir / "fisher_nodes.csv"
-    edges_csv = state.outputs.fim_distance_dir / "fisher_edges.csv"
-    coords_csv = state.outputs.fim_mds_dir / "mds_coords.csv"
+    nodes_csv = state.outputs.fisher_nodes_csv
+    edges_csv = state.outputs.fisher_edges_csv
+    coords_csv = state.outputs.mds_coords_csv
 
     if run_single_geodesic:
         if None in (
@@ -118,10 +124,43 @@ def run_geometry_stage(
             r1=fan_target_r,
             outdir=state.outputs.fim_geodesic_fan_dir,
         )
-        
+
     run_curvature(
-        fim_csv=state.outputs.fim_dir / "fim_surface.csv",
+        fim_csv=state.outputs.fim_surface_csv,
         outdir=state.outputs.fim_curvature_dir,
+    )
+
+    # ------------------------------------------------------------------
+    # Pass 1 canonical mirrors
+    # ------------------------------------------------------------------
+
+    mirror_optional_file(
+        state.outputs.fim_surface_csv,
+        state.observatory.geometry_metric_surface_csv,
+    )
+    mirror_optional_file(
+        state.outputs.fim_metadata_txt,
+        state.observatory.geometry_metric_metadata_txt,
+    )
+    mirror_file(
+        state.outputs.fisher_nodes_csv,
+        state.observatory.geometry_graph_nodes_csv,
+    )
+    mirror_file(
+        state.outputs.fisher_edges_csv,
+        state.observatory.geometry_graph_edges_csv,
+    )
+    mirror_file(
+        state.outputs.fisher_distance_matrix_csv,
+        state.observatory.geometry_distance_matrix_csv,
+    )
+    mirror_file(
+        state.outputs.mds_coords_csv,
+        state.observatory.geometry_mds_coords_csv,
+    )
+    mirror_optional_file(
+        state.outputs.curvature_surface_csv,
+        state.observatory.geometry_curvature_surface_csv,
     )
 
     return state.with_metadata(

--- a/src/pam/pipeline/stages/operators.py
+++ b/src/pam/pipeline/stages/operators.py
@@ -5,6 +5,7 @@ from pam.operators.lazarus import run_lazarus
 from pam.operators.probes import run_probes
 from pam.operators.scaled_probes import run_scaled_probes
 from pam.operators.transition_rate import run_transition_rate
+from pam.pipeline.artifacts import mirror_file
 from pam.pipeline.state import PipelineState
 
 
@@ -31,41 +32,46 @@ def run_operators_stage(
     -----
     - File-first orchestration over the existing outputs root.
     - Preserves current artifact contracts under outputs/.
+    - Mirrors first-pass canonical operator artifacts into observatory/.
     """
 
+    # ------------------------------------------------------------------
+    # Legacy-active writes
+    # ------------------------------------------------------------------
+
     run_lazarus(
-        signed_phase_csv=state.outputs.fim_phase_dir / "signed_phase_coords.csv",
-        curvature_csv=state.outputs.fim_curvature_dir / "curvature_surface.csv",
-        seam_csv=state.outputs.fim_phase_dir / "phase_boundary_mds_backprojected.csv",
+        signed_phase_csv=state.outputs.signed_phase_coords_csv,
+        curvature_csv=state.outputs.curvature_surface_csv,
+        seam_csv=state.outputs.phase_boundary_backprojected_csv,
         outdir=state.outputs.fim_lazarus_dir,
         threshold_quantile=lazarus_threshold_quantile,
     )
 
     run_geodesic_extraction(
-        edges_csv=state.outputs.fim_distance_dir / "fisher_edges.csv",
-        mds_csv=state.outputs.fim_mds_dir / "mds_coords.csv",
-        signed_phase_csv=state.outputs.fim_phase_dir / "signed_phase_coords.csv",
-        curvature_csv=state.outputs.fim_curvature_dir / "curvature_surface.csv",
-        seam_csv=state.outputs.fim_phase_dir / "phase_boundary_mds_backprojected.csv",
+        edges_csv=state.outputs.fisher_edges_csv,
+        mds_csv=state.outputs.mds_coords_csv,
+        signed_phase_csv=state.outputs.signed_phase_coords_csv,
+        curvature_csv=state.outputs.curvature_surface_csv,
+        seam_csv=state.outputs.phase_boundary_backprojected_csv,
         outdir=state.outputs.fim_ops_dir,
     )
 
     run_probes(
-        edges_csv=state.outputs.fim_distance_dir / "fisher_edges.csv",
-        mds_csv=state.outputs.fim_mds_dir / "mds_coords.csv",
-        signed_phase_csv=state.outputs.fim_phase_dir / "signed_phase_coords.csv",
-        curvature_csv=state.outputs.fim_curvature_dir / "curvature_surface.csv",
-        seam_csv=state.outputs.fim_phase_dir / "phase_boundary_mds_backprojected.csv",
+        edges_csv=state.outputs.fisher_edges_csv,
+        mds_csv=state.outputs.mds_coords_csv,
+        signed_phase_csv=state.outputs.signed_phase_coords_csv,
+        curvature_csv=state.outputs.curvature_surface_csv,
+        seam_csv=state.outputs.phase_boundary_backprojected_csv,
         outdir=state.outputs.fim_ops_dir,
     )
 
     run_scaled_probes(
-        edges_csv=state.outputs.fim_distance_dir / "fisher_edges.csv",
-        mds_csv=state.outputs.fim_mds_dir / "mds_coords.csv",
-        signed_phase_csv=state.outputs.fim_phase_dir / "signed_phase_coords.csv",
-        curvature_csv=state.outputs.fim_curvature_dir / "curvature_surface.csv",
-        lazarus_csv=state.outputs.fim_lazarus_dir / "lazarus_scores.csv",
-        seam_csv=state.outputs.fim_phase_dir / "phase_boundary_mds_backprojected.csv",
+        edges_csv=state.outputs.fisher_edges_csv,
+        mds_csv=state.outputs.mds_coords_csv,
+        signed_phase_csv=state.outputs.signed_phase_coords_csv,
+        curvature_csv=state.outputs.curvature_surface_csv,
+        lazarus_csv=state.outputs.lazarus_scores_csv,
+        seam_csv=state.outputs.phase_boundary_backprojected_csv,
         outdir=state.outputs.fim_ops_scaled_dir,
         n_pairs=scaled_n_pairs,
         seed=scaled_seed,
@@ -76,6 +82,31 @@ def run_operators_stage(
         paths_csv=state.outputs.fim_ops_scaled_dir / "scaled_probe_paths.csv",
         outdir=state.outputs.fim_transition_rate_dir,
         within_k=transition_within_k,
+    )
+
+    # ------------------------------------------------------------------
+    # Pass 1 canonical mirrors
+    # ------------------------------------------------------------------
+
+    mirror_file(
+        state.outputs.lazarus_scores_csv,
+        state.observatory.operators_lazarus_scores_csv,
+    )
+    mirror_file(
+        state.outputs.lazarus_summary_csv,
+        state.observatory.operators_lazarus_summary_csv,
+    )
+    mirror_file(
+        state.outputs.transition_rate_states_csv,
+        state.observatory.operators_transition_rate_states_csv,
+    )
+    mirror_file(
+        state.outputs.transition_rate_labeled_csv,
+        state.observatory.operators_transition_rate_labeled_csv,
+    )
+    mirror_file(
+        state.outputs.transition_rate_summary_csv,
+        state.observatory.operators_transition_rate_summary_csv,
     )
 
     return state.with_metadata(

--- a/src/pam/pipeline/stages/phase.py
+++ b/src/pam/pipeline/stages/phase.py
@@ -4,6 +4,7 @@ from pam.phase.seam import run_seam_extraction
 from pam.phase.seam_distance import run_seam_distance
 from pam.phase.seam_embedding import run_seam_embedding
 from pam.phase.signed_phase import run_signed_phase
+from pam.pipeline.artifacts import mirror_file
 from pam.pipeline.state import PipelineState
 
 
@@ -26,33 +27,55 @@ def run_phase_stage(
     -----
     - File-first orchestration over the existing outputs root.
     - Preserves current artifact contracts under outputs/fim_phase.
+    - Mirrors first-pass canonical phase artifacts into observatory/.
     """
 
+    # ------------------------------------------------------------------
+    # Legacy-active writes
+    # ------------------------------------------------------------------
+
     run_seam_extraction(
-        curvature_csv=state.outputs.fim_curvature_dir / "curvature_surface.csv",
+        curvature_csv=state.outputs.curvature_surface_csv,
         outdir=state.outputs.fim_phase_dir,
         threshold=seam_threshold,
     )
 
     run_seam_embedding(
         boundary_csv=state.outputs.fim_phase_dir / "phase_boundary_points.csv",
-        mds_csv=state.outputs.fim_mds_dir / "mds_coords.csv",
+        mds_csv=state.outputs.mds_coords_csv,
         outdir=state.outputs.fim_phase_dir,
         n_samples=seam_samples,
     )
 
     run_seam_distance(
-        distance_csv=state.outputs.fim_distance_dir / "fisher_distance_matrix.csv",
-        nodes_csv=state.outputs.fim_distance_dir / "fisher_nodes.csv",
-        seam_csv=state.outputs.fim_phase_dir / "phase_boundary_mds_backprojected.csv",
+        distance_csv=state.outputs.fisher_distance_matrix_csv,
+        nodes_csv=state.outputs.fisher_nodes_csv,
+        seam_csv=state.outputs.phase_boundary_backprojected_csv,
         outdir=state.outputs.fim_phase_dir,
     )
 
     run_signed_phase(
-        mds_csv=state.outputs.fim_mds_dir / "mds_coords.csv",
-        seam_csv=state.outputs.fim_phase_dir / "phase_boundary_mds_backprojected.csv",
-        phase_distance_csv=state.outputs.fim_phase_dir / "phase_distance_to_seam.csv",
+        mds_csv=state.outputs.mds_coords_csv,
+        seam_csv=state.outputs.phase_boundary_backprojected_csv,
+        phase_distance_csv=state.outputs.phase_distance_to_seam_csv,
         outdir=state.outputs.fim_phase_dir,
+    )
+
+    # ------------------------------------------------------------------
+    # Pass 1 canonical mirrors
+    # ------------------------------------------------------------------
+
+    mirror_file(
+        state.outputs.phase_boundary_backprojected_csv,
+        state.observatory.phase_boundary_csv,
+    )
+    mirror_file(
+        state.outputs.phase_distance_to_seam_csv,
+        state.observatory.phase_distance_to_seam_csv,
+    )
+    mirror_file(
+        state.outputs.signed_phase_coords_csv,
+        state.observatory.phase_signed_phase_csv,
     )
 
     return state.with_metadata(

--- a/src/pam/pipeline/stages/topology.py
+++ b/src/pam/pipeline/stages/topology.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pandas as pd
 
+from pam.pipeline.artifacts import mirror_file
 from pam.pipeline.state import PipelineState
 from pam.topology.critical_points import run_critical_points
 from pam.topology.field import run_field_alignment
@@ -53,17 +54,16 @@ def _run_identity_topology_outputs(
         - identity_obstruction_nodes.csv
         - identity_obstruction_signed_nodes.csv
     """
-    fim_identity_dir = Path(state.outputs.root) / "fim_identity"
-    fim_identity_holonomy_dir = Path(state.outputs.root) / "fim_identity_holonomy"
+    fim_identity_dir = state.outputs.identity_dir
+    fim_identity_holonomy_dir = state.outputs.identity_holonomy_dir
     fim_identity_dir.mkdir(parents=True, exist_ok=True)
     fim_identity_holonomy_dir.mkdir(parents=True, exist_ok=True)
 
-    # 1) Build local identity proxy graphs from canonical upstream artifacts
     proxy_node_df, proxy_edge_df = load_identity_proxy_inputs(
-        nodes_csv=state.outputs.fim_distance_dir / "fisher_nodes.csv",
-        edges_csv=state.outputs.fim_distance_dir / "fisher_edges.csv",
-        criticality_csv=state.outputs.fim_critical_dir / "criticality_surface.csv",
-        phase_distance_csv=state.outputs.fim_phase_dir / "phase_distance_to_seam.csv",
+        nodes_csv=state.outputs.fisher_nodes_csv,
+        edges_csv=state.outputs.fisher_edges_csv,
+        criticality_csv=state.outputs.criticality_surface_csv,
+        phase_distance_csv=state.outputs.phase_distance_to_seam_csv,
     )
 
     identity_graphs = build_local_identity_graphs(
@@ -75,7 +75,6 @@ def _run_identity_topology_outputs(
         ),
     )
 
-    # 2) Build grid + identity field
     identity_grid = identity_grid_from_node_graphs(
         node_df=proxy_node_df,
         identity_graphs=identity_graphs,
@@ -85,7 +84,6 @@ def _run_identity_topology_outputs(
         normalized=normalized_distance,
     )
 
-    # Node-level field table
     work = proxy_node_df.copy().sort_values(["i", "j"]).reset_index(drop=True)
     work["node_id"] = pd.to_numeric(work["node_id"], errors="coerce").astype("Int64").astype(str)
 
@@ -164,17 +162,12 @@ def _run_identity_topology_outputs(
                     }
                 )
 
-    identity_field_nodes_csv = fim_identity_dir / "identity_field_nodes.csv"
-    identity_field_edges_csv = fim_identity_dir / "identity_field_edges.csv"
-    identity_spin_csv = fim_identity_dir / "identity_spin.csv"
+    pd.DataFrame(field_rows).to_csv(state.outputs.identity_field_nodes_csv, index=False)
+    pd.DataFrame(edge_rows).to_csv(state.outputs.identity_field_edges_csv, index=False)
+    pd.DataFrame(spin_rows).to_csv(state.outputs.identity_spin_csv, index=False)
 
-    pd.DataFrame(field_rows).to_csv(identity_field_nodes_csv, index=False)
-    pd.DataFrame(edge_rows).to_csv(identity_field_edges_csv, index=False)
-    pd.DataFrame(spin_rows).to_csv(identity_spin_csv, index=False)
-
-    # 3) Holonomy table
     holonomy_nodes_df = load_identity_transport_nodes(
-        identity_nodes_csv=identity_field_nodes_csv,
+        identity_nodes_csv=state.outputs.identity_field_nodes_csv,
     )
     hol_df = build_identity_holonomy_table(
         nodes_df=holonomy_nodes_df,
@@ -184,10 +177,8 @@ def _run_identity_topology_outputs(
         ),
     )
 
-    identity_holonomy_cells_csv = fim_identity_holonomy_dir / "identity_holonomy_cells.csv"
-    hol_df.to_csv(identity_holonomy_cells_csv, index=False)
+    hol_df.to_csv(state.outputs.identity_holonomy_cells_csv, index=False)
 
-    # 4) Alignment summary
     def _corr_summary(df: pd.DataFrame, x: str, y: str) -> dict[str, float]:
         work = df[[x, y]].dropna()
         if len(work) < 3:
@@ -214,13 +205,11 @@ def _run_identity_topology_outputs(
             _corr_summary(hol_df, "abs_holonomy_residual", "max_abs_corner_spin"),
         ]
     )
-    identity_holonomy_alignment_csv = fim_identity_holonomy_dir / "identity_holonomy_alignment.csv"
-    hol_align.to_csv(identity_holonomy_alignment_csv, index=False)
+    hol_align.to_csv(state.outputs.identity_holonomy_alignment_csv, index=False)
 
-    # 5) Transport-derived local obstruction fields
     obstruction_nodes_df, obstruction_cells_df = load_identity_obstruction_inputs(
-        identity_nodes_csv=identity_field_nodes_csv,
-        holonomy_cells_csv=identity_holonomy_cells_csv,
+        identity_nodes_csv=state.outputs.identity_field_nodes_csv,
+        holonomy_cells_csv=state.outputs.identity_holonomy_cells_csv,
     )
 
     obstruction_df = build_identity_obstruction_table(
@@ -231,27 +220,18 @@ def _run_identity_topology_outputs(
         ),
     )
 
-    fim_identity_obstruction_dir = Path(state.outputs.root) / "fim_identity_obstruction"
-    fim_identity_obstruction_dir.mkdir(parents=True, exist_ok=True)
-
-    identity_obstruction_nodes_csv = (
-        fim_identity_obstruction_dir / "identity_obstruction_nodes.csv"
-    )
-    identity_obstruction_signed_nodes_csv = (
-        fim_identity_obstruction_dir / "identity_obstruction_signed_nodes.csv"
-    )
-
-    obstruction_df.to_csv(identity_obstruction_nodes_csv, index=False)
-    obstruction_df.to_csv(identity_obstruction_signed_nodes_csv, index=False)
+    state.outputs.identity_obstruction_dir.mkdir(parents=True, exist_ok=True)
+    obstruction_df.to_csv(state.outputs.identity_obstruction_nodes_csv, index=False)
+    obstruction_df.to_csv(state.outputs.identity_obstruction_signed_nodes_csv, index=False)
 
     return {
-        "identity_field_nodes_csv": str(identity_field_nodes_csv),
-        "identity_field_edges_csv": str(identity_field_edges_csv),
-        "identity_spin_csv": str(identity_spin_csv),
-        "identity_holonomy_cells_csv": str(identity_holonomy_cells_csv),
-        "identity_holonomy_alignment_csv": str(identity_holonomy_alignment_csv),
-        "identity_obstruction_nodes_csv": str(identity_obstruction_nodes_csv),
-        "identity_obstruction_signed_nodes_csv": str(identity_obstruction_signed_nodes_csv),
+        "identity_field_nodes_csv": str(state.outputs.identity_field_nodes_csv),
+        "identity_field_edges_csv": str(state.outputs.identity_field_edges_csv),
+        "identity_spin_csv": str(state.outputs.identity_spin_csv),
+        "identity_holonomy_cells_csv": str(state.outputs.identity_holonomy_cells_csv),
+        "identity_holonomy_alignment_csv": str(state.outputs.identity_holonomy_alignment_csv),
+        "identity_obstruction_nodes_csv": str(state.outputs.identity_obstruction_nodes_csv),
+        "identity_obstruction_signed_nodes_csv": str(state.outputs.identity_obstruction_signed_nodes_csv),
     }
 
 
@@ -268,42 +248,93 @@ def run_topology_stage(
       2. Gradient alignment
       3. Critical points
       4. Organizational topology / phase selection map
+      5. Identity field / holonomy / obstruction
 
     Notes
     -----
     - File-first orchestration over the existing outputs root.
     - Preserves current artifact contracts under outputs/.
+    - Mirrors first-pass canonical topology artifacts into observatory/.
     """
 
+    # ------------------------------------------------------------------
+    # Legacy-active writes
+    # ------------------------------------------------------------------
+
     run_field_alignment(
-        mds_csv=state.outputs.fim_mds_dir / "mds_coords.csv",
-        phase_csv=state.outputs.fim_phase_dir / "signed_phase_coords.csv",
-        lazarus_csv=state.outputs.fim_lazarus_dir / "lazarus_scores.csv",
+        mds_csv=state.outputs.mds_coords_csv,
+        phase_csv=state.outputs.signed_phase_coords_csv,
+        lazarus_csv=state.outputs.lazarus_scores_csv,
         paths_csv=state.outputs.fim_ops_scaled_dir / "scaled_probe_paths.csv",
         outdir=state.outputs.fim_field_alignment_dir,
     )
 
     run_gradient_alignment(
-        mds_csv=state.outputs.fim_mds_dir / "mds_coords.csv",
-        phase_csv=state.outputs.fim_phase_dir / "signed_phase_coords.csv",
-        lazarus_csv=state.outputs.fim_lazarus_dir / "lazarus_scores.csv",
+        mds_csv=state.outputs.mds_coords_csv,
+        phase_csv=state.outputs.signed_phase_coords_csv,
+        lazarus_csv=state.outputs.lazarus_scores_csv,
         outdir=state.outputs.fim_gradient_alignment_dir,
     )
 
     run_critical_points(
-        fim_csv=state.outputs.fim_dir / "fim_surface.csv",
-        curvature_csv=state.outputs.fim_curvature_dir / "curvature_surface.csv",
-        phase_distance_csv=state.outputs.fim_phase_dir / "phase_distance_to_seam.csv",
+        fim_csv=state.outputs.fim_surface_csv,
+        curvature_csv=state.outputs.curvature_surface_csv,
+        phase_distance_csv=state.outputs.phase_distance_to_seam_csv,
         outdir=state.outputs.fim_critical_dir,
         top_k=critical_top_k,
     )
 
     run_organization(
-        summary_csv=state.outputs.fim_initial_conditions_dir / "initial_conditions_outcome_summary.csv",
+        summary_csv=state.outputs.initial_conditions_outcome_summary_csv,
         outdir=state.outputs.fim_initial_conditions_dir,
     )
 
     identity_outputs = _run_identity_topology_outputs(state)
+
+    # ------------------------------------------------------------------
+    # Pass 1 canonical mirrors
+    # ------------------------------------------------------------------
+
+    mirror_file(
+        state.outputs.criticality_surface_csv,
+        state.observatory.topology_criticality_surface_csv,
+    )
+    mirror_file(
+        state.outputs.critical_points_csv,
+        state.observatory.topology_critical_points_csv,
+    )
+    mirror_file(
+        state.outputs.initial_conditions_outcome_summary_csv,
+        state.observatory.topology_initial_conditions_summary_csv,
+    )
+    mirror_file(
+        state.outputs.identity_field_nodes_csv,
+        state.observatory.topology_identity_field_nodes_csv,
+    )
+    mirror_file(
+        state.outputs.identity_field_edges_csv,
+        state.observatory.topology_identity_field_edges_csv,
+    )
+    mirror_file(
+        state.outputs.identity_spin_csv,
+        state.observatory.topology_identity_spin_csv,
+    )
+    mirror_file(
+        state.outputs.identity_holonomy_cells_csv,
+        state.observatory.topology_identity_holonomy_cells_csv,
+    )
+    mirror_file(
+        state.outputs.identity_holonomy_alignment_csv,
+        state.observatory.topology_identity_holonomy_alignment_csv,
+    )
+    mirror_file(
+        state.outputs.identity_obstruction_nodes_csv,
+        state.observatory.topology_identity_obstruction_nodes_csv,
+    )
+    mirror_file(
+        state.outputs.identity_obstruction_signed_nodes_csv,
+        state.observatory.topology_identity_obstruction_signed_nodes_csv,
+    )
 
     return state.with_metadata(
         topology={


### PR DESCRIPTION
Summary

Implements the first pass of observatory artifact canonicalization by mirroring core geometry, phase, operator, and topology artifacts into stable canonical locations under observatory/derived/, while preserving the existing outputs/ write surface.

What this changes

Adds canonical observatory mirrors for the current first-class artifact families:

Geometry

* metric surface
* graph nodes
* graph edges
* distance matrix
* MDS coordinates
* curvature surface

Phase

* seam boundary / seam nodes
* distance to seam
* signed phase

Operators

* Lazarus scores
* Lazarus summary
* transition-rate states
* transition-rate labeled outputs
* transition-rate summary

Topology

* criticality surface
* critical points
* initial-conditions outcome summary
* identity field nodes
* identity field edges
* identity spin
* identity holonomy cells
* identity holonomy alignment
* identity obstruction nodes
* identity obstruction signed nodes

Implementation approach

This PR does not remove or rename the legacy outputs/ paths.

Instead, it:

* extends OutputPaths and ObservatoryPaths with explicit file-level contracts
* adds small artifact mirroring helpers
* keeps the existing stage producers writing to outputs/
* mirrors first-pass canonical surfaces into observatory/derived/

This keeps the pipeline and downstream tooling backward-compatible while establishing a canonical observatory artifact surface.

Why

The repository has now reached full corpus-Cp closure:

* full trajectory coverage
* full pipeline completion
* working TUI inspection across modes and overlays

With that closure established, the next structural step is to move core observatory artifacts out of the long-running outputs/ ↔ observatory/ transition ambiguity and make artifact truth explicit in the filesystem.

Scope

* canonical path contracts for first-pass artifact families
* mirrored writes into observatory/derived/
* no legacy-path removal yet
* no TUI loader migration yet
* no study-output migration yet

Follow-up

Planned next steps after this PR:

1. corpus-scoped raw generation before Cp2
2. explicit initial-conditions pipeline wiring
3. TUI loader migration toward canonical observatory reads
4. pass-2 canonicalization for hubs / hotspots / family bundles