### PR TITLE
refactor: migrate TUI loaders to canonical observatory artifact paths

### DIFF
--- a/observatory/app.py
+++ b/observatory/app.py
@@ -95,12 +95,30 @@ class ObservatoryApp(App):
         super().__init__()
         self.state = ObservatoryState()
         self.run_data = load_run_data(self.state.outputs_root)
-        self.geometry_data = load_geometry_data(self.state.outputs_root)
-        self.phase_data = load_phase_data(self.state.outputs_root)
-        self.topology_data = load_topology_data(self.state.outputs_root)
-        self.operators_data = load_operators_data(self.state.outputs_root)
-        self.identity_data = load_identity_data(self.state.outputs_root)
-        self.mds_data = load_mds_data(self.state.outputs_root)
+        self.geometry_data = load_geometry_data(
+            self.state.outputs_root,
+            self.state.observatory_root,
+        )
+        self.phase_data = load_phase_data(
+            self.state.outputs_root,
+            self.state.observatory_root,
+        )
+        self.topology_data = load_topology_data(
+            self.state.outputs_root,
+            self.state.observatory_root,
+        )
+        self.operators_data = load_operators_data(
+            self.state.outputs_root,
+            self.state.observatory_root,
+        )
+        self.identity_data = load_identity_data(
+            self.state.outputs_root,
+            self.state.observatory_root,
+        )
+        self.mds_data = load_mds_data(
+            self.state.outputs_root,
+            self.state.observatory_root,
+        )
 
         self.grid_r_vals = list(range(10))
         self.grid_a_vals = list(range(10))
@@ -676,12 +694,30 @@ class ObservatoryApp(App):
 
     def action_refresh_state(self) -> None:
         self.run_data = load_run_data(self.state.outputs_root)
-        self.geometry_data = load_geometry_data(self.state.outputs_root)
-        self.phase_data = load_phase_data(self.state.outputs_root)
-        self.topology_data = load_topology_data(self.state.outputs_root)
-        self.operators_data = load_operators_data(self.state.outputs_root)
-        self.identity_data = load_identity_data(self.state.outputs_root)
-        self.mds_data = load_mds_data(self.state.outputs_root)
+        self.geometry_data = load_geometry_data(
+            self.state.outputs_root,
+            self.state.observatory_root,
+        )
+        self.phase_data = load_phase_data(
+            self.state.outputs_root,
+            self.state.observatory_root,
+        )
+        self.topology_data = load_topology_data(
+            self.state.outputs_root,
+            self.state.observatory_root,
+        )
+        self.operators_data = load_operators_data(
+            self.state.outputs_root,
+            self.state.observatory_root,
+        )
+        self.identity_data = load_identity_data(
+            self.state.outputs_root,
+            self.state.observatory_root,
+        )
+        self.mds_data = load_mds_data(
+            self.state.outputs_root,
+            self.state.observatory_root,
+        )
         self._update_grid_shape_from_run_data()
         self.state.status_message = "Refreshed"
         self._render_all()

--- a/observatory/loaders/geometry_loader.py
+++ b/observatory/loaders/geometry_loader.py
@@ -20,11 +20,25 @@ def _safe_mtime(path: Path) -> float | None:
         return None
 
 
-def load_geometry_data(outputs_root: str | Path = "outputs") -> GeometryData:
+def load_geometry_data(
+    outputs_root: str | Path = "outputs",
+    observatory_root: str | Path = "observatory",
+) -> GeometryData:
     outputs_root = Path(outputs_root)
+    observatory_root = Path(observatory_root)
 
-    curvature_csv = outputs_root / "fim_curvature" / "curvature_surface.csv"
-    fim_csv = outputs_root / "fim" / "fim_surface.csv"
+    canonical_curvature_csv = (
+        observatory_root / "derived" / "geometry" / "curvature" / "curvature_surface.csv"
+    )
+    canonical_fim_csv = (
+        observatory_root / "derived" / "geometry" / "metric" / "fim_surface.csv"
+    )
+
+    legacy_curvature_csv = outputs_root / "fim_curvature" / "curvature_surface.csv"
+    legacy_fim_csv = outputs_root / "fim" / "fim_surface.csv"
+
+    curvature_csv = canonical_curvature_csv if canonical_curvature_csv.exists() else legacy_curvature_csv
+    fim_csv = canonical_fim_csv if canonical_fim_csv.exists() else legacy_fim_csv
 
     curv = pd.read_csv(curvature_csv).copy() if curvature_csv.exists() else pd.DataFrame()
     fim = pd.read_csv(fim_csv).copy() if fim_csv.exists() else pd.DataFrame()

