### PR TITLE
feat(obs052): add first attractor basin mapping pass

### DIFF
--- a/docs/05_project/observatory_chain_obs028c_to_obs051.md
+++ b/docs/05_project/observatory_chain_obs028c_to_obs051.md
@@ -1,0 +1,415 @@
+# Observatory Chain — OBS-028c to OBS-051
+
+## Scope
+
+This document defines the canonical reproducible observatory chain from the seam-bundle layer through the first predictive and first Lyapunov-like follow-up studies.
+
+The chain covers:
+
+- OBS-028c canonical seam bundle
+- scale-conditioned family substrate construction
+- OBS-022 scene-bundle preparation
+- OBS-024 family hotspot occupancy
+- OBS-050 structural coupling persistence
+- OBS-051 local divergence in seam-coupled escalation windows
+
+This document is intended to stabilize the observatory pipeline across machines and corpora.
+
+---
+
+## Current Status
+
+### Canonical / stable enough to rely on
+- OBS-028c
+- scale family substrate build
+- OBS-022 scene bundle preparation
+- OBS-024 family hotspot occupancy
+- OBS-050 structural coupling persistence
+
+### Running and reproducible, but not yet canonically stable in interpretation
+- OBS-051 local divergence in coupled windows
+
+### Cross-corpus note
+- OBS-050 reproduces qualitatively across corpus C and corpus Cp
+- OBS-051 runs on both, but the dynamical conclusion is currently corpus-sensitive and should be treated as provisional
+
+---
+
+## Environment Notes
+
+### Machine roles
+- **MacBook**: corpus C, canonical smaller observatory baseline
+- **Mac mini**: corpus Cp, larger corpus observatory regime
+
+### General invocation pattern
+Most commands assume:
+
+```bash
+PYTHONPATH=src .venv/bin/python <script.py>
+```
+
+On the Mac mini environment, equivalent project-local Python invocation is also acceptable if the virtual environment differs.
+
+---
+
+## Step 0 — Base Canonical Field Stack
+
+### Purpose
+Provide the canonical non-scale-local observatory fields used downstream by seam, substrate, and predictive studies.
+
+### Required inputs
+Expected to already exist from earlier observatory construction:
+- `outputs/fim_distance/`
+- `outputs/fim_mds/`
+- `outputs/fim_phase/`
+- `outputs/fim_identity/`
+- `outputs/fim_identity_obstruction/`
+- `outputs/fim_critical/`
+- `outputs/fim_lazarus/`
+- `outputs/fim_response_operator/`
+
+### Required outputs
+At minimum:
+- `outputs/fim_distance/fisher_nodes.csv`
+- `outputs/fim_distance/fisher_edges.csv`
+- `outputs/fim_mds/mds_coords.csv`
+- `outputs/fim_phase/signed_phase_coords.csv`
+- `outputs/fim_phase/phase_distance_to_seam.csv`
+- `outputs/fim_identity/identity_field_nodes.csv`
+- `outputs/fim_identity_obstruction/identity_obstruction_nodes.csv`
+- `outputs/fim_identity_obstruction/identity_obstruction_signed_nodes.csv`
+- `outputs/fim_critical/criticality_surface.csv`
+- `outputs/fim_lazarus/lazarus_scores.csv`
+- `outputs/fim_response_operator/response_operator_nodes.csv`
+
+### Verification
+Confirm these files exist before continuing.
+
+---
+
+## Step 1 — OBS-028c Prerequisite Chain
+
+### Purpose
+Build the precursor studies needed for canonical seam-bundle export.
+
+### Commands
+
+```bash
+PYTHONPATH=src .venv/bin/python experiments/studies/fim_response_complex_compatibility.py
+PYTHONPATH=src .venv/bin/python experiments/studies/fim_response_operator_decomposition.py
+PYTHONPATH=src .venv/bin/python experiments/studies/obs025_anisotropy_vs_relational_obstruction.py
+PYTHONPATH=src .venv/bin/python experiments/studies/obs025_two_field_seam_panel.py
+PYTHONPATH=src .venv/bin/python experiments/studies/obs026_family_two_field_occupancy.py
+PYTHONPATH=src .venv/bin/python experiments/studies/obs028_embedding_comparison.py
+PYTHONPATH=src .venv/bin/python experiments/studies/obs028b_diffusion_mode_analysis.py
+```
+
+### Expected outputs
+- `outputs/fim_response_complex_compatibility/...`
+- `outputs/fim_response_operator_decomposition/...`
+- `outputs/obs025_anisotropy_vs_relational_obstruction/...`
+- `outputs/obs025_two_field_seam_panel/...`
+- `outputs/obs026_family_two_field_occupancy/...`
+- `outputs/obs028_embedding_comparison/...`
+- `outputs/obs028b_diffusion_mode_analysis/...`
+
+### Verification
+All summary text files should exist and be nonempty.
+
+---
+
+## Step 2 — OBS-028c Canonical Seam Bundle
+
+### Purpose
+Export the canonical seam bundle from the base observatory stack.
+
+### Command
+
+```bash
+PYTHONPATH=src .venv/bin/python experiments/studies/obs028c_export_canonical_seam_bundle.py
+```
+
+### Expected outputs
+- `outputs/obs028c_canonical_seam_bundle/seam_nodes.csv`
+- `outputs/obs028c_canonical_seam_bundle/seam_family_summary.csv`
+- `outputs/obs028c_canonical_seam_bundle/seam_embedding_summary.csv`
+- `outputs/obs028c_canonical_seam_bundle/seam_metadata.txt`
+
+### Status
+Canonical.
+
+---
+
+## Step 3 — Build Scale Family Substrate
+
+### Purpose
+Construct a scale-conditioned path-family substrate from scale-local probe paths, using the base canonical field stack as the reference observatory geometry.
+
+### Canonical note
+This is the crucial point where:
+- path data is scale-local
+- field diagnostics are base-output canonical
+
+This distinction should remain explicit.
+
+### Command
+
+```bash
+PYTHONPATH=src .venv/bin/python experiments/toy/build_scale_family_substrate.py \
+  --scale-root outputs/scales/100000 \
+  --outputs-root outputs
+```
+
+### Expected outputs
+Under:
+- `outputs/scales/100000/family_substrate/`
+
+At minimum:
+- `path_nodes_for_family.csv`
+- `path_node_diagnostics.csv`
+- `path_diagnostics.csv`
+- `path_family_assignments.csv`
+- `path_family_summary.csv`
+- `family_substrate_metadata.txt`
+
+### Verification
+Expected rough structure:
+- path-node tables nonempty
+- path diagnostics row count approximately equals unique path count
+- family summary contains multiple families, not a collapsed singleton row
+
+### Status
+Canonical.
+
+---
+
+## Step 4 — Prepare OBS-022 Scene Inputs
+
+### Purpose
+Refresh the scale-family substrate, scene bundle, hotspot occupancy, canonical seam bundle mirror, and optional pass-2 annotation mirrors from one orchestration point.
+
+### Canonical command
+
+```bash
+PYTHONPATH=src .venv/bin/python experiments/toy/prepare_obs022_scene_inputs.py \
+  --scale-root outputs/scales/100000 \
+  --outputs-root outputs \
+  --run-hotspot-occupancy \
+  --run-canonical-seam-bundle \
+  --run-pass2-annotations
+```
+
+### Expected outputs
+At minimum:
+- `outputs/obs022_scene_bundle/scene_nodes.csv`
+- `outputs/obs022_scene_bundle/scene_edges.csv`
+- `outputs/obs022_scene_bundle/scene_seam.csv`
+- `outputs/obs022_scene_bundle/scene_hubs.csv`
+- `outputs/obs022_scene_bundle/scene_routes.csv`
+- `outputs/obs022_scene_bundle/scene_glyphs.csv`
+- `outputs/obs022_scene_bundle/scene_metadata.txt`
+
+Also refreshes:
+- family substrate outputs
+- OBS-024 outputs
+- OBS-028c outputs
+- pass-2 annotation mirrors if enabled
+
+### Status
+Canonical orchestration entry point.
+
+---
+
+## Step 5 — OBS-024 Family Hotspot Occupancy
+
+### Purpose
+Measure how route families occupy hotspot-like node regions in the scene representation.
+
+### Canonical invocation
+Usually produced via `prepare_obs022_scene_inputs.py`, but can be run directly if prerequisites already exist.
+
+### Direct command
+
+```bash
+PYTHONPATH=src .venv/bin/python experiments/toy/obs024_family_hotspot_occupancy.py
+```
+
+### Expected outputs
+- `outputs/obs024_family_hotspot_occupancy/family_hotspot_occupancy_nodes.csv`
+- `outputs/obs024_family_hotspot_occupancy/family_hotspot_occupancy_summary.csv`
+- `outputs/obs024_family_hotspot_occupancy/obs024_family_hotspot_occupancy_summary.txt`
+- `outputs/obs024_family_hotspot_occupancy/obs024_family_hotspot_occupancy_figure.png`
+
+### Status
+Canonical.
+
+---
+
+## Step 6 — OBS-050 Structural Coupling Persistence
+
+### Purpose
+Test whether recovery-like roughness-escalation windows remain structurally coupled to the seam more often than nonrecovering windows.
+
+### Canonical command
+
+```bash
+PYTHONPATH=src .venv/bin/python experiments/studies/obs050_structural_coupling_persistence.py
+```
+
+### Expected outputs
+Under:
+- `outputs/obs050_structural_coupling_persistence/`
+
+At minimum:
+- `structural_coupling_segments.csv`
+- `structural_coupling_path_summary.csv`
+- `structural_coupling_family_summary.csv`
+- `structural_coupling_seam_band_summary.csv`
+- `structural_coupling_coupled_vs_decoupled_summary.csv`
+- `obs050_structural_coupling_persistence_summary.txt`
+- `obs050_m_seam_vs_mean_distance_to_seam.png`
+- `obs050_seam_band_distribution_by_outcome.png`
+- `obs050_coupled_vs_decoupled_by_outcome.png`
+
+### Canonical interpretation
+OBS-050 is currently treated as cross-corpus robust at the qualitative level.
+
+### Verification targets
+Summary should report:
+- recovering coupled share
+- nonrecovering coupled share
+- coupled risk ratio
+- coupled odds ratio
+
+Direction should remain:
+- recovering more coupled than nonrecovering
+
+### Status
+Canonical, cross-corpus qualitatively replicated.
+
+---
+
+## Step 7 — OBS-051 Local Divergence in Coupled Windows
+
+### Purpose
+Measure Lyapunov-like local divergence inside seam-coupled roughness-escalation windows.
+
+### Canonical commands
+Run at least these three passes:
+
+#### All coupled windows
+```bash
+PYTHONPATH=src .venv/bin/python experiments/studies/obs051_local_divergence_in_coupled_windows.py \
+  --seam-band-filter all
+```
+
+#### Core-only windows
+```bash
+PYTHONPATH=src .venv/bin/python experiments/studies/obs051_local_divergence_in_coupled_windows.py \
+  --seam-band-filter core
+```
+
+#### Near-only windows
+```bash
+PYTHONPATH=src .venv/bin/python experiments/studies/obs051_local_divergence_in_coupled_windows.py \
+  --seam-band-filter near
+```
+
+### Expected outputs
+Under:
+- `outputs/obs051_local_divergence_in_coupled_windows/`
+
+At minimum:
+- `obs051_window_divergence.csv`
+- `obs051_outcome_summary.csv`
+- `obs051_family_summary.csv`
+- `obs051_local_divergence_summary.txt`
+- `obs051_lambda_boxplot_by_outcome.png`
+- `obs051_lambda_vs_initial_separation.png`
+
+### Instrument note
+The refined version includes:
+- nonzero minimum initial separation
+- standardized matching features
+- secondary boundedness proxies:
+  - `mean_delta_d`
+  - `mean_bounded_share`
+
+### Current status
+Runs reproducibly on both machines, but interpretation is currently **corpus-sensitive**.
+
+### Cross-corpus note
+- On corpus C, refined OBS-051 suggests stronger boundedness in recovery-like near-band windows
+- On corpus Cp, refined OBS-051 does not preserve that directional conclusion
+- Therefore OBS-051 should currently be treated as **provisional**, not canonical
+
+### Operational interpretation
+- `core` currently behaves more like a high-pressure contact regime than a clean bounded recovery regime
+- `near` is the most informative band, but remains corpus-sensitive in direction
+
+### Status
+Provisional.
+
+---
+
+## Canonical vs Provisional Summary
+
+### Canonical chain components
+- OBS-028c prerequisites
+- OBS-028c canonical seam bundle
+- scale family substrate build
+- OBS-022 scene input preparation
+- OBS-024 hotspot occupancy
+- OBS-050 structural coupling persistence
+
+### Provisional chain components
+- OBS-051 local divergence in coupled windows
+
+---
+
+## Verification Checklist
+
+### Minimal file-level checks
+- all expected summary text files exist
+- all expected primary csv outputs exist
+- no zero-row summary tables where meaningful results are expected
+
+### Scientific checks
+
+#### OBS-050
+- recovering coupled share > nonrecovering coupled share
+- coupled risk ratio > 1
+
+#### OBS-051
+- script runs successfully for `all`, `core`, and `near`
+- summary files are produced
+- results explicitly recorded as corpus-sensitive until further stabilization
+
+---
+
+## Recommended Verification Note
+
+Maintain a companion note such as:
+
+- `docs/05_project/observatory_chain_verification_C_vs_Cp.md`
+
+This should record:
+- machine
+- corpus
+- date
+- command set used
+- whether each stage ran
+- whether qualitative conclusions replicated
+- whether stage is canonical or provisional
+
+---
+
+## Current Recommended Interpretation
+
+The observatory chain currently supports the following structure:
+
+- seam bundle and family substrate layers are reproducible
+- predictive seam-coupling persistence is stable enough to treat as canonical
+- local divergence inside coupled windows is scientifically promising, but not yet stable enough to treat as corpus-invariant
+
+That distinction should remain explicit in downstream use.

