### PR TITLE
feat: formalize OBS-028c seam bundle preparation workflow

### DIFF
--- a/experiments/studies/prepare_obs028c_seam_bundle_inputs.py
+++ b/experiments/studies/prepare_obs028c_seam_bundle_inputs.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Config:
+    python_bin: str = sys.executable
+
+
+def run(cmd: list[str]) -> None:
+    print(" ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Prepare OBS-028c canonical seam bundle inputs."
+    )
+    parser.add_argument("--python-bin", default=sys.executable)
+    args = parser.parse_args()
+
+    cfg = Config(python_bin=args.python_bin)
+    project_root = Path(__file__).resolve().parents[2]
+
+    steps = [
+        "experiments/studies/fim_response_complex_compatibility.py",
+        "experiments/studies/fim_response_operator_decomposition.py",
+        "experiments/studies/obs025_anisotropy_vs_relational_obstruction.py",
+        "experiments/studies/obs025_two_field_seam_panel.py",
+        "experiments/studies/obs026_family_two_field_occupancy.py",
+        "experiments/studies/obs028_embedding_comparison.py",
+        "experiments/studies/obs028b_diffusion_mode_analysis.py",
+        "experiments/studies/obs028c_export_canonical_seam_bundle.py",
+    ]
+
+    for rel in steps:
+        run([cfg.python_bin, str(project_root / rel)])
+
+    print()
+    print("=== OBS-028c Seam Bundle Inputs Prepared ===")
+    print("Produced or refreshed:")
+    print("  - response complex compatibility")
+    print("  - response operator decomposition")
+    print("  - anisotropy vs relational obstruction")
+    print("  - two-field seam panel")
+    print("  - family two-field occupancy")
+    print("  - embedding comparison")
+    print("  - diffusion mode analysis")
+    print("  - canonical seam bundle")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary

Formalizes the recovered prerequisite chain required to produce outputs/obs028c_canonical_seam_bundle/.

What this adds

* a one-shot wrapper that runs the full seam-bundle prep arc in order

Recovered dependency chain

1. response complex compatibility
2. response operator decomposition
3. anisotropy vs relational obstruction
4. two-field seam panel
5. family two-field occupancy
6. embedding comparison
7. diffusion mode analysis
8. canonical seam bundle export

Why

This replaces a remembered manual sequence with an explicit, reproducible workflow and clarifies that OBS-028c is a downstream seam-study artifact rather than a direct canonical pipeline output.