--- a/observatory/loaders/identity_loader.py
+++ b/observatory/loaders/identity_loader.py
@@ -21,17 +21,45 @@ def _safe_mtime(path: Path) -> float | None:
         return None
 
 
-def load_identity_data(outputs_root: str | Path = "outputs") -> IdentityData:
+def load_identity_data(
+    outputs_root: str | Path = "outputs",
+    observatory_root: str | Path = "observatory",
+) -> IdentityData:
     outputs_root = Path(outputs_root)
+    observatory_root = Path(observatory_root)
 
-    identity_nodes_csv = outputs_root / "fim_identity" / "identity_field_nodes.csv"
-    obstruction_csv = outputs_root / "fim_identity_obstruction" / "identity_obstruction_nodes.csv"
-    obstruction_signed_csv = outputs_root / "fim_identity_obstruction" / "identity_obstruction_signed_nodes.csv"
-    holonomy_cells_csv = outputs_root / "fim_identity_holonomy" / "identity_holonomy_cells.csv"
+    canonical_identity_nodes_csv = (
+        observatory_root / "derived" / "topology" / "identity" / "identity_field_nodes.csv"
+    )
+    canonical_obstruction_csv = (
+        observatory_root / "derived" / "topology" / "identity" / "identity_obstruction_nodes.csv"
+    )
+    canonical_obstruction_signed_csv = (
+        observatory_root / "derived" / "topology" / "identity" / "identity_obstruction_signed_nodes.csv"
+    )
+    canonical_holonomy_cells_csv = (
+        observatory_root / "derived" / "topology" / "identity" / "identity_holonomy_cells.csv"
+    )
+
+    legacy_identity_nodes_csv = outputs_root / "fim_identity" / "identity_field_nodes.csv"
+    legacy_obstruction_csv = outputs_root / "fim_identity_obstruction" / "identity_obstruction_nodes.csv"
+    legacy_obstruction_signed_csv = outputs_root / "fim_identity_obstruction" / "identity_obstruction_signed_nodes.csv"
+    legacy_holonomy_cells_csv = outputs_root / "fim_identity_holonomy" / "identity_holonomy_cells.csv"
+
+    identity_nodes_csv = canonical_identity_nodes_csv if canonical_identity_nodes_csv.exists() else legacy_identity_nodes_csv
+    obstruction_csv = canonical_obstruction_csv if canonical_obstruction_csv.exists() else legacy_obstruction_csv
+    obstruction_signed_csv = (
+        canonical_obstruction_signed_csv
+        if canonical_obstruction_signed_csv.exists()
+        else legacy_obstruction_signed_csv
+    )
+    holonomy_cells_csv = canonical_holonomy_cells_csv if canonical_holonomy_cells_csv.exists() else legacy_holonomy_cells_csv
 
     identity_nodes = pd.read_csv(identity_nodes_csv).copy() if identity_nodes_csv.exists() else pd.DataFrame()
     obstruction = pd.read_csv(obstruction_csv).copy() if obstruction_csv.exists() else pd.DataFrame()
-    obstruction_signed = pd.read_csv(obstruction_signed_csv).copy() if obstruction_signed_csv.exists() else pd.DataFrame()
+    obstruction_signed = (
+        pd.read_csv(obstruction_signed_csv).copy() if obstruction_signed_csv.exists() else pd.DataFrame()
+    )
     holonomy_cells = pd.read_csv(holonomy_cells_csv).copy() if holonomy_cells_csv.exists() else pd.DataFrame()
 
     for df in [identity_nodes, obstruction, obstruction_signed]:
@@ -70,20 +98,28 @@ def load_identity_data(outputs_root: str | Path = "outputs") -> IdentityData:
     merged = identity_nodes.copy()
 
     if not obstruction.empty:
-        cols = [c for c in [
-            "node_id",
-            "obstruction_mean_holonomy",
-            "obstruction_mean_abs_holonomy",
-            "obstruction_max_abs_holonomy",
-        ] if c in obstruction.columns]
+        cols = [
+            c
+            for c in [
+                "node_id",
+                "obstruction_mean_holonomy",
+                "obstruction_mean_abs_holonomy",
+                "obstruction_max_abs_holonomy",
+            ]
+            if c in obstruction.columns
+        ]
         merged = merged.merge(obstruction[cols], on="node_id", how="left")
 
     if not obstruction_signed.empty:
