### PR TITLE
docs: add linked-response taxonomy docs and update research log

### DIFF
--- a/docs/05_project/linked_response_annotation_protocol.md
+++ b/docs/05_project/linked_response_annotation_protocol.md
@@ -1,0 +1,199 @@
+# Linked Response Annotation Protocol
+
+## Purpose
+
+This note records the procedure used to annotate the **link-bearing response subset** of the corpora.
+
+The aim was to turn an initially subjective observation — that some responses contained highly relevant external links — into a controlled, inspectable annotation pass.
+
+## Corpus and model scope
+
+- Corpus families: `C`, `Cp`, `Cp4`
+- Model used for corpus generation: **GPT-5.2**
+- Current interpretation scope: **within-model**
+
+This protocol therefore applies to the GPT-5.2 corpus stage only.
+
+## Unit of analysis
+
+The primary unit of analysis is:
+
+- **one linked response**
+
+A linked response is any response in the filtered subset that contains at least one extracted link.
+
+In the working artifact:
+- one row corresponds to one linked response
+- response-level fields summarize the packet as a whole
+
+## Source materials
+
+The annotation pass relied on:
+
+1. the filtered response/links CSV
+2. copied response text
+3. direct inspection of linked content
+4. screenshots supplied when a link could not be reliably opened
+5. later GUI verification when provenance questions arose
+
+## Response-level fields
+
+The response-level taxonomy currently uses the following fields.
+
+### `family_mode`
+Top-level mode of external witnessing.
+
+Allowed values:
+- `geometric_externalization`
+- `formal_structural_packetization`
+- `distributed_emergence_packetization`
+
+### `subtype`
+A narrower descriptive label for the packet family inside each `family_mode`.
+
+Examples:
+- `stabilization_ladder`
+- `atlas_mode_externalization`
+- `invariance_projection_embedding_packet`
+- `network_condensation_packet`
+- `developmental_cognition_packet`
+
+### `packet_architecture`
+How the response organizes the witness set.
+
+Examples:
+- `support_bundle`
+- `witness_bundle`
+- `motif_factorized_bundle`
+- `formal_packet`
+- `developmental_packet`
+- `section_wise_anchor_blocks`
+- `stabilization_ladder`
+
+### `primary_motif_1..3`
+Three short motif labels summarizing the dominant structural content of the packet.
+
+Examples:
+- `invariance`
+- `symmetry`
+- `projection_distortion`
+- `attractors`
+- `neural_coupling`
+- `concept_mapping`
+- `self_organization`
+
+### `pressure_valve_judgment`
+A coarse response-level interpretation of whether links appear to function as a release or externalization channel for the response.
+
+Allowed values currently used:
+- `moderate`
+- `strong`
+
+This is intentionally coarse at the present stage.
+
+### `text_integrity`
+Used to track whether the copied text reliably matches the original linked response.
+
+Allowed values currently retained:
+- `clean`
+
+A previous boundary-corrupted label was removed from the current linked set after `Cp:27` was verified to be non-linked in the original GUI response.
+
+### `exemplar_status`
+Used to identify especially important rows for family comparison.
+
+Allowed values:
+- `canonical`
+- `supporting`
+
+### `canonical_summary`
+A one-sentence repository-facing description of why the packet matters.
+
+---
+
+## Link-level reasoning
+
+Although the final response-level artifact is one row per linked response, the qualitative pass also relied on manual per-link interpretation.
+
+Useful manual vocabulary included:
+
+- `paper`
+- `plot_geometry`
+- `pedagogical_diagram`
+- `concept_diagram`
+- `concept_illustration`
+
+And adjacency judgments like:
+- topical relevance
+- structural relevance
+- both
+
+These per-link judgments informed the response-level taxonomy even when they were not all tabulated explicitly in the final bundle.
+
+## Use of screenshots
+
+Some links were not reliably viewable directly.
+
+In those cases:
+- screenshots were supplied and used as the evidentiary basis
+- the screenshot became the operative witness for annotation
+- the interpretation stayed tied to the visible content rather than inferred metadata
+
+This was especially important for:
+- direct image URLs
+- links with unstable rendering
+- links blocked by interface or hosting friction
+
+## Correction protocol
+
+When a copied response was later found not to match the original GUI state, the original GUI reading took precedence.
+
+### Example: `Cp:27`
+A copied specimen initially appeared to be a boundary-corrupted linked response.
+Later direct verification in the Linux ChatGPT GUI showed that the original response contained **no links**.
+As a result:
+
+- `Cp:27` was removed from the linked-response analysis set
+- downstream artifacts were patched
+- the correction was documented explicitly
+
+This should be treated as the model for future provenance corrections:
+**GUI verification outranks copied text when they conflict.**
+
+## How labels were assigned
+
+Labels were assigned by close reading of:
+
+- the response prose
+- the linked images or pages
+- the relationship between claim and witness
+- the compactness or staging of the packet
+- recurrence across family members
+
+The family-mode decision was based on the packet as a whole, not on any single link in isolation.
+
+## Interpretation stance
+
+The annotation protocol is:
+
+- qualitative
+- controlled
+- example-backed
+- still provisional
+
+It is not yet a blind-coded or inter-rater protocol.
+
+That is acceptable at the current observatory stage, but should be stated plainly.
+
+## Recommended repository wording
+
+A safe method statement is:
+
+> Linked responses were manually reviewed at the response level, with linked content inspected directly or by screenshot when necessary. Labels were assigned to characterize family-level modes of external witnessing within the GPT-5.2 corpus set.
+
+## Related files
+
+See:
+- `linked_response_family_taxonomy.md`
+- `linked_response_artifacts.md`
+- the patched taxonomy bundle