--- a/docs/05_project/observatory_chain_verification_C_vs_Cp.md
+++ b/docs/05_project/observatory_chain_verification_C_vs_Cp.md
@@ -1,0 +1,229 @@
+# Observatory Chain Verification — C vs Cp
+
+## Scope
+
+This note records end-to-end verification of the canonical observatory chain from OBS-028c through OBS-051 on both supported corpus environments:
+
+- **C** on the MacBook
+- **Cp** on the Mac mini
+
+The purpose of this note is operational and scientific:
+
+- confirm that the chain runs reproducibly on both machines
+- distinguish stable from provisional observatory stages
+- record which conclusions replicate across corpora and which do not
+
+---
+
+## Verification Date
+
+- Date: 2026-04-27
+
+---
+
+## Environments
+
+### MacBook
+- Corpus: **C**
+- Role: canonical smaller observatory baseline
+
+### Mac mini
+- Corpus: **Cp**
+- Role: larger corpus observatory regime
+
+---
+
+## Runner Used
+
+Canonical runner:
+
+```bash
+./scripts/run_observatory_chain_obs028c_to_obs051.sh
+```
+
+This runner completed successfully on both machines.
+
+---
+
+## Chain Stages Verified
+
+The following stages were executed successfully on both environments:
+
+1. OBS-028c prerequisite chain
+2. OBS-028c canonical seam bundle
+3. scale-conditioned family substrate build
+4. OBS-022 scene input preparation
+5. OBS-024 family hotspot occupancy
+6. OBS-050 structural coupling persistence
+7. OBS-051 local divergence in coupled windows
+   - `all`
+   - `core`
+   - `near`
+
+---
+
+## File-Level Verification
+
+On both machines, the chain produced the expected output directories and summary artifacts for:
+
+- `outputs/obs028c_canonical_seam_bundle/`
+- `outputs/scales/100000/family_substrate/`
+- `outputs/obs022_scene_bundle/`
+- `outputs/obs024_family_hotspot_occupancy/`
+- `outputs/obs050_structural_coupling_persistence/`
+- `outputs/obs051_local_divergence_in_coupled_windows/`
+
+The runner completed without manual intervention.
+
+---
+
+## Scientific Verification Summary
+
+## OBS-028c
+
+### Status
+- Reproducible
+- Treated as canonical
+
+### Verification result
+- Canonical seam bundle exports successfully on both machines
+- No cross-machine instability observed at the operational level
+
+---
+
+## Scale Family Substrate / OBS-022 / OBS-024
+
+### Status
+- Reproducible
+- Treated as canonical infrastructure layers
+
+### Verification result
+- Family substrate builds correctly on both machines
+- OBS-022 scene bundle refreshes correctly on both machines
+- OBS-024 hotspot occupancy runs correctly on both machines
+
+These stages are currently treated as stable observatory infrastructure.
+
+---
+
+## OBS-050 — Structural Coupling Persistence
+
+### Status
+- Reproducible
+- Treated as canonical
+- Cross-corpus qualitatively replicated
+
+### Shared qualitative result
+On both C and Cp:
+
+- recovery-like roughness-escalation windows are much more likely than nonrecovering windows to remain in coupled seam bands
+- the seam-coupling persistence result is preserved qualitatively
+- coupled-vs-decoupled separation remains the key predictive signal
+
+### Conclusion
+OBS-050 is currently treated as the first **cross-corpus robust predictive observatory result**.
+
+### Operational interpretation
+- OBS-050 is stable enough to serve as part of the canonical observatory chain
+- exact effect sizes differ between corpora, but the direction of the result is preserved
+
+---
+
+## OBS-051 — Local Divergence in Coupled Windows
+
+### Status
+- Reproducible as a pipeline stage
+- **Not** currently canonical in interpretation
+- Treated as provisional / corpus-sensitive
+
+### Verification result
+OBS-051 runs successfully on both machines in all refined modes:
+
+- `all`
+- `core`
+- `near`
+
+However, the scientific conclusion does **not** remain stable across corpora.
+
+### Shared structural observation
+- the `core` seam band does **not** behave like a clean bounded recovery regime
+- `core` is better interpreted as a high-pressure contact regime
+
+### Corpus-sensitive result
+The `near` band, which is the most informative band in the refined OBS-051 instrument, does not preserve the same directional conclusion across C and Cp.
+
+- On corpus **C**, refined OBS-051 suggests stronger boundedness in recovery-like near-band windows
+- On corpus **Cp**, refined OBS-051 does not preserve that direction and can reverse it
+
+### Conclusion
+OBS-051 is currently treated as:
+
+- operationally reproducible
+- scientifically promising
+- but **corpus-sensitive and provisional**
+
+It should not yet be cited as a corpus-invariant observatory result.
+
+---
+
+## Current Canonical / Provisional Split
+
+### Canonical / stable enough to rely on
+- OBS-028c
+- scale family substrate build
+- OBS-022 scene input preparation
+- OBS-024 family hotspot occupancy
+- OBS-050 structural coupling persistence
+
+### Provisional / not yet corpus-invariant
+- OBS-051 local divergence in coupled windows
+
+---
+
+## Recommended Current Observatory Reading
+
+The observatory chain currently supports the following distinction:
+
+### Stable
+Retained seam coupling during roughness escalation is a robust cross-corpus feature.
+
+### Not yet stable
+The boundedness structure inside seam-coupled windows is corpus-sensitive and not yet canonical.
+
+This means the present observatory spine supports:
+
+- seam bundle
+- family substrate
+- scene preparation
+- hotspot occupancy
+- predictive seam-coupling persistence
+
+while treating local-divergence interpretation as an active refinement frontier rather than closed observatory fact.
+
+---
+
+## Practical Consequence
+
+Future downstream studies should use the following rule:
+
+- OBS-050 may be treated as part of the canonical observatory foundation
+- OBS-051 may be run and inspected, but should be labeled **provisional** until a corpus-stable interpretation is achieved
+
+This distinction should remain explicit in:
+- docs
+- PR descriptions
+- logbook entries
+- future observatory summaries
+
+---
+
+## Next-Step Recommendation
+
+The chain from OBS-028c through OBS-051 is now stable enough operationally to support future work.
+
+Recommended next posture:
+
+1. preserve the current canonical/provisional split explicitly
+2. avoid building strong new theoretical claims on top of OBS-051 alone
+3. treat OBS-052 and later basin-style analyses as downstream of a still-provisional divergence layer
+4. use the current chain as the reproducible observatory baseline for future refinement