-        cols = [c for c in [
-            "node_id",
-            "obstruction_signed_sum_holonomy",
-            "obstruction_signed_weighted_holonomy",
-        ] if c in obstruction_signed.columns]
+        cols = [
+            c
+            for c in [
+                "node_id",
+                "obstruction_signed_sum_holonomy",
+                "obstruction_signed_weighted_holonomy",
+            ]
+            if c in obstruction_signed.columns
+        ]
         merged = merged.merge(obstruction_signed[cols], on="node_id", how="left")
 
     if "obstruction_mean_abs_holonomy" in merged.columns:

--- a/observatory/loaders/mds_loader.py
+++ b/observatory/loaders/mds_loader.py
@@ -19,9 +19,17 @@ def _safe_mtime(path: Path) -> float | None:
         return None
 
 
-def load_mds_data(outputs_root: str | Path = "outputs") -> MDSData:
+def load_mds_data(
+    outputs_root: str | Path = "outputs",
+    observatory_root: str | Path = "observatory",
+) -> MDSData:
     outputs_root = Path(outputs_root)
-    mds_csv = outputs_root / "fim_mds" / "mds_coords.csv"
+    observatory_root = Path(observatory_root)
+
+    canonical_csv = observatory_root / "derived" / "geometry" / "mds" / "coords.csv"
+    legacy_csv = outputs_root / "fim_mds" / "mds_coords.csv"
+
+    mds_csv = canonical_csv if canonical_csv.exists() else legacy_csv
 
     if not mds_csv.exists():
         return MDSData(mds_df=pd.DataFrame(), mtime=None)

--- a/observatory/loaders/operators_loader.py
+++ b/observatory/loaders/operators_loader.py
@@ -19,9 +19,17 @@ def _safe_mtime(path: Path) -> float | None:
         return None
 
 
-def load_operators_data(outputs_root: str | Path = "outputs") -> OperatorsData:
+def load_operators_data(
+    outputs_root: str | Path = "outputs",
+    observatory_root: str | Path = "observatory",
+) -> OperatorsData:
     outputs_root = Path(outputs_root)