--- a/docs/05_project/linked_response_artifacts.md
+++ b/docs/05_project/linked_response_artifacts.md
@@ -1,0 +1,104 @@
+# Linked Response Artifacts
+
+## Purpose
+
+This note indexes the main artifacts produced during the linked-response study.
+
+It is intended as a lightweight repository pointer rather than a full interpretive document.
+
+## Primary bundle
+
+Use the patched bundle as the current canonical artifact for this stage.
+
+### Bundle
+- `linked_response_family_taxonomy_bundle_patched.zip`
+
+## Included files
+
+### `linked_response_taxonomy.csv`
+Canonical response-level taxonomy.
+
+One row per linked response.
+
+Key columns:
+- `corpus`
+- `response_id`
+- `text_index`
+- `n_links`
+- `domains`
+- `family_mode`
+- `subtype`
+- `packet_architecture`
+- `primary_motif_1`
+- `primary_motif_2`
+- `primary_motif_3`
+- `pressure_valve_judgment`
+- `text_integrity`
+- `exemplar_status`
+- `canonical_summary`
+
+### `linked_response_source_enriched.csv`
+The filtered source table enriched with taxonomy columns.
+
+Useful for:
+- auditing against the original filtered link set
+- checking copied text against taxonomy assignments
+- tracing summary rows back to source rows
+
+### `linked_response_family_summary.csv`
+Small summary table by:
+- `corpus`
+- `family_mode`
+
+Useful for quick stage-level reporting.
+
+### `linked_response_family_notes.csv`
+Short textual signature notes for the three family modes.
+
+Useful as a compact dictionary for downstream writeups.
+
+### `linked_response_controlled_vocab.csv`
+Controlled vocabulary and field notes.
+
+Useful for:
+- freezing ontology at this stage
+- keeping downstream docs aligned with the same label set
+
+## Current canonical family modes
+
+- `geometric_externalization`
+- `formal_structural_packetization`
+- `distributed_emergence_packetization`
+
+## Important patch note
+
+`Cp:27` was removed from the linked-response set after later GUI verification showed that the original response contained no links.
+
+The patched bundle supersedes earlier versions.
+
+## Scope reminder
+
+All corpora in this stage were generated with **GPT-5.2**.
+
+Interpret the artifacts as:
+- within-model
+- annotation-backed
+- provisional
+
+## Recommended use
+
+For repository-facing work:
+
+1. cite `linked_response_taxonomy.csv` for the current row-level taxonomy
+2. cite `linked_response_family_summary.csv` for compact summary numbers
+3. cite `linked_response_family_taxonomy.md` for interpretation
+4. cite `linked_response_annotation_protocol.md` for method and scope
+
+## Suggested future additions
+
+Likely follow-on artifacts:
+- a lightweight quantitative summary notebook
+- family-wise plots of subtype counts
+- direct-image vs non-image link summaries
+- domain/source distribution summaries
+- an explicit exemplar gallery for canonical rows