--- a/experiments/studies/obs052_attractor_basin_mapping.py
+++ b/experiments/studies/obs052_attractor_basin_mapping.py
@@ -1,0 +1,673 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""
+OBS-052 — Attractor basin mapping from recurrence, boundedness, and recovery landing.
+
+Core question
+-------------
+Do recovery-like coupled windows preferentially terminate in recurrent,
+low-divergence, low-roughness, low-drift regions, and do these regions form
+distinct seam-core/near alignment sinks versus seam-far decoupled sinks?
+
+Motivation
+----------
+OBS-050 established that recovery-like roughness-escalation windows are much
+more likely to remain seam-coupled than nonrecovering windows.
+
+OBS-051 established that, among coupled windows, recovery-like regimes are
+dynamically more bounded.
+
+OBS-052 asks the next natural question:
+where do those bounded, recovery-like windows tend to land?
+
+This script builds a first node-level basin analysis using:
+- recurrence / visitation density
+- local divergence from OBS-051
+- roughness from OBS-050
+- seam-drift from OBS-050
+- recovery landing density
+
+This is a first attractor-basin pass, not yet a final recovery-basin theory.
+
+Inputs
+------
+1. OBS-022 scene bundle:
+   outputs/obs022_scene_bundle/scene_nodes.csv
+   outputs/obs022_scene_bundle/scene_routes.csv
+
+2. Family substrate:
+   outputs/scales/100000/family_substrate/path_family_assignments.csv
+
+3. OBS-050:
+   outputs/obs050_structural_coupling_persistence/structural_coupling_segments.csv
+
+4. OBS-051:
+   outputs/obs051_local_divergence_in_coupled_windows/obs051_window_divergence.csv
+
+Outputs
+-------
+<outdir>/
+  obs052_node_basin_table.csv
+  obs052_recovery_landing_table.csv
+  obs052_top_basin_candidates.csv
+  obs052_attractor_basin_summary.txt
+  obs052_attractor_map_mds.png
+  obs052_recovery_landing_map_mds.png
+  obs052_phase_portrait_roughness_vs_lambda.png
+
+Interpretation
+--------------
+Node-level attractor score A(x) is a first heuristic composite:
+
+    A(x) = z(recurrence_paths)
+           - z(mean_lambda_local)
+           - z(mean_roughness)
+           - z(mean_abs_m_seam)
+           + z(recovery_landings)
+
+High A(x):
+    recurrent, bounded, low-roughness, low-drift, recovery-attracting node
+
+Provisional classes:
+- alignment_sink: seam core/near and high A(x)
+- decoupled_sink: seam far and high A(x)
+"""
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+
+RECOVERING_FAMILIES = {"stable_seam_corridor", "reorganization_heavy"}
+NONRECOVERING_FAMILIES = {"off_seam_reorganizing", "settled_distant"}
+
+
+@dataclass(frozen=True)
+class Config:
+    scene_nodes_csv: str = "outputs/obs022_scene_bundle/scene_nodes.csv"
+    scene_routes_csv: str = "outputs/obs022_scene_bundle/scene_routes.csv"
+    family_csv: str = "outputs/scales/100000/family_substrate/path_family_assignments.csv"
+    obs050_segments_csv: str = "outputs/obs050_structural_coupling_persistence/structural_coupling_segments.csv"
+    obs051_windows_csv: str = "outputs/obs051_local_divergence_in_coupled_windows/obs051_window_divergence.csv"
+    outdir: str = "outputs/obs052_attractor_basin_mapping"
+    seam_core_max: float = 0.05
+    seam_near_max: float = 0.15
+    top_k: int = 20
+
+
+def safe_read_csv(path: Path) -> pd.DataFrame:
+    if not path.exists():
+        raise FileNotFoundError(path)
+    return pd.read_csv(path).copy()
+
+
+def to_numeric_inplace(df: pd.DataFrame, cols: Iterable[str]) -> None:
+    for col in cols:
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+
+
+def classify_outcome(path_family: str) -> str:
+    if path_family in RECOVERING_FAMILIES:
+        return "recovering"
+    if path_family in NONRECOVERING_FAMILIES:
+        return "nonrecovering"
+    return "other"
+
+
+def classify_seam_band(mean_distance_to_seam: float, core_max: float, near_max: float) -> str:
+    if not np.isfinite(mean_distance_to_seam):
+        return "unknown"
+    if mean_distance_to_seam <= core_max:
+        return "core"
+    if mean_distance_to_seam <= near_max:
+        return "near"
+    return "far"
+
+
+def zscore_series(s: pd.Series, eps: float = 1e-12) -> pd.Series:
+    x = pd.to_numeric(s, errors="coerce")
+    mu = float(x.mean(skipna=True)) if x.notna().any() else 0.0
+    sd = float(x.std(skipna=True)) if x.notna().any() else 0.0
+    return (x - mu) / max(sd, eps)
+
+
+def load_inputs(cfg: Config) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    nodes = safe_read_csv(Path(cfg.scene_nodes_csv))
+    routes = safe_read_csv(Path(cfg.scene_routes_csv))
+    fam = safe_read_csv(Path(cfg.family_csv))
+    segs = safe_read_csv(Path(cfg.obs050_segments_csv))
+    obs051 = safe_read_csv(Path(cfg.obs051_windows_csv))
+
+    for df in [nodes, routes, fam, segs, obs051]:
+        if "path_id" in df.columns:
+            df["path_id"] = df["path_id"].astype(str)
+        if "segment_id" in df.columns:
+            df["segment_id"] = df["segment_id"].astype(str)
+
+    to_numeric_inplace(
+        nodes,
+        [
+            "node_id", "r", "alpha", "mds1", "mds2",
+            "distance_to_seam", "signed_phase", "lazarus_score",
+            "response_strength", "node_holonomy_proxy",
+        ],
+    )
+    to_numeric_inplace(
+        routes,
+        [
+            "node_id", "step", "r", "alpha", "mds1", "mds2",
+            "distance_to_seam", "signed_phase", "lazarus_score",
+            "response_strength",
+        ],
+    )
+    to_numeric_inplace(
+        segs,
+        [
+            "start_step", "end_step", "center_step",
+            "mean_roughness", "mean_roughness_smoothed",
+            "mean_distance_to_seam", "min_distance_to_seam",
+            "center_distance_to_seam", "m_r", "m_seam",
+        ],
+    )
+    to_numeric_inplace(
+        obs051,
+        [
+            "mean_d_start", "mean_d_end",
+            "mean_lambda_local", "median_lambda_local", "max_lambda_local",
+        ],
+    )
+
+    if "path_family" not in fam.columns:
+        raise ValueError("family assignments file must contain path_family")
+
+    return nodes, routes, fam, segs, obs051
+
+
+def build_segment_endpoint_nodes(routes: pd.DataFrame, segs: pd.DataFrame) -> pd.DataFrame:
+    """
+    Map each OBS-050 segment to its terminal node via scene_routes.
+    Uses exact path_id + end_step match.
+    """
+    use_routes = routes.copy()
+    use_routes["path_id"] = use_routes["path_id"].astype(str)
+    use_routes["step"] = pd.to_numeric(use_routes["step"], errors="coerce")
+
+    use_segs = segs[["segment_id", "path_id", "path_family", "outcome_group", "start_step", "end_step", "seam_band", "coupling_class"]].copy()
+    use_segs["path_id"] = use_segs["path_id"].astype(str)
+    use_segs["end_step"] = pd.to_numeric(use_segs["end_step"], errors="coerce")
+
+    end_nodes = use_segs.merge(
+        use_routes[
+            [
+                "path_id", "step", "node_id", "mds1", "mds2",
+                "distance_to_seam", "path_family", "is_representative", "is_branch_away"
+            ]
+            if "is_representative" in use_routes.columns and "is_branch_away" in use_routes.columns
+            else [c for c in ["path_id", "step", "node_id", "mds1", "mds2", "distance_to_seam", "path_family"] if c in use_routes.columns]
+        ],
+        left_on=["path_id", "end_step"],
+        right_on=["path_id", "step"],
+        how="left",
+        suffixes=("", "_route"),
+    )
+
+    if "path_family_route" in end_nodes.columns:
+        end_nodes["path_family"] = end_nodes["path_family"].fillna(end_nodes["path_family_route"])
+        end_nodes = end_nodes.drop(columns=["path_family_route"])
+
+    return end_nodes
+
+
+def build_node_recurrence_table(nodes: pd.DataFrame, routes: pd.DataFrame, fam: pd.DataFrame) -> pd.DataFrame:
+    fam_use = fam[["path_id", "path_family"]].drop_duplicates().copy()
+    fam_use["outcome_group"] = fam_use["path_family"].map(classify_outcome)
+
+    route_use = routes.copy()
+    route_use["path_id"] = route_use["path_id"].astype(str)
+    route_use = route_use.merge(fam_use, on="path_id", how="left", suffixes=("", "_fam"))
+    if "path_family_fam" in route_use.columns:
+        route_use["path_family"] = route_use["path_family"].fillna(route_use["path_family_fam"])
+        route_use = route_use.drop(columns=["path_family_fam"])
+
+    agg = (
+        route_use.groupby("node_id", dropna=False)
+        .agg(
+            n_visits=("path_id", "size"),
+            n_unique_paths=("path_id", "nunique"),
+            n_recovering_paths=("path_id", lambda s: int(route_use.loc[s.index, "outcome_group"].eq("recovering").groupby(level=0).first().sum()) if len(s) else 0),
+        )
+        .reset_index()
+    )
+
+    # Better explicit counts by node
+    counts = (
+        route_use.groupby(["node_id", "outcome_group"], dropna=False)["path_id"]
+        .nunique()
+        .reset_index(name="n_unique_paths_by_outcome")
+    )
+    pivot = (
+        counts.pivot(index="node_id", columns="outcome_group", values="n_unique_paths_by_outcome")
+        .fillna(0)
+        .reset_index()
+    )
+    pivot.columns = [str(c) for c in pivot.columns]
+    for c in ["recovering", "nonrecovering", "other"]:
+        if c not in pivot.columns:
+            pivot[c] = 0
+        pivot = pivot.rename(columns={c: f"n_unique_paths_{c}"})
+
+    out = nodes.copy()
+    out = out.merge(agg, on="node_id", how="left")
+    out = out.merge(pivot, on="node_id", how="left")
+
+    for c in ["n_visits", "n_unique_paths", "n_unique_paths_recovering", "n_unique_paths_nonrecovering", "n_unique_paths_other"]:
+        if c in out.columns:
+            out[c] = pd.to_numeric(out[c], errors="coerce").fillna(0).astype(int)
+
+    out["seam_band"] = out["distance_to_seam"].map(
+        lambda x: classify_seam_band(float(x), 0.05, 0.15) if pd.notna(x) else "unknown"
+    )
+    return out
+
+
+def build_obs051_window_summary(obs051: pd.DataFrame) -> pd.DataFrame:
+    """
+    OBS-051 input file name suggests window divergence, but the content is the
+    per-window summary table. We aggregate defensively by segment_id.
+    """
+    required = {"segment_id", "path_id", "outcome_group"}
+    missing = required - set(obs051.columns)
+    if missing:
+        raise ValueError(f"OBS-051 windows file missing required columns: {sorted(missing)}")
+
+    keep = [
+        c for c in [
+            "segment_id", "path_id", "path_family", "outcome_group",
+            "seam_band", "coupling_class",
+            "mean_lambda_local", "median_lambda_local", "max_lambda_local",
+            "mean_d_start", "mean_d_end",
+        ] if c in obs051.columns
+    ]
+    return obs051[keep].drop_duplicates().copy()
+
+
+def build_recovery_landing_table(
+    seg_end_nodes: pd.DataFrame,
+    obs051_win: pd.DataFrame,
+) -> pd.DataFrame:
+    """
+    Count where windows land, especially recovering coupled windows.
+    """
+    work = seg_end_nodes.copy()
+    work = work.merge(
+        obs051_win[
+            [c for c in [
+                "segment_id", "mean_lambda_local", "median_lambda_local", "max_lambda_local",
+                "coupling_class", "seam_band", "outcome_group", "path_family"
+            ] if c in obs051_win.columns]
+        ].drop_duplicates(subset=["segment_id"]),
+        on="segment_id",
+        how="left",
+        suffixes=("", "_obs051"),
+    )
+
+    if "outcome_group_obs051" in work.columns and "outcome_group" in work.columns:
+        work["outcome_group"] = work["outcome_group"].fillna(work["outcome_group_obs051"])
+        work = work.drop(columns=["outcome_group_obs051"])
+    if "path_family_obs051" in work.columns and "path_family" in work.columns:
+        work["path_family"] = work["path_family"].fillna(work["path_family_obs051"])
+        work = work.drop(columns=["path_family_obs051"])
+
+    out = (
+        work.groupby(["node_id", "outcome_group"], dropna=False)
+        .agg(
+            n_landings=("segment_id", "size"),
+            n_unique_paths=("path_id", "nunique"),
+            mean_lambda_local=("mean_lambda_local", "mean"),
+        )
+        .reset_index()
+    )
+
+    pivot_counts = (
+        out.pivot(index="node_id", columns="outcome_group", values="n_landings")
+        .fillna(0)
+        .reset_index()
+    )
+    pivot_paths = (
+        out.pivot(index="node_id", columns="outcome_group", values="n_unique_paths")
+        .fillna(0)
+        .reset_index()
+    )
+
+    pivot_counts.columns = [str(c) for c in pivot_counts.columns]
+    pivot_paths.columns = [str(c) for c in pivot_paths.columns]
+
+    for c in ["recovering", "nonrecovering", "other"]:
+        if c not in pivot_counts.columns:
+            pivot_counts[c] = 0
+        if c not in pivot_paths.columns:
+            pivot_paths[c] = 0
+
+    pivot_counts = pivot_counts.rename(
+        columns={
+            "recovering": "recovering_landings",
+            "nonrecovering": "nonrecovering_landings",
+            "other": "other_landings",
+        }
+    )
+    pivot_paths = pivot_paths.rename(
+        columns={
+            "recovering": "recovering_unique_path_landings",
+            "nonrecovering": "nonrecovering_unique_path_landings",
+            "other": "other_unique_path_landings",
+        }
+    )
+
+    landing_table = pivot_counts.merge(pivot_paths, on="node_id", how="outer").fillna(0)
+    for c in landing_table.columns:
+        if c != "node_id":
+            landing_table[c] = pd.to_numeric(landing_table[c], errors="coerce").fillna(0).astype(int)
+
+    return landing_table
+
+
+def build_node_basin_table(
+    node_table: pd.DataFrame,
+    seg_end_nodes: pd.DataFrame,
+    obs051_win: pd.DataFrame,
+    landing_table: pd.DataFrame,
+) -> pd.DataFrame:
+    # Join OBS-050 per-segment variables onto end nodes, then aggregate by node
+    seg_attrs = seg_end_nodes[
+        [c for c in [
+            "segment_id", "node_id", "path_id", "path_family", "outcome_group",
+            "seam_band", "coupling_class",
+            "mean_roughness", "mean_roughness_smoothed", "m_seam", "m_r",
+            "mean_distance_to_seam", "min_distance_to_seam"
+        ] if c in seg_end_nodes.columns]
+    ].copy()
+
+    if "mean_roughness" not in seg_attrs.columns:
+        # pull from OBS-050 if segment mapping retained only subset
+        pass
+
+    seg_merged = seg_attrs.merge(
+        obs051_win[
+            [c for c in [
+                "segment_id", "mean_lambda_local", "median_lambda_local", "max_lambda_local"
+            ] if c in obs051_win.columns]
+        ].drop_duplicates(subset=["segment_id"]),
+        on="segment_id",
+        how="left",
+    )
+
+    node_dyn = (
+        seg_merged.groupby("node_id", dropna=False)
+        .agg(
+            mean_lambda_local=("mean_lambda_local", "mean"),
+            median_lambda_local=("mean_lambda_local", "median"),
+            mean_roughness=("mean_roughness", "mean"),
+            mean_abs_m_seam=("m_seam", lambda s: float(np.nanmean(np.abs(pd.to_numeric(s, errors="coerce"))))),
+            mean_m_seam=("m_seam", "mean"),
+            n_segment_landings=("segment_id", "size"),
+            n_unique_segment_paths=("path_id", "nunique"),
+        )
+        .reset_index()
+    )
+
+    out = node_table.merge(node_dyn, on="node_id", how="left")
+    out = out.merge(landing_table, on="node_id", how="left")
+
+    for c in [
+        "recovering_landings", "nonrecovering_landings", "other_landings",
+        "recovering_unique_path_landings", "nonrecovering_unique_path_landings", "other_unique_path_landings",
+    ]:
+        if c in out.columns:
+            out[c] = pd.to_numeric(out[c], errors="coerce").fillna(0).astype(int)
+
+    # composite score
+    out["z_recurrence"] = zscore_series(out["n_unique_paths"])
+    out["z_lambda"] = zscore_series(out["mean_lambda_local"])
+    out["z_roughness"] = zscore_series(out["mean_roughness"])
+    out["z_abs_m_seam"] = zscore_series(out["mean_abs_m_seam"])
+    out["z_recovery_landings"] = zscore_series(out["recovering_landings"])
+
+    out["attractor_score"] = (
+        out["z_recurrence"].fillna(0.0)
+        - out["z_lambda"].fillna(0.0)
+        - out["z_roughness"].fillna(0.0)
+        - out["z_abs_m_seam"].fillna(0.0)
+        + out["z_recovery_landings"].fillna(0.0)
+    )
+
+    def _classify(row: pd.Series) -> str:
+        seam_band = str(row.get("seam_band", "unknown"))
+        if not pd.notna(row.get("attractor_score")):
+            return "unknown"
+        if seam_band in {"core", "near"}:
+            return "alignment_sink"
+        if seam_band == "far":
+            return "decoupled_sink"
+        return "unknown"
+
+    out["basin_class"] = out.apply(_classify, axis=1)
+
+    return out
+
+
+def build_top_basin_candidates(node_basin: pd.DataFrame, top_k: int) -> pd.DataFrame:
+    cols = [
+        c for c in [
+            "node_id", "r", "alpha", "mds1", "mds2", "seam_band", "basin_class",
+            "n_visits", "n_unique_paths",
+            "recovering_landings", "nonrecovering_landings",
+            "mean_lambda_local", "mean_roughness", "mean_abs_m_seam",
+            "attractor_score",
+        ] if c in node_basin.columns
+    ]
+    return (
+        node_basin[cols]
+        .sort_values("attractor_score", ascending=False)
+        .head(top_k)
+        .reset_index(drop=True)
+    )
+
+
+def summarize_text(
+    node_basin: pd.DataFrame,
+    top_basin: pd.DataFrame,
+    cfg: Config,
+) -> str:
+    lines: list[str] = []
+    lines.append("=== OBS-052 Attractor Basin Mapping Summary ===")
+    lines.append("")
+    lines.append(f"top_k = {cfg.top_k}")
+    lines.append(f"n_nodes = {len(node_basin)}")
+    lines.append("")
+
+    if len(node_basin):
+        for cls in ["alignment_sink", "decoupled_sink", "unknown"]:
+            sub = node_basin[node_basin["basin_class"] == cls]
+            if len(sub) == 0:
+                continue
+            lines.append(
+                f"{cls}: "
+                f"n_nodes={len(sub)}, "
+                f"mean_attractor_score={pd.to_numeric(sub['attractor_score'], errors='coerce').mean():.6f}, "
+                f"mean_lambda_local={pd.to_numeric(sub['mean_lambda_local'], errors='coerce').mean():.6f}, "
+                f"mean_roughness={pd.to_numeric(sub['mean_roughness'], errors='coerce').mean():.6f}, "
+                f"mean_recovering_landings={pd.to_numeric(sub['recovering_landings'], errors='coerce').mean():.6f}"
+            )
+
+    lines.append("")
+    lines.append("Top basin candidates")
+    for _, row in top_basin.iterrows():
+        lines.append(
+            f"node_id={int(row['node_id'])} | "
+            f"seam_band={row.get('seam_band')} | "
+            f"basin_class={row.get('basin_class')} | "
+            f"attractor_score={float(row['attractor_score']):.6f} | "
+            f"n_unique_paths={int(row['n_unique_paths']) if pd.notna(row.get('n_unique_paths')) else 0} | "
+            f"recovering_landings={int(row['recovering_landings']) if pd.notna(row.get('recovering_landings')) else 0} | "
+            f"nonrecovering_landings={int(row['nonrecovering_landings']) if pd.notna(row.get('nonrecovering_landings')) else 0} | "
+            f"mean_lambda_local={float(row['mean_lambda_local']) if pd.notna(row.get('mean_lambda_local')) else float('nan'):.6f} | "
+            f"mean_roughness={float(row['mean_roughness']) if pd.notna(row.get('mean_roughness')) else float('nan'):.6f} | "
+            f"mean_abs_m_seam={float(row['mean_abs_m_seam']) if pd.notna(row.get('mean_abs_m_seam')) else float('nan'):.6f}"
+        )
+
+    return "\n".join(lines)
+
+
+def plot_attractor_map(node_basin: pd.DataFrame, outpath: Path) -> None:
+    fig, ax = plt.subplots(figsize=(8, 6))
+    plot_df = node_basin.dropna(subset=["mds1", "mds2", "attractor_score"]).copy()
+
+    sizes = 20 + 20 * zscore_series(plot_df["n_unique_paths"]).fillna(0.0).clip(lower=-1.0, upper=3.0).to_numpy()
+    sizes = np.maximum(sizes, 12)
+
+    sc = ax.scatter(
+        plot_df["mds1"],
+        plot_df["mds2"],
+        c=plot_df["attractor_score"],
+        s=sizes,
+    )
+    ax.set_title("OBS-052: attractor score on manifold")
+    ax.set_xlabel("mds1")
+    ax.set_ylabel("mds2")
+    fig.colorbar(sc, ax=ax, label="attractor_score")
+    fig.tight_layout()
+    fig.savefig(outpath, dpi=180)
+    plt.close(fig)
+
+
+def plot_recovery_landing_map(node_basin: pd.DataFrame, outpath: Path) -> None:
+    fig, ax = plt.subplots(figsize=(8, 6))
+    plot_df = node_basin.dropna(subset=["mds1", "mds2"]).copy()
+    vals = pd.to_numeric(plot_df.get("recovering_landings", 0), errors="coerce").fillna(0)
+    sizes = 12 + 8 * np.sqrt(vals.to_numpy(dtype=float))
+
+    sc = ax.scatter(
+        plot_df["mds1"],
+        plot_df["mds2"],
+        c=vals,
+        s=sizes,
+    )
+    ax.set_title("OBS-052: recovery landing density on manifold")
+    ax.set_xlabel("mds1")
+    ax.set_ylabel("mds2")
+    fig.colorbar(sc, ax=ax, label="recovering_landings")
+    fig.tight_layout()
+    fig.savefig(outpath, dpi=180)
+    plt.close(fig)
+
+
+def plot_phase_portrait(node_basin: pd.DataFrame, outpath: Path) -> None:
+    fig, ax = plt.subplots(figsize=(8, 6))
+    plot_df = node_basin.dropna(subset=["mean_roughness", "mean_lambda_local", "seam_band"]).copy()
+
+    for seam_band in ["core", "near", "far", "unknown"]:
+        sub = plot_df[plot_df["seam_band"] == seam_band]
+        if len(sub) == 0:
+            continue
+        ax.scatter(sub["mean_roughness"], sub["mean_lambda_local"], s=24, label=seam_band)
+
+    ax.axhline(0.0, linewidth=1)
+    ax.set_xlabel("mean_roughness")
+    ax.set_ylabel("mean_lambda_local")
+    ax.set_title("OBS-052: phase portrait (roughness vs local divergence)")
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(outpath, dpi=180)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="OBS-052 attractor basin mapping.")
+    parser.add_argument("--scene-nodes-csv", default=Config.scene_nodes_csv)
+    parser.add_argument("--scene-routes-csv", default=Config.scene_routes_csv)
+    parser.add_argument("--family-csv", default=Config.family_csv)
+    parser.add_argument("--obs050-segments-csv", default=Config.obs050_segments_csv)
+    parser.add_argument("--obs051-windows-csv", default=Config.obs051_windows_csv)
+    parser.add_argument("--outdir", default=Config.outdir)
+    parser.add_argument("--seam-core-max", type=float, default=Config.seam_core_max)
+    parser.add_argument("--seam-near-max", type=float, default=Config.seam_near_max)
+    parser.add_argument("--top-k", type=int, default=Config.top_k)
+    args = parser.parse_args()
+
+    cfg = Config(
+        scene_nodes_csv=args.scene_nodes_csv,
+        scene_routes_csv=args.scene_routes_csv,
+        family_csv=args.family_csv,
+        obs050_segments_csv=args.obs050_segments_csv,
+        obs051_windows_csv=args.obs051_windows_csv,
+        outdir=args.outdir,
+        seam_core_max=args.seam_core_max,
+        seam_near_max=args.seam_near_max,
+        top_k=args.top_k,
+    )
+
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    nodes, routes, fam, segs, obs051 = load_inputs(cfg)
+
+    if "outcome_group" not in segs.columns and "path_family" in segs.columns:
+        segs["outcome_group"] = segs["path_family"].map(classify_outcome)
+    if "coupling_class" not in segs.columns and "seam_band" in segs.columns:
+        segs["coupling_class"] = np.where(
+            segs["seam_band"].isin(["core", "near"]),
+            "coupled",
+            np.where(segs["seam_band"] == "far", "decoupled", "unknown"),
+        )
+
+    node_recurrence = build_node_recurrence_table(nodes, routes, fam)
+    obs051_win = build_obs051_window_summary(obs051)
+    seg_end_nodes = build_segment_endpoint_nodes(routes, segs)
+    # add obs050 fields needed for basin aggregation
+    seg_end_nodes = seg_end_nodes.merge(
+        segs[
+            [c for c in [
+                "segment_id", "path_id", "path_family", "outcome_group",
+                "seam_band", "coupling_class",
+                "mean_roughness", "mean_roughness_smoothed", "m_seam", "m_r",
+                "mean_distance_to_seam", "min_distance_to_seam"
+            ] if c in segs.columns]
+        ].drop_duplicates(subset=["segment_id"]),
+        on=["segment_id", "path_id"],
+        how="left",
+        suffixes=("", "_seg"),
+    )
+
+    landing_table = build_recovery_landing_table(seg_end_nodes, obs051_win)
+    node_basin = build_node_basin_table(node_recurrence, seg_end_nodes, obs051_win, landing_table)
+    top_basin = build_top_basin_candidates(node_basin, cfg.top_k)
+
+    node_basin.to_csv(outdir / "obs052_node_basin_table.csv", index=False)
+    landing_table.to_csv(outdir / "obs052_recovery_landing_table.csv", index=False)
+    top_basin.to_csv(outdir / "obs052_top_basin_candidates.csv", index=False)
+
+    summary_txt = summarize_text(node_basin, top_basin, cfg)
+    (outdir / "obs052_attractor_basin_summary.txt").write_text(summary_txt, encoding="utf-8")
+
+    plot_attractor_map(node_basin, outdir / "obs052_attractor_map_mds.png")
+    plot_recovery_landing_map(node_basin, outdir / "obs052_recovery_landing_map_mds.png")
+    plot_phase_portrait(node_basin, outdir / "obs052_phase_portrait_roughness_vs_lambda.png")
+
+    print(outdir / "obs052_node_basin_table.csv")
+    print(outdir / "obs052_recovery_landing_table.csv")
+    print(outdir / "obs052_top_basin_candidates.csv")
+    print(outdir / "obs052_attractor_basin_summary.txt")
+    print(outdir / "obs052_attractor_map_mds.png")
+    print(outdir / "obs052_recovery_landing_map_mds.png")
+    print(outdir / "obs052_phase_portrait_roughness_vs_lambda.png")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_observatory_chain_obs028c_to_obs051.sh
+++ b/scripts/run_observatory_chain_obs028c_to_obs051.sh
@@ -1,0 +1,235 @@
+et -euo pipefail
+
+# run_observatory_chain_obs028c_to_obs051.sh
+#
+# Canonical runner for the observatory chain from OBS-028c through OBS-051.
+#
+# Scope:
+#   1. OBS-028c prerequisite studies
+#   2. OBS-028c canonical seam bundle
+#   3. Scale family substrate build
+#   4. OBS-022 scene input preparation
+#   5. OBS-050 structural coupling persistence
+#   6. OBS-051 local divergence (all/core/near)
+#
+# Notes:
+# - OBS-050 is treated as canonical / cross-corpus qualitatively stable
+# - OBS-051 is treated as provisional / corpus-sensitive
+# - This script is intentionally explicit rather than clever
+
+if [[ -z "${PYTHON_BIN:-}" ]]; then
+  if [[ -x ".venv/bin/python" ]]; then
+    PYTHON_BIN=".venv/bin/python"
+  elif command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN="$(command -v python3)"
+  elif command -v python >/dev/null 2>&1; then
+    PYTHON_BIN="$(command -v python)"
+  else
+    echo "ERROR: no Python interpreter found." >&2
+    exit 1
+  fi
+fi
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+export PYTHONPATH="${PYTHONPATH:-src}"
+
+OUTPUTS_ROOT="${OUTPUTS_ROOT:-outputs}"
+SCALE_ROOT="${SCALE_ROOT:-outputs/scales/100000}"
+
+RUN_OBS028C_PREREQS="${RUN_OBS028C_PREREQS:-1}"
+RUN_OBS028C="${RUN_OBS028C:-1}"
+RUN_FAMILY_SUBSTRATE="${RUN_FAMILY_SUBSTRATE:-1}"
+RUN_SCENE_PREP="${RUN_SCENE_PREP:-1}"
+RUN_OBS050="${RUN_OBS050:-1}"
+RUN_OBS051="${RUN_OBS051:-1}"
+
+OBS051_MIN_INITIAL_DISTANCE="${OBS051_MIN_INITIAL_DISTANCE:-0.05}"
+
+log() {
+  echo
+  echo "==> $1"
+}
+
+run_py() {
+  echo "+ $PYTHON_BIN $*"
+  "$PYTHON_BIN" "$@"
+}
+
+require_file() {
+  local path="$1"
+  if [[ ! -f "$path" ]]; then
+    echo "ERROR: required file missing: $path" >&2
+    exit 1
+  fi
+}
+
+verify_nonempty() {
+  local path="$1"
+  require_file "$path"
+  if [[ ! -s "$path" ]]; then
+    echo "ERROR: file exists but is empty: $path" >&2
+    exit 1
+  fi
+}
+
+print_config() {
+  log "runner configuration"
+  echo "PROJECT_ROOT=$PROJECT_ROOT"
+  echo "PYTHON_BIN=$PYTHON_BIN"
+  echo "PYTHONPATH=$PYTHONPATH"
+  echo "OUTPUTS_ROOT=$OUTPUTS_ROOT"
+  echo "SCALE_ROOT=$SCALE_ROOT"
+  echo "RUN_OBS028C_PREREQS=$RUN_OBS028C_PREREQS"
+  echo "RUN_OBS028C=$RUN_OBS028C"
+  echo "RUN_FAMILY_SUBSTRATE=$RUN_FAMILY_SUBSTRATE"
+  echo "RUN_SCENE_PREP=$RUN_SCENE_PREP"
+  echo "RUN_OBS050=$RUN_OBS050"
+  echo "RUN_OBS051=$RUN_OBS051"
+  echo "OBS051_MIN_INITIAL_DISTANCE=$OBS051_MIN_INITIAL_DISTANCE"
+}
+
+run_obs028c_prereqs() {
+  log "OBS-028c prerequisite chain"
+  run_py experiments/studies/fim_response_complex_compatibility.py
+  run_py experiments/studies/fim_response_operator_decomposition.py
+  run_py experiments/studies/obs025_anisotropy_vs_relational_obstruction.py
+  run_py experiments/studies/obs025_two_field_seam_panel.py
+  run_py experiments/studies/obs026_family_two_field_occupancy.py
+  run_py experiments/studies/obs028_embedding_comparison.py
+  run_py experiments/studies/obs028b_diffusion_mode_analysis.py
+
+  verify_nonempty "$OUTPUTS_ROOT/fim_response_complex_compatibility/response_complex_compatibility_summary.txt"
+  verify_nonempty "$OUTPUTS_ROOT/fim_response_operator_decomposition/response_operator_decomposition_summary.txt"
+  verify_nonempty "$OUTPUTS_ROOT/obs025_anisotropy_vs_relational_obstruction/obs025_anisotropy_vs_relational_obstruction_summary.txt"
+  verify_nonempty "$OUTPUTS_ROOT/obs025_two_field_seam_panel/obs025_two_field_seam_panel_summary.txt"
+  verify_nonempty "$OUTPUTS_ROOT/obs026_family_two_field_occupancy/obs026_family_two_field_occupancy_summary.txt"
+  verify_nonempty "$OUTPUTS_ROOT/obs028_embedding_comparison/obs028_embedding_comparison_summary.txt"
+  verify_nonempty "$OUTPUTS_ROOT/obs028b_diffusion_mode_analysis/obs028b_diffusion_mode_analysis_summary.txt"
+}
+
+run_obs028c() {
+  log "OBS-028c canonical seam bundle"
+  run_py experiments/studies/obs028c_export_canonical_seam_bundle.py
+
+  verify_nonempty "$OUTPUTS_ROOT/obs028c_canonical_seam_bundle/seam_nodes.csv"
+  verify_nonempty "$OUTPUTS_ROOT/obs028c_canonical_seam_bundle/seam_family_summary.csv"
+  verify_nonempty "$OUTPUTS_ROOT/obs028c_canonical_seam_bundle/seam_embedding_summary.csv"
+  verify_nonempty "$OUTPUTS_ROOT/obs028c_canonical_seam_bundle/seam_metadata.txt"
+}
+
+run_family_substrate() {
+  log "scale-conditioned family substrate"
+  run_py experiments/toy/build_scale_family_substrate.py \
+    --scale-root "$SCALE_ROOT" \
+    --outputs-root "$OUTPUTS_ROOT"
+
+  verify_nonempty "$SCALE_ROOT/family_substrate/path_nodes_for_family.csv"
+  verify_nonempty "$SCALE_ROOT/family_substrate/path_node_diagnostics.csv"
+  verify_nonempty "$SCALE_ROOT/family_substrate/path_diagnostics.csv"
+  verify_nonempty "$SCALE_ROOT/family_substrate/path_family_assignments.csv"
+  verify_nonempty "$SCALE_ROOT/family_substrate/path_family_summary.csv"
+  verify_nonempty "$SCALE_ROOT/family_substrate/family_substrate_metadata.txt"
+}
+
+run_scene_prep() {
+  log "OBS-022 scene input preparation"
+  run_py experiments/toy/prepare_obs022_scene_inputs.py \
+    --scale-root "$SCALE_ROOT" \
+    --outputs-root "$OUTPUTS_ROOT" \
+    --run-hotspot-occupancy \
+    --run-canonical-seam-bundle \
+    --run-pass2-annotations
+
+  verify_nonempty "$OUTPUTS_ROOT/obs022_scene_bundle/scene_nodes.csv"
+  verify_nonempty "$OUTPUTS_ROOT/obs022_scene_bundle/scene_edges.csv"
+  verify_nonempty "$OUTPUTS_ROOT/obs022_scene_bundle/scene_seam.csv"
+  verify_nonempty "$OUTPUTS_ROOT/obs022_scene_bundle/scene_hubs.csv"
+  verify_nonempty "$OUTPUTS_ROOT/obs022_scene_bundle/scene_routes.csv"
+  verify_nonempty "$OUTPUTS_ROOT/obs022_scene_bundle/scene_glyphs.csv"
+  verify_nonempty "$OUTPUTS_ROOT/obs022_scene_bundle/scene_metadata.txt"
+
+  verify_nonempty "$OUTPUTS_ROOT/obs024_family_hotspot_occupancy/family_hotspot_occupancy_summary.csv"
+  verify_nonempty "$OUTPUTS_ROOT/obs024_family_hotspot_occupancy/obs024_family_hotspot_occupancy_summary.txt"
+  verify_nonempty "$OUTPUTS_ROOT/obs028c_canonical_seam_bundle/seam_metadata.txt"
+}
+
+run_obs050() {
+  log "OBS-050 structural coupling persistence"
+  run_py experiments/studies/obs050_structural_coupling_persistence.py
+
+  verify_nonempty "$OUTPUTS_ROOT/obs050_structural_coupling_persistence/structural_coupling_segments.csv"
+  verify_nonempty "$OUTPUTS_ROOT/obs050_structural_coupling_persistence/structural_coupling_seam_band_summary.csv"
+  verify_nonempty "$OUTPUTS_ROOT/obs050_structural_coupling_persistence/structural_coupling_coupled_vs_decoupled_summary.csv"
+  verify_nonempty "$OUTPUTS_ROOT/obs050_structural_coupling_persistence/obs050_structural_coupling_persistence_summary.txt"
+}
+
+run_obs051_pass() {
+  local seam_band="$1"
+  log "OBS-051 local divergence (${seam_band})"
+  run_py experiments/studies/obs051_local_divergence_in_coupled_windows.py \
+    --seam-band-filter "$seam_band" \
+    --min-initial-distance "$OBS051_MIN_INITIAL_DISTANCE"
+
+  verify_nonempty "$OUTPUTS_ROOT/obs051_local_divergence_in_coupled_windows/obs051_window_divergence.csv"
+  verify_nonempty "$OUTPUTS_ROOT/obs051_local_divergence_in_coupled_windows/obs051_outcome_summary.csv"
+  verify_nonempty "$OUTPUTS_ROOT/obs051_local_divergence_in_coupled_windows/obs051_family_summary.csv"
+  verify_nonempty "$OUTPUTS_ROOT/obs051_local_divergence_in_coupled_windows/obs051_local_divergence_summary.txt"
+
+  cp \
+    "$OUTPUTS_ROOT/obs051_local_divergence_in_coupled_windows/obs051_window_divergence.csv" \
+    "$OUTPUTS_ROOT/obs051_local_divergence_in_coupled_windows/obs051_window_divergence_${seam_band}.csv"
+
+  cp \
+    "$OUTPUTS_ROOT/obs051_local_divergence_in_coupled_windows/obs051_outcome_summary.csv" \
+    "$OUTPUTS_ROOT/obs051_local_divergence_in_coupled_windows/obs051_outcome_summary_${seam_band}.csv"
+
+  cp \
+    "$OUTPUTS_ROOT/obs051_local_divergence_in_coupled_windows/obs051_family_summary.csv" \
+    "$OUTPUTS_ROOT/obs051_local_divergence_in_coupled_windows/obs051_family_summary_${seam_band}.csv"
+
+  cp \
+    "$OUTPUTS_ROOT/obs051_local_divergence_in_coupled_windows/obs051_local_divergence_summary.txt" \
+    "$OUTPUTS_ROOT/obs051_local_divergence_in_coupled_windows/obs051_local_divergence_summary_${seam_band}.txt"
+}
+
+main() {
+  print_config
+
+  if [[ "$RUN_OBS028C_PREREQS" == "1" ]]; then
+    run_obs028c_prereqs
+  fi
+
+  if [[ "$RUN_OBS028C" == "1" ]]; then
+    run_obs028c
+  fi
+
+  if [[ "$RUN_FAMILY_SUBSTRATE" == "1" ]]; then
+    run_family_substrate
+  fi
+
+  if [[ "$RUN_SCENE_PREP" == "1" ]]; then
+    run_scene_prep
+  fi
+
+  if [[ "$RUN_OBS050" == "1" ]]; then
+    run_obs050
+  fi
+
+  if [[ "$RUN_OBS051" == "1" ]]; then
+    run_obs051_pass all
+    run_obs051_pass core
+    run_obs051_pass near
+  fi
+
+  log "observatory chain complete"
+  echo "OBS-028c outputs: $OUTPUTS_ROOT/obs028c_canonical_seam_bundle"
+  echo "Family substrate:   $SCALE_ROOT/family_substrate"
+  echo "OBS-022 bundle:     $OUTPUTS_ROOT/obs022_scene_bundle"
+  echo "OBS-024 outputs:    $OUTPUTS_ROOT/obs024_family_hotspot_occupancy"
+  echo "OBS-050 outputs:    $OUTPUTS_ROOT/obs050_structural_coupling_persistence"
+  echo "OBS-051 outputs:    $OUTPUTS_ROOT/obs051_local_divergence_in_coupled_windows"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

This PR adds OBS-052 as a first attractor-basin mapping pass downstream of the current observatory chain.

## What it adds

- `experiments/studies/obs052_attractor_basin_mapping.py`
- node-level recurrence / visitation aggregation
- recovery landing density aggregation
- first composite attractor score
- MDS attractor map and recovery landing map outputs
- top basin candidate export and summary text

## Scientific goal

OBS-052 asks whether recovery-like coupled windows preferentially terminate in recurrent, low-divergence, low-drift regions, and whether these regions separate into seam-core/near alignment sinks versus seam-far decoupled sinks.

## Current status

This is a **first-pass** instrument and should be treated as provisional.

The class-level signal is promising, but top-node rankings are not yet stable enough to treat as canonical. In particular, the current score can still mix:

- true recurrent sinks
- high-traffic terminal nodes
- nodes with incomplete dynamic fields

## Interpretation

OBS-052 should currently be understood as an exploratory downstream layer built on top of OBS-050 and provisional OBS-051 outputs.

It is useful for basin-style inspection, but not yet for strong canonical attractor claims.

## Notes

- OBS-050 remains the stable predictive base
- OBS-051 remains corpus-sensitive
- OBS-052 is therefore also provisional by dependency