### PR TITLE
feat: canonicalize structural annotation artifacts

### DIFF
--- a/experiments/canonicalize_pass2_annotations.py
+++ b/experiments/canonicalize_pass2_annotations.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pam.io.paths import ObservatoryPaths
+from pam.pipeline.artifacts import mirror_file
+
+
+def main() -> None:
+    observatory = ObservatoryPaths(Path("observatory"))
+
+    mirror_file(
+        Path("outputs/obs022_scene_bundle/scene_hubs.csv"),
+        observatory.topology_hub_nodes_csv,
+    )
+    mirror_file(
+        Path("outputs/obs024_family_hotspot_occupancy/family_hotspot_occupancy_nodes.csv"),
+        observatory.topology_hotspot_nodes_csv,
+    )
+    mirror_file(
+        Path("outputs/obs028c_canonical_seam_bundle/seam_nodes.csv"),
+        observatory.topology_seam_bundle_nodes_csv,
+    )
+    mirror_file(
+        Path("outputs/obs028c_canonical_seam_bundle/seam_embedding_summary.csv"),
+        observatory.topology_seam_bundle_embedding_summary_csv,
+    )
+    mirror_file(
+        Path("outputs/obs028c_canonical_seam_bundle/seam_family_summary.csv"),
+        observatory.topology_seam_bundle_family_summary_csv,
+    )
+
+    print(observatory.topology_annotations_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pam/io/paths.py
+++ b/src/pam/io/paths.py
@@ -433,3 +433,27 @@ class ObservatoryPaths:
     @property
     def topology_identity_obstruction_signed_nodes_csv(self) -> Path:
         return self.topology_identity_dir / "identity_obstruction_signed_nodes.csv"
+
+    @property
+    def topology_annotations_dir(self) -> Path:
+        return self.topology_dir / "annotations"
+
+    @property
+    def topology_hub_nodes_csv(self) -> Path:
+        return self.topology_annotations_dir / "hub_nodes.csv"
+
+    @property
+    def topology_hotspot_nodes_csv(self) -> Path:
+        return self.topology_annotations_dir / "hotspot_nodes.csv"
+
+    @property
+    def topology_seam_bundle_nodes_csv(self) -> Path:
+        return self.topology_annotations_dir / "seam_bundle_nodes.csv"
+
+    @property
+    def topology_seam_bundle_embedding_summary_csv(self) -> Path:
+        return self.topology_annotations_dir / "seam_bundle_embedding_summary.csv"
+
+    @property
+    def topology_seam_bundle_family_summary_csv(self) -> Path:
+        return self.topology_annotations_dir / "seam_bundle_family_summary.csv"


### PR DESCRIPTION
Summary

Canonicalizes the next observatory-facing structural annotation surfaces by mirroring hub, hotspot, and seam-bundle artifacts into stable locations under observatory/derived/topology/annotations/.

What this includes

* hub node annotations
* hotspot node annotations
* seam-bundle node table
* seam-bundle embedding summary
* seam-bundle family summary

Why

These artifacts are the clearest next structural observatory surfaces after Pass 1. They support the seam / hub / hotspot ontology already emerging in the observatory and are likely next inputs for future TUI manifold upgrades.

Implementation approach

This PR preserves legacy outputs/ artifacts and mirrors selected annotation surfaces into canonical observatory paths.

Scope

* structural annotation canonicalization only
* no family-layer promotion yet
* no rendering redesign yet

Deferred

The broader outputs/canonical/* family-layer artifacts are intentionally deferred until their producing pipeline is made explicit and reproducible.