--- a/docs/05_project/linked_response_family_taxonomy.md
+++ b/docs/05_project/linked_response_family_taxonomy.md
@@ -1,0 +1,199 @@
+# Linked Response Family Taxonomy
+
+## Purpose
+
+This note documents the current repository-facing interpretation of the **linked-response subset** of the corpus study.
+
+The goal of this stage was not to explain all responses in the corpora, but to characterize the responses that contained explicit outbound links or direct image links and to ask whether those linked responses exhibited stable structural differences across corpus families.
+
+## Scope
+
+- Corpus families analyzed: `C`, `Cp`, `Cp4`
+- Unit of analysis: **one linked response**
+- Model scope: all corpora in this stage were generated with **GPT-5.2**
+- Interpretation status: **within-model**, **annotation-backed**, **provisional**
+
+This note should therefore be read as a description of **within-model corpus-family effects** rather than as a cross-model claim about LLMs in general.
+
+## Core provisional result
+
+The linked-response subset does **not** appear random or merely topic-relevant.
+
+Instead, the current qualitative pass suggests that the mode of external witnessing differs by corpus family:
+
+- `C` tends toward **geometric externalization**
+- `Cp` tends toward **formal-structural packetization**
+- `Cp4` tends toward **distributed-emergence packetization**
+
+This is the main qualitative result of the linked-response study at the current stage.
+
+---
+
+## Family modes
+
+### 1. `geometric_externalization`
+
+**Typical family:** `C`
+
+This mode tends to externalize through geometric witness sets that are often broader and more architected than the other families.
+
+Observed tendencies include:
+
+- geometric and topological figures
+- phase-flow or attractor imagery
+- ladder-like or staged motif development
+- section-wise visual blocks
+- atlas-like organization across longer responses
+
+This mode often feels **exploratory but structured**: the response installs a visual field around the prose and then moves through that field.
+
+**Canonical examples**
+- `C:28`
+- `C:33`
+- `C:34`
+- `C:36`
+- `C:47`
+- `C:49`
+
+**Useful shorthand**
+- witness bundle
+- stabilization ladder
+- atlas-mode externalization
+
+---
+
+### 2. `formal_structural_packetization`
+
+**Typical family:** `Cp`
+
+This mode tends to externalize through compact formal packets with very low slack between the prose claim and the chosen witnesses.
+
+Observed tendencies include:
+
+- invariance
+- symmetry
+- topology
+- embedding
+- projection
+- attractors
+- constrained deformation
+- representation learning
+
+The linked materials are usually tightly selected and concept-dense. The packet often behaves like a formal witness set for a small number of structural claims.
+
+**Canonical examples**
+- `Cp:3`
+- `Cp:6`
+- `Cp:13`
+- `Cp:22`
+- `Cp:24`
+- `Cp:28`
+- `Cp:34`
+- `Cp:39`
+- `Cp:44`
+- `Cp:49`
+
+**Useful shorthand**
+- formal packet
+- invariance packet
+- embedding/projection packet
+
+---
+
+### 3. `distributed_emergence_packetization`
+
+**Typical family:** `Cp4`
+
+This mode tends to externalize through emergence-oriented packets centered on distributed interaction, coherence formation, and staged relational integration.
+
+Observed tendencies include:
+
+- neural coupling
+- concept maps
+- networks
+- murmurations
+- local-to-global emergence
+- self-organization
+- developmental cognition
+- embodied intuition
+
+Relative to `Cp`, this mode is usually less formal in the narrow geometric sense and more oriented toward **process, distributed interaction, and coherence formation over time**.
+
+**Canonical examples**
+- `Cp4:8`
+- `Cp4:17`
+- `Cp4:21`
+- `Cp4:24`
+
+**Useful shorthand**
+- emergence packet
+- local-rule packet
+- developmental cognition packet
+
+---
+
+## Canonical contrasts
+
+The family-level distinction becomes especially clear when compared across exemplars.
+
+### `C:49`
+- atlas-like
+- section-wise anchor blocks
+- architected progression across motifs
+
+### `Cp:49`
+- compact
+- formal
+- invariance/projection/embedding packet
+
+### `Cp4:24`
+- staged cognition packet
+- neural signal flow to concept mapping to embodied intuition
+
+Together these provide a useful cross-family contrast:
+- architected geometric staging
+- compact formal packetization
+- developmental emergence packetization
+
+---
+
+## Notes on data hygiene
+
+### `Cp:27`
+A previously copied specimen, `Cp:27`, was later checked in the Linux ChatGPT GUI and found to contain **no links in the original response**.
+
+It was therefore **removed** from the linked-response analysis set and should **not** be treated as a true linked specimen.
+
+This correction should be preserved in downstream documentation and summaries.
+
+---
+
+## Scope and limits
+
+The current result is intentionally narrow.
+
+### It does support
+- a family-structured interpretation of the linked-response subset
+- a stable working taxonomy for repository use
+- exemplar-based comparison across `C`, `Cp`, and `Cp4`
+
+### It does not yet support
+- cross-model generalization
+- claims about all responses rather than the linked subset
+- strong causal claims about why linking occurs
+- final quantitative claims about frequency, significance, or mechanism
+
+## Current working interpretation
+
+The safest current wording is:
+
+> In the GPT-5.2 corpus set, linked responses appear to exhibit family-structured modes of external witnessing. `C` favors geometric externalization, `Cp` favors compact formal-structural packetization, and `Cp4` favors distributed-emergence packetization.
+
+That is the level of claim this stage currently warrants.
+
+## Related artifacts
+
+See:
+- `linked_response_annotation_protocol.md`
+- `linked_response_artifacts.md`
+- the linked-response taxonomy bundle in `outputs/` or the equivalent artifact directory