-    lazarus_csv = outputs_root / "fim_lazarus" / "lazarus_scores.csv"
+    observatory_root = Path(observatory_root)
+
+    canonical_lazarus_csv = observatory_root / "derived" / "operators" / "lazarus" / "lazarus_scores.csv"
+    legacy_lazarus_csv = outputs_root / "fim_lazarus" / "lazarus_scores.csv"
+
+    lazarus_csv = canonical_lazarus_csv if canonical_lazarus_csv.exists() else legacy_lazarus_csv
 
     if not lazarus_csv.exists():
         return OperatorsData(

--- a/observatory/loaders/phase_loader.py
+++ b/observatory/loaders/phase_loader.py
@@ -20,11 +20,25 @@ def _safe_mtime(path: Path) -> float | None:
         return None
 
 
-def load_phase_data(outputs_root: str | Path = "outputs") -> PhaseData:
+def load_phase_data(
+    outputs_root: str | Path = "outputs",
+    observatory_root: str | Path = "observatory",
+) -> PhaseData:
     outputs_root = Path(outputs_root)
+    observatory_root = Path(observatory_root)
 
-    signed_phase_csv = outputs_root / "fim_phase" / "signed_phase_coords.csv"
-    seam_distance_csv = outputs_root / "fim_phase" / "phase_distance_to_seam.csv"
+    canonical_signed_phase_csv = observatory_root / "derived" / "phase" / "signed_phase.csv"
+    canonical_seam_distance_csv = observatory_root / "derived" / "phase" / "distance_to_seam.csv"
+
+    legacy_signed_phase_csv = outputs_root / "fim_phase" / "signed_phase_coords.csv"
+    legacy_seam_distance_csv = outputs_root / "fim_phase" / "phase_distance_to_seam.csv"
+
+    signed_phase_csv = (
+        canonical_signed_phase_csv if canonical_signed_phase_csv.exists() else legacy_signed_phase_csv
+    )
+    seam_distance_csv = (
+        canonical_seam_distance_csv if canonical_seam_distance_csv.exists() else legacy_seam_distance_csv
+    )
 
     signed = pd.read_csv(signed_phase_csv).copy() if signed_phase_csv.exists() else pd.DataFrame()
     seam = pd.read_csv(seam_distance_csv).copy() if seam_distance_csv.exists() else pd.DataFrame()

--- a/observatory/loaders/run_loader.py
+++ b/observatory/loaders/run_loader.py
@@ -21,6 +21,16 @@ def _safe_mtime(path: Path) -> float | None:
 
 
 def load_run_data(outputs_root: str | Path = "outputs") -> RunData:
+    """
+    Load raw run coverage data from the active run root.
+
+    Notes
+    -----
+    - This loader reads the raw generation surface, not observatory/derived artifacts.
+    - In the corpus/campaign model, `outputs_root` should typically point to a
+      campaign-scoped raw root such as:
+          outputs/corpora/<corpus>/campaigns/<campaign>
+    """
     outputs_root = Path(outputs_root)
     index_csv = outputs_root / "index.csv"
 

--- a/observatory/loaders/topology_loader.py
+++ b/observatory/loaders/topology_loader.py
@@ -19,9 +19,21 @@ def _safe_mtime(path: Path) -> float | None:
         return None
 
 
-def load_topology_data(outputs_root: str | Path = "outputs") -> TopologyData:
+def load_topology_data(
+    outputs_root: str | Path = "outputs",
+    observatory_root: str | Path = "observatory",
+) -> TopologyData:
     outputs_root = Path(outputs_root)
-    criticality_csv = outputs_root / "fim_critical" / "criticality_surface.csv"
+    observatory_root = Path(observatory_root)
+
+    canonical_criticality_csv = (
+        observatory_root / "derived" / "topology" / "criticality" / "criticality_surface.csv"
+    )
+    legacy_criticality_csv = outputs_root / "fim_critical" / "criticality_surface.csv"
+
+    criticality_csv = (
+        canonical_criticality_csv if canonical_criticality_csv.exists() else legacy_criticality_csv
+    )
 
     if not criticality_csv.exists():
         return TopologyData(

--- a/observatory/state.py
+++ b/observatory/state.py
@@ -18,6 +18,8 @@ class ObservatoryState:
     status_message: str = "Ready"
 
     outputs_root: str = "outputs"
+    observatory_root: str = "observatory"
+
     right_pane_mode: str = "detail"  # detail | ranking
     ranking_index: int = 0
     marker_mode: str = "off"  # off | seam | critical | obstruction | lazarus


### PR DESCRIPTION
Summary

Migrates the observatory TUI loaders to prefer canonical derived artifact paths under observatory/derived/ while preserving legacy outputs/ fallback behavior where needed.

What this changes

Updates the TUI app and loader stack so that:

* geometry data loads from canonical observatory artifacts first
* phase data loads from canonical observatory artifacts first
* operators data loads from canonical observatory artifacts first
* topology data loads from canonical observatory artifacts first
* identity data loads from canonical observatory artifacts first
* MDS data loads from canonical observatory artifacts first
* raw run coverage continues to load from the active run root

Files updated

* observatory/app.py
* observatory/loaders/geometry_loader.py
* observatory/loaders/identity_loader.py
* observatory/loaders/mds_loader.py
* observatory/loaders/operators_loader.py
* observatory/loaders/phase_loader.py
* observatory/loaders/run_loader.py
* observatory/loaders/topology_loader.py
* observatory/state.py

Design

This PR establishes the intended loader split:

* raw run data comes from outputs_root
* derived scientific surfaces come from observatory_root, with legacy outputs/ fallback for compatibility

ObservatoryState now carries both:

* outputs_root
* observatory_root

so the TUI can distinguish between raw campaign surfaces and canonical derived observatory surfaces.

Why

The repository now has:

* first-pass canonical artifact mirroring under observatory/derived/
* explicit initial-conditions pipeline wiring
* and stable corpus/campaign-scoped raw generation

With those prerequisites in place, the TUI should no longer treat the legacy outputs/ tree as the primary truth surface for derived observatory layers.

Validation

* full pipeline executed successfully
* canonical observatory artifacts were produced
* the TUI launched successfully
* existing app behavior appears unchanged under the new loader path resolution

Scope

* loader-path migration only
* no rendering redesign yet
* no manifold visual upgrade yet
* no pass-2 structural annotation canonicalization yet