### PR TITLE
feat: add corpus hygiene audit and linked-response annotation scaffolds

### DIFF
--- a/experiments/studies/audit_corpus_response_hygiene.py
+++ b/experiments/studies/audit_corpus_response_hygiene.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+
+"""
+Audit corpus response hygiene across PAM corpus variants.
+
+Purpose
+-------
+Detect simple hygiene phenomena in response texts, focusing on:
+- presence / absence of links
+- empty responses
+- very short responses
+- partial / truncated-like responses
+
+This is a lightweight first-pass audit instrument, intended to identify
+possible corpus confounds before deeper observatory interpretation.
+
+Expected input
+--------------
+A directory containing corpus JSON files such as:
+
+    observatory/corpora/
+      C.json
+      Cp.json
+      Cp2.json
+      Cp3.json
+      Cp4.json
+
+Each file is expected to contain either:
+- a JSON list of strings
+- a JSON list of dicts with a text-bearing field
+- a dict with a top-level list under common keys like "texts", "responses", or "items"
+
+Outputs
+-------
+<outdir>/
+  corpus_response_hygiene_rows.csv
+  corpus_response_hygiene_summary.csv
+  corpus_response_hygiene_summary.txt
+
+Heuristics
+----------
+Link detection:
+- URL-like regex match on http://, https://, or www.
+
+Empty:
+- stripped text length == 0
+
+Very short:
+- character length below threshold OR token count below threshold
+
+Partial:
+- ends without terminal punctuation
+- or ends in trailing connector / punctuation suggesting continuation
+- or has unmatched opening brackets / quotes
+
+Truncated-like:
+- partial plus stronger abrupt-cut patterns
+- ends with unfinished short token / connector / colon / dash
+"""
+
+import argparse
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Any
+
+import pandas as pd
+
+
+URL_RE = re.compile(
+    r"""(?ix)
+    \b(
+        https?://[^\s<>()\[\]{}"']+
+        |
+        www\.[^\s<>()\[\]{}"']+
+    )
+    """
+)
+
+TOKEN_RE = re.compile(r"\b\w+\b", flags=re.UNICODE)
+TERMINAL_RE = re.compile(r'[.!?)"\]»”]\s*$')
+TRAILING_CONTINUATION_RE = re.compile(
+    r"""(?ix)
+    (
+        [,;:]\s*$
+        |
+        [\-–—]\s*$
+        |
+        \b(and|or|but|because|that|which|who|when|where|while|with|without|if|then|than|to|of|for|in|on|at|from|by|as)\s*$
+    )
+    """
+)
+
+
+@dataclass(frozen=True)
+class Config:
+    corpora_root: str = "observatory/corpora"
+    outdir: str = "outputs/corpus_response_hygiene_audit"
+    very_short_char_threshold: int = 40
+    very_short_token_threshold: int = 8
+    show_examples_per_corpus: int = 5
+
+
+def safe_read_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def iter_candidate_texts(obj: Any) -> Iterable[tuple[int, str]]:
+    """
+    Yield (index, text) from a few common corpus JSON shapes.
+    """
+    if isinstance(obj, list):
+        for i, item in enumerate(obj):
+            text = extract_text(item)
+            yield i, text
+        return
+
+    if isinstance(obj, dict):
+        for key in ["texts", "responses", "items", "data", "records"]:
+            if key in obj and isinstance(obj[key], list):
+                for i, item in enumerate(obj[key]):
+                    text = extract_text(item)
+                    yield i, text
+                return
+
+    raise ValueError("Unsupported corpus JSON structure")
+
+
+def extract_text(item: Any) -> str:
+    if item is None:
+        return ""
+    if isinstance(item, str):
+        return item
+    if isinstance(item, dict):
+        for key in [
+            "text",
+            "response",
+            "content",
+            "output",
+            "assistant_response",
+            "message",
+            "body",
+        ]:
+            if key in item:
+                value = item[key]
+                return "" if value is None else str(value)
+    return str(item)
+
+
+def count_links(text: str) -> int:
+    return len(URL_RE.findall(text))
+
+
+def token_count(text: str) -> int:
+    return len(TOKEN_RE.findall(text))
+
+
+def unmatched_brackets_or_quotes(text: str) -> bool:
+    pairs = [
+        ("(", ")"),
+        ("[", "]"),
+        ("{", "}"),
+    ]
+    for left, right in pairs:
+        if text.count(left) > text.count(right):
+            return True
+
+    for quote in ['"', "'", "“", "”", "‘", "’"]:
+        # crude but useful first-pass heuristic
+        if text.count(quote) % 2 == 1:
+            return True
+
+    return False
+
+
+def classify_partial(text: str) -> tuple[bool, bool]:
+    stripped = text.strip()
+    if not stripped:
+        return False, False
+
+    ends_cleanly = bool(TERMINAL_RE.search(stripped))
+    continuation_tail = bool(TRAILING_CONTINUATION_RE.search(stripped))
+    unmatched = unmatched_brackets_or_quotes(stripped)
+
+    is_partial = (not ends_cleanly) or continuation_tail or unmatched
+
+    # stronger abrupt-cut signal
+    last_token = ""
+    toks = TOKEN_RE.findall(stripped)
+    if toks:
+        last_token = toks[-1]
+
+    truncated_like = False
+    if continuation_tail or unmatched:
+        truncated_like = True
+    elif not ends_cleanly:
+        if len(last_token) <= 3:
+            truncated_like = True
+        elif re.search(r"[a-zA-Z0-9]$", stripped):
+            truncated_like = True
+
+    return is_partial, truncated_like
+
+
+def audit_text(
+    text: str,
+    *,
+    very_short_char_threshold: int,
+    very_short_token_threshold: int,
+) -> dict[str, object]:
+    raw = "" if text is None else str(text)
+    stripped = raw.strip()
+
+    n_chars = len(stripped)
+    n_tokens = token_count(stripped)
+    n_links = count_links(stripped)
+
+    is_empty = n_chars == 0
+    is_very_short = (n_chars < very_short_char_threshold) or (n_tokens < very_short_token_threshold)
+
+    is_partial, is_truncated_like = classify_partial(stripped)
+
+    return {
+        "text": raw,
+        "n_chars": n_chars,
+        "n_tokens": n_tokens,
+        "has_link": int(n_links > 0),
+        "n_links": n_links,
+        "is_empty": int(is_empty),
+        "is_very_short": int((not is_empty) and is_very_short),
+        "is_partial": int((not is_empty) and is_partial),
+        "is_truncated_like": int((not is_empty) and is_truncated_like),
+    }
+
+
+def load_corpus_rows(path: Path, cfg: Config) -> pd.DataFrame:
+    obj = safe_read_json(path)
+    rows: list[dict[str, object]] = []
+
+    for idx, text in iter_candidate_texts(obj):
+        audit = audit_text(
+            text,
+            very_short_char_threshold=cfg.very_short_char_threshold,
+            very_short_token_threshold=cfg.very_short_token_threshold,
+        )
+        rows.append(
+            {
+                "corpus": path.stem,
+                "source_file": str(path),
+                "text_index": idx,
+                **audit,
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+def build_summary(rows_df: pd.DataFrame) -> pd.DataFrame:
+    if rows_df.empty:
+        return pd.DataFrame()
+
+    out = (
+        rows_df.groupby("corpus", dropna=False)
+        .agg(
+            n_texts=("text_index", "size"),
+            mean_chars=("n_chars", "mean"),
+            mean_tokens=("n_tokens", "mean"),
+            link_share=("has_link", "mean"),
+            mean_links=("n_links", "mean"),
+            empty_share=("is_empty", "mean"),
+            very_short_share=("is_very_short", "mean"),
+            partial_share=("is_partial", "mean"),
+            truncated_like_share=("is_truncated_like", "mean"),
+        )
+        .reset_index()
+    )
+
+    for col in [
+        "mean_chars",
+        "mean_tokens",
+        "link_share",
+        "mean_links",
+        "empty_share",
+        "very_short_share",
+        "partial_share",
+        "truncated_like_share",
+    ]:
+        out[col] = pd.to_numeric(out[col], errors="coerce")
+
+    return out.sort_values("corpus").reset_index(drop=True)
+
+
+def summarize_text(rows_df: pd.DataFrame, summary_df: pd.DataFrame, cfg: Config) -> str:
+    lines: list[str] = []
+    lines.append("=== Corpus Response Hygiene Audit Summary ===")
+    lines.append("")
+    lines.append(f"very_short_char_threshold = {cfg.very_short_char_threshold}")
+    lines.append(f"very_short_token_threshold = {cfg.very_short_token_threshold}")
+    lines.append(f"n_rows = {len(rows_df)}")
+    lines.append("")
+
+    if summary_df.empty:
+        lines.append("No corpus rows found.")
+        return "\n".join(lines)
+
+    for _, row in summary_df.iterrows():
+        lines.append(
+            f"{row['corpus']}: "
+            f"n_texts={int(row['n_texts'])}, "
+            f"mean_chars={row['mean_chars']:.2f}, "
+            f"mean_tokens={row['mean_tokens']:.2f}, "
+            f"link_share={row['link_share']:.4f}, "
+            f"mean_links={row['mean_links']:.4f}, "
+            f"empty_share={row['empty_share']:.4f}, "
+            f"very_short_share={row['very_short_share']:.4f}, "
+            f"partial_share={row['partial_share']:.4f}, "
+            f"truncated_like_share={row['truncated_like_share']:.4f}"
+        )
+
+        sub = rows_df[rows_df["corpus"] == row["corpus"]].copy()
+        examples = sub[
+            (sub["has_link"] == 1)
+            | (sub["is_empty"] == 1)
+            | (sub["is_very_short"] == 1)
+            | (sub["is_partial"] == 1)
+            | (sub["is_truncated_like"] == 1)
+        ].head(cfg.show_examples_per_corpus)
+
+        if not examples.empty:
+            lines.append("  examples:")
+            for _, ex in examples.iterrows():
+                snippet = str(ex["text"]).strip().replace("\n", " ")
+                if len(snippet) > 120:
+                    snippet = snippet[:117] + "..."
+                flags = []
+                for col in ["has_link", "is_empty", "is_very_short", "is_partial", "is_truncated_like"]:
+                    if int(ex[col]) == 1:
+                        flags.append(col)
+                lines.append(
+                    f"    - idx={int(ex['text_index'])} | flags={','.join(flags) if flags else 'none'} | text={snippet!r}"
+                )
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Audit link / empty / partial response hygiene across corpora.")
+    parser.add_argument("--corpora-root", default="observatory/corpora")
+    parser.add_argument("--outdir", default="outputs/corpus_response_hygiene_audit")
+    parser.add_argument("--very-short-char-threshold", type=int, default=40)
+    parser.add_argument("--very-short-token-threshold", type=int, default=8)
+    parser.add_argument("--show-examples-per-corpus", type=int, default=5)
+    args = parser.parse_args()
+
+    cfg = Config(
+        corpora_root=args.corpora_root,
+        outdir=args.outdir,
+        very_short_char_threshold=args.very_short_char_threshold,
+        very_short_token_threshold=args.very_short_token_threshold,
+        show_examples_per_corpus=args.show_examples_per_corpus,
+    )
+
+    corpora_root = Path(cfg.corpora_root)
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    if not corpora_root.exists():
+        raise FileNotFoundError(corpora_root)
+
+    json_files = [
+        p for p in sorted(corpora_root.glob("*.json"))
+        if p.stem in {"C", "Cp", "Cp2", "Cp3", "Cp4"}
+    ]
+    if not json_files:
+        raise FileNotFoundError(f"No corpus variant .json files found in {corpora_root}")
+
+    row_frames: list[pd.DataFrame] = []
+    for path in json_files:
+        df = load_corpus_rows(path, cfg)
+        row_frames.append(df)
+
+    rows_df = pd.concat(row_frames, ignore_index=True) if row_frames else pd.DataFrame()
+    summary_df = build_summary(rows_df)
+
+    rows_csv = outdir / "corpus_response_hygiene_rows.csv"
+    summary_csv = outdir / "corpus_response_hygiene_summary.csv"
+    summary_txt = outdir / "corpus_response_hygiene_summary.txt"
+
+    rows_df.to_csv(rows_csv, index=False)
+    summary_df.to_csv(summary_csv, index=False)
+    summary_txt.write_text(summarize_text(rows_df, summary_df, cfg), encoding="utf-8")
+
+    print(rows_csv)
+    print(summary_csv)
+    print(summary_txt)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/studies/corpus_link_annotation_scaffold.py
+++ b/experiments/studies/corpus_link_annotation_scaffold.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+
+"""
+Build a first-pass annotation scaffold for link / boundary-event analysis
+across PAM corpus variants.
+
+Purpose
+-------
+Create a response-level CSV suitable for manual annotation of:
+- link presence
+- geometric / topical adjacency
+- pressure-valve judgments
+- known boundary events
+
+This script does NOT decide the scientific interpretation.
+It only prepares a clean annotation table with auto-filled structural fields.
+
+Expected input
+--------------
+A directory containing corpus JSON files such as:
+
+    observatory/corpora/
+      C.json
+      Cp.json
+      Cp2.json
+      Cp3.json
+      Cp4.json
+
+Each corpus file is expected to be a JSON list of strings.
+
+Outputs
+-------
+<outdir>/
+  corpus_link_annotation_scaffold.csv
+  corpus_link_annotation_scaffold_summary.txt
+
+Notes
+-----
+- boundary_event defaults to "none"
+- manual annotation columns are left blank where appropriate
+- known boundary events can be injected via CLI flags if desired
+"""
+
+import argparse
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+
+URL_RE = re.compile(
+    r"""(?ix)
+    \b(
+        https?://[^\s<>()\[\]{}"']+
+        |
+        www\.[^\s<>()\[\]{}"']+
+    )
+    """
+)
+
+TOKEN_RE = re.compile(r"\b\w+\b", flags=re.UNICODE)
+
+DEFAULT_CORPORA = ("C", "Cp", "Cp2", "Cp3", "Cp4")
+
+
+@dataclass(frozen=True)
+class Config:
+    corpora_root: str = "observatory/corpora"
+    outdir: str = "outputs/corpus_link_annotation"
+    annotator: str = ""
+    corpora: tuple[str, ...] = DEFAULT_CORPORA
+    cp3_empty_index: int | None = 49
+    cp4_failure_start_index: int | None = 38
+
+
+def safe_read_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def extract_texts(obj: Any) -> list[str]:
+    if isinstance(obj, list) and all(isinstance(x, str) or x is None for x in obj):
+        return ["" if x is None else str(x) for x in obj]
+    raise ValueError(f"Unsupported corpus JSON structure for annotation scaffold: {type(obj)}")
+
+
+def token_count(text: str) -> int:
+    return len(TOKEN_RE.findall(text))
+
+
+def extract_links(text: str) -> list[str]:
+    matches = URL_RE.findall(text or "")
+    return [m.strip() for m in matches if str(m).strip()]
+
+
+def extract_domains(links: list[str]) -> list[str]:
+    domains: list[str] = []
+    for link in links:
+        normalized = link
+        if normalized.startswith("www."):
+            normalized = "http://" + normalized
+        m = re.match(r"(?i)https?://([^/\s]+)", normalized)
+        if not m:
+            continue
+        domain = m.group(1).lower().strip()
+        if domain.startswith("www."):
+            domain = domain[4:]
+        domains.append(domain)
+    # stable unique order
+    seen: set[str] = set()
+    out: list[str] = []
+    for d in domains:
+        if d not in seen:
+            seen.add(d)
+            out.append(d)
+    return out
+
+
+def classify_length_band(n_tokens: int) -> str:
+    if n_tokens < 120:
+        return "short"
+    if n_tokens < 300:
+        return "medium"
+    return "long"
+
+
+def boundary_event_default(corpus: str, idx: int, text: str, cfg: Config) -> str:
+    """
+    Provenance-aware defaults based on known session failures discussed by user.
+
+    Current known cases:
+    - Cp3 had a bricked/frozen chat after 49 responses; empty final response residue
+    - Cp4 had a bricked/frozen/unusable chat after 38 responses; later responses may be partial/empty residues
+
+    These are defaults only and can be revised manually.
+    """
+    stripped = (text or "").strip()
+
+    if corpus == "Cp3" and cfg.cp3_empty_index is not None and idx == cfg.cp3_empty_index and stripped == "":
+        return "empty_session_failure"
+
+    if corpus == "Cp4" and cfg.cp4_failure_start_index is not None and idx >= cfg.cp4_failure_start_index:
+        if stripped == "":
+            return "empty_session_failure"
+        return "partial_session_failure"
+
+    return "none"
+
+
+def build_rows(corpus_name: str, texts: list[str], cfg: Config) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+
+    for idx, raw_text in enumerate(texts):
+        text = "" if raw_text is None else str(raw_text)
+        stripped = text.strip()
+
+        links = extract_links(text)
+        domains = extract_domains(links)
+
+        n_chars = len(stripped)
+        n_tokens = token_count(stripped)
+        has_link = int(len(links) > 0)
+        n_links = len(links)
+        response_id = f"{corpus_name}:{idx}"
+
+        row = {
+            # identity
+            "corpus": corpus_name,
+            "text_index": idx,
+            "response_id": response_id,
+
+            # raw structure
+            "response_text": text,
+            "n_chars": n_chars,
+            "n_tokens": n_tokens,
+            "has_link": has_link,
+            "n_links": n_links,
+            "domains": ";".join(domains),
+            "turn_depth_proxy": idx + 1,
+            "length_band": classify_length_band(n_tokens),
+
+            # provenance / boundary
+            "boundary_event": boundary_event_default(corpus_name, idx, text, cfg),
+
+            # manual annotation columns
+            "link_adj_label": "",
+            "link_adj_strength": "",
+            "anchor_type": "",
+            "thumb_relevant": "",
+            "pressure_valve_judgment": "",
+            "annotator": cfg.annotator,
+            "notes": "",
+        }
+        rows.append(row)
+
+    return rows
+
+
+def summarize(df: pd.DataFrame) -> str:
+    lines: list[str] = []
+    lines.append("=== Corpus Link Annotation Scaffold Summary ===")
+    lines.append("")
+    lines.append(f"n_rows = {len(df)}")
+    lines.append("")
+
+    if df.empty:
+        lines.append("No rows generated.")
+        return "\n".join(lines)
+
+    for corpus, sub in df.groupby("corpus", dropna=False):
+        n = len(sub)
+        lines.append(
+            f"{corpus}: "
+            f"n_texts={n}, "
+            f"link_share={sub['has_link'].mean():.4f}, "
+            f"mean_links={sub['n_links'].mean():.4f}, "
+            f"boundary_none={(sub['boundary_event'] == 'none').mean():.4f}, "
+            f"boundary_empty={(sub['boundary_event'] == 'empty_session_failure').mean():.4f}, "
+            f"boundary_partial={(sub['boundary_event'] == 'partial_session_failure').mean():.4f}"
+        )
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build annotation scaffold for corpus link / boundary-event study.")
+    parser.add_argument("--corpora-root", default="observatory/corpora")
+    parser.add_argument("--outdir", default="outputs/corpus_link_annotation")
+    parser.add_argument("--annotator", default="")
+    parser.add_argument("--cp3-empty-index", type=int, default=49)
+    parser.add_argument("--cp4-failure-start-index", type=int, default=38)
+    parser.add_argument(
+        "--corpora",
+        nargs="*",
+        default=list(DEFAULT_CORPORA),
+        help="Corpus stems to include, e.g. C Cp Cp2 Cp3 Cp4",
+    )
+    args = parser.parse_args()
+
+    cfg = Config(
+        corpora_root=args.corpora_root,
+        outdir=args.outdir,
+        annotator=args.annotator,
+        corpora=tuple(args.corpora),
+        cp3_empty_index=args.cp3_empty_index,
+        cp4_failure_start_index=args.cp4_failure_start_index,
+    )
+
+    corpora_root = Path(cfg.corpora_root)
+    outdir = Path(cfg.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    if not corpora_root.exists():
+        raise FileNotFoundError(corpora_root)
+
+    rows: list[dict[str, object]] = []
+    for corpus_name in cfg.corpora:
+        path = corpora_root / f"{corpus_name}.json"
+        if not path.exists():
+            raise FileNotFoundError(path)
+
+        obj = safe_read_json(path)
+        texts = extract_texts(obj)
+        rows.extend(build_rows(corpus_name, texts, cfg))
+
+    df = pd.DataFrame(rows)
+
+    desired_cols = [
+        "corpus",
+        "text_index",
+        "response_id",
+        "response_text",
+        "n_chars",
+        "n_tokens",
+        "has_link",
+        "n_links",
+        "domains",
+        "turn_depth_proxy",
+        "length_band",
+        "boundary_event",
+        "link_adj_label",
+        "link_adj_strength",
+        "anchor_type",
+        "thumb_relevant",
+        "pressure_valve_judgment",
+        "annotator",
+        "notes",
+    ]
+    df = df[desired_cols].copy()
+
+    out_csv = outdir / "corpus_link_annotation_scaffold.csv"
+    out_txt = outdir / "corpus_link_annotation_scaffold_summary.txt"
+
+    df.to_csv(out_csv, index=False)
+    out_txt.write_text(summarize(df), encoding="utf-8")
+
+    print(out_csv)
+    print(out_txt)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/studies/corpus_link_annotation_scaffold_filter.py
+++ b/experiments/studies/corpus_link_annotation_scaffold_filter.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+"""
+Filter the corpus link annotation scaffold down to link-bearing rows only.
+
+Purpose
+-------
+Create a smaller CSV for manual annotation of the link phenomenon
+(geometric adjacency / pressure-valve hypothesis) by keeping only rows
+where `has_link == 1`.
+
+Expected input
+--------------
+outputs/corpus_link_annotation/corpus_link_annotation_scaffold.csv
+
+Outputs
+-------
+<outdir>/
+  corpus_link_annotation_links_only.csv
+  corpus_link_annotation_links_only_summary.txt
+"""
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+
+def summarize(df: pd.DataFrame) -> str:
+    lines: list[str] = []
+    lines.append("=== Corpus Link Annotation (Links Only) Summary ===")
+    lines.append("")
+    lines.append(f"n_rows = {len(df)}")
+    lines.append("")
+
+    if df.empty:
+        lines.append("No link-bearing rows found.")
+        return "\n".join(lines) + "\n"
+
+    for corpus, sub in df.groupby("corpus", dropna=False):
+        lines.append(
+            f"{corpus}: "
+            f"n_rows={len(sub)}, "
+            f"mean_links={pd.to_numeric(sub['n_links'], errors='coerce').mean():.4f}, "
+            f"boundary_none={(sub['boundary_event'] == 'none').mean():.4f}, "
+            f"boundary_empty={(sub['boundary_event'] == 'empty_session_failure').mean():.4f}, "
+            f"boundary_partial={(sub['boundary_event'] == 'partial_session_failure').mean():.4f}"
+        )
+
+    lines.append("")
+    lines.append("Suggested annotation columns:")
+    lines.append("- link_adj_label")
+    lines.append("- link_adj_strength")
+    lines.append("- anchor_type")
+    lines.append("- thumb_relevant")
+    lines.append("- pressure_valve_judgment")
+    lines.append("- notes")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Filter annotation scaffold to link-bearing rows only.")
+    parser.add_argument(
+        "--input-csv",
+        default="outputs/corpus_link_annotation/corpus_link_annotation_scaffold.csv",
+    )
+    parser.add_argument(
+        "--outdir",
+        default="outputs/corpus_link_annotation",
+    )
+    parser.add_argument(
+        "--sort-by",
+        nargs="*",
+        default=["corpus", "text_index"],
+        help="Columns to sort by before writing output.",
+    )
+    args = parser.parse_args()
+
+    input_csv = Path(args.input_csv)
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    if not input_csv.exists():
+        raise FileNotFoundError(input_csv)
+
+    df = pd.read_csv(input_csv)
+
+    if "has_link" not in df.columns:
+        raise ValueError(f"`has_link` column not found in {input_csv}")
+
+    links_only = df[pd.to_numeric(df["has_link"], errors="coerce").fillna(0).astype(int) == 1].copy()
+
+    sort_cols = [c for c in args.sort_by if c in links_only.columns]
+    if sort_cols:
+        links_only = links_only.sort_values(sort_cols).reset_index(drop=True)
+
+    out_csv = outdir / "corpus_link_annotation_links_only.csv"
+    out_txt = outdir / "corpus_link_annotation_links_only_summary.txt"
+
+    links_only.to_csv(out_csv, index=False)
+    out_txt.write_text(summarize(links_only), encoding="utf-8")
+
+    print(out_csv)
+    print(out_txt)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR adds the first-pass study scripts used to inspect response hygiene and to scaffold the linked-response annotation workflow.

## What’s included

### New studies
- `experiments/studies/audit_corpus_response_hygiene.py`
- `experiments/studies/corpus_link_annotation_scaffold.py`
- `experiments/studies/corpus_link_annotation_scaffold_filter.py`

## Why

This stage of the work needed two preparatory layers:

1. a hygiene pass over the corpora
   - empty responses
   - partial/truncated responses
   - direct/external link presence

2. a scaffold for isolating and filtering the link-bearing subset
   - so linked responses could be inspected and annotated as their own observatory surface

These scripts support the later linked-response taxonomy work, but this PR keeps the pipeline step separate from the repository-facing interpretation/docs step.

## Notes

- This is still a preparatory / instrumentation PR, not the final family-taxonomy interpretation.
- Some responses previously suspected to be hygiene issues were later understood as GUI/session artifacts rather than corpus-quality failures per se.
- This PR is mainly about getting the inspection and filtering machinery into the repo.

## Follow-up

A separate PR will add the repository-facing documentation for the linked-response family taxonomy and log the associated observatory-stage notes.