--- a/docs/research_log.md
+++ b/docs/research_log.md
@@ -1034,3 +1034,77 @@ Introduces a two-stage instability discriminator combining seam-coupling persist
 Normalized from the extended OBS-051 entry; divergence formulation, group separation, and combined interpretation with OBS-050 preserved without modification.
 
 ---
+
+## OBS-052
+
+**Date:** 2026-05-01  
+**State:** Attractor basin mapping established from recurrence, boundedness, roughness, seam-drift, and recovery landing density
+
+**Claim:**  
+Recovery-like coupled windows preferentially land in seam-aligned, recurrent, bounded, low-drift node regions, forming a distinct alignment-sink basin class separate from a seam-far decoupled sink regime.
+
+**Summary:**  
+A first node-level attractor-basin analysis was constructed by integrating recurrence, local divergence, roughness, seam-drift, and recovery landing density into a composite attractor score. This extends the observatory from window-level instability analysis (OBS-050, OBS-051) to node-level landing structure, allowing recovery behavior to be studied as a geometric distribution over the manifold.
+
+The analysis identifies two stable basin classes. The alignment-sink class is characterized by higher attractor scores, lower divergence, lower roughness, and higher recovery landing density, and is predominantly seam-aligned. The decoupled-sink class is seam-far, with higher roughness and lower recovery favorability, though still recurrent. This establishes that recovery-like dynamics do not terminate uniformly, but preferentially accumulate in specific structured regions.
+
+Although numerical outputs vary across runs in exact node rankings and class sizes, the higher-level two-class basin structure remains stable. The result is therefore robust at the class level, even if individual node identities are not yet fixed. This supports a structured attractor interpretation rather than a single undifferentiated sink.
+
+Overall, the manifold now exhibits a first attractor-basin layer in which recovery-like bounded dynamics are linked to seam-aligned landing regions, while a contrasting seam-far recurrent regime coexists with weaker recovery association.
+
+**Operational consequence:**  
+Introduces a node-level attractor-basin instrument linking recovery behavior to landing geometry, enabling classification of nodes into seam-aligned and seam-far sink regimes based on composite dynamical and geometric features.
+
+**Recovery note:**  
+First-pass basin construction; class structure is stable but node-level rankings and exact statistics remain provisional pending run provenance stabilization.
+
+---
+
+## OBS-053
+
+**Date:** 2026-05-01  
+**State:** Family-structured external witnessing established in the GPT-5.2 linked-response subset
+
+**Claim:**  
+Link-bearing responses in the GPT-5.2 corpus exhibit a non-random, family-structured mode of external witnessing rather than incidental link insertion.
+
+**Summary:**  
+A qualitative, response-level analysis was conducted on the linked-response subset across corpora `C`, `Cp`, and `Cp4`, all generated under GPT-5.2. Each response was annotated using a structured taxonomy capturing family mode, packet structure, motifs, and witnessing role. This established a controlled observational basis for evaluating whether links function as structured elements rather than incidental additions.
+
+Three distinct family-level witnessing modes were identified. In `C`, links form geometric externalizations, organizing conceptual space through staged, often atlas-like constructions. In `Cp`, links appear as compact formal-structural packets, tightly aligned with the logical content of the prose. In `Cp4`, links operate as distributed-emergence packets, emphasizing coherence arising from interaction, network formation, and developmental structure.
+
+These patterns demonstrate that links act as external witnesses whose structure reflects the underlying discourse regime. The linked-response layer therefore preserves family distinctions not only in language but in how external conceptual material is selected, organized, and deployed.
+
+**Operational consequence:**  
+Establishes a response-level taxonomy for linked outputs and promotes the linked-response layer to a valid observatory surface, enabling structured annotation and cross-family comparison of external witnessing behavior.
+
+**Recovery note:**  
+Scope restricted to GPT-5.2 corpus stage; qualitative and annotation-backed; taxonomy and specimen set refined with provenance correction (e.g., removal of Cp:27).
+
+---
+
+## OBS-054
+
+**Date:** 2026-05-01  
+**State:** Linked-response taxonomy instrument consolidated at repository level
+
+**Claim:**  
+The linked-response study has matured into a stable, repository-level observatory instrument with defined ontology, artifacts, and method.
+
+**Summary:**  
+Following the establishment of family-structured external witnessing, the linked-response layer was formalized into a repository-ready instrument. A response-level taxonomy artifact was constructed with one row per linked response, capturing corpus identity, link structure, family mode, subtype, packet architecture, motifs, and interpretive annotations. This converts the stage from qualitative narrative into a structured and reusable dataset.
+
+A controlled vocabulary was stabilized across three family modes—geometric externalization, formal-structural packetization, and distributed-emergence packetization—along with a second layer of subtype labels. These vocabularies define the current ontology of external witnessing and enable consistent classification across the linked-response subset.
+
+Repository-facing documentation was produced to preserve the stage, including taxonomy definitions, annotation protocol, and artifact indexing. Scope constraints were explicitly frozen: the study is limited to GPT-5.2, applies only to the linked-response subset, and remains qualitative and annotation-backed. Provenance discipline was incorporated through explicit correction procedures, including removal of misclassified specimens.
+
+The result is a transition from conversational observation to a durable observatory layer with stable terminology, reproducible method, and preserved artifacts.
+
+**Operational consequence:**  
+Promotes the linked-response layer to a reusable research instrument, enabling structured analysis, comparison, and downstream quantitative or cross-layer integration without re-deriving the taxonomy.
+
+**Recovery note:**  
+Instrument is stable but provisional; lacks inter-rater validation, full statistical treatment, and cross-model generalization; scope explicitly limited to GPT-5.2 linked-response subset.
+
+---
+


### PR DESCRIPTION
## Summary

This PR adds the repository-facing markdown docs for the linked-response study stage and updates the research log accordingly.

## What’s included

### New docs
- `docs/05_project/linked_response_family_taxonomy.md`
- `docs/05_project/linked_response_annotation_protocol.md`
- `docs/05_project/linked_response_artifacts.md`

### Updated
- `docs/research_log.md`

## Why

The linked-response study has reached the point where the ontology and method need to be frozen in repo-facing form.

This PR preserves:

- the family-level taxonomy for linked responses
- the annotation protocol used for the links-only subset
- the artifact/index layer for downstream reuse
- the scope condition that this stage is based on **GPT-5.2** corpora
- the corrected provenance note that `Cp:27` was removed after GUI verification showed it was not truly link-bearing

## Main repository-level result captured here

For the verified linked-response subset:

- `C` → `geometric_externalization`
- `Cp` → `formal_structural_packetization`
- `Cp4` → `distributed_emergence_packetization`

These docs are intentionally framed as:
- within-model
- annotation-backed
- provisional
- repository-facing

## Notes

- This PR is documentation and observatory-stage consolidation, not a new study script PR.
- The linked-response artifact bundle itself is treated as an output artifact rather than committed prose.
- Observatory numbering has been corrected so that the attractor-basin study remains `OBS-052`, and the linked-response notes shift forward accordingly.

## Follow-up

A likely next step is a lightweight quantitative pass over the patched linked-response taxonomy tables.