### PR TITLE
fix: quench metrics for constant Cp2 trajectories

### DIFF
--- a/experiments/common_quench_metrics.py
+++ b/experiments/common_quench_metrics.py
@@ -5,7 +5,7 @@ from pam.corpora import texts_C, texts_Cp, texts_Cp2, texts_Cp3, texts_Cp4
 from pam.types import RunParams
 from pam.engine.core import run_quench
 from pam.metrics.entropy import compute_entropy_series
-from pam.metrics.macrostate import sliding_piF, macrostate_from_microstructure
+from pam.metrics.macrostate import sliding_piF
 from pam.metrics.lag import smooth, lag_corr
 from pam.metrics.regression import granger_delta_r2, fit_minimal_models
 from pam.measurement.builders import build_injector, build_tip, macro_fn_factory
@@ -20,11 +20,52 @@ CORPORA = {
 }
 
 
+def safe_lag_corr(x, y, *, max_lag: int = 80):
+    """
+    Compute lag correlation while tolerating correlation-degenerate trajectories.
+
+    Some valid corpus / parameter regimes can produce a constant freeze series,
+    constant entropy series, or otherwise all-NaN lag correlations. Those runs
+    should still write trajectories and index rows. In that case, return the
+    standard lag grid, NaN correlations, neutral best_lag=0, and best_corr=NaN.
+    """
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+
+    lags_fallback = np.arange(-max_lag, max_lag + 1, dtype=int)
+    corrs_fallback = np.full(lags_fallback.shape, np.nan, dtype=float)
+
+    if x.size == 0 or y.size == 0:
+        return lags_fallback, corrs_fallback, 0, np.nan
+
+    m = min(x.size, y.size)
+    x = x[:m]
+    y = y[:m]
+
+    finite = np.isfinite(x) & np.isfinite(y)
+    if finite.sum() < 3:
+        return lags_fallback, corrs_fallback, 0, np.nan
+
+    if np.nanstd(x[finite]) <= 0.0 or np.nanstd(y[finite]) <= 0.0:
+        return lags_fallback, corrs_fallback, 0, np.nan
+
+    try:
+        return lag_corr(x, y, max_lag=max_lag)
+    except ValueError as exc:
+        if "All-NaN slice encountered" not in str(exc):
+            raise
+        return lags_fallback, corrs_fallback, 0, np.nan
+
+
 def run_one_seed(*, seed: int, texts0, tip, mix_inj, params: RunParams, alpha: float, W: int):
     params_seed = type(params)(
-        alpha=params.alpha, r=params.r, seed=seed, iters=params.iters,
+        alpha=params.alpha,
+        r=params.r,
+        seed=seed,
+        iters=params.iters,
         anchor_set_size=params.anchor_set_size,
-        store_snapshots=True, store_every=1
+        store_snapshots=True,
+        store_every=1,
     )
 
     result = run_quench(
@@ -40,7 +81,12 @@ def run_one_seed(*, seed: int, texts0, tip, mix_inj, params: RunParams, alpha: f
     corp_snaps = result.corp_snapshots
     states = result.states
 
-    entropy_reports = compute_entropy_series(corp_snaps, tip, anchor_set_size=params_seed.anchor_set_size, sample_every=1)
+    entropy_reports = compute_entropy_series(
+        corp_snaps,
+        tip,
+        anchor_set_size=params_seed.anchor_set_size,
+        sample_every=1,
+    )
     H_joint = np.array([r.H_joint for r in entropy_reports], dtype=float)
     K = np.array([r.K for r in entropy_reports], dtype=float)
 
@@ -57,7 +103,7 @@ def run_one_seed(*, seed: int, texts0, tip, mix_inj, params: RunParams, alpha: f
     pi = pi[:m]
     Hs = Hs[:m]
 
-    lags, corrs, best_lag, best_corr = lag_corr(pi, Hs, max_lag=80)
+    lags, corrs, best_lag, best_corr = safe_lag_corr(pi, Hs, max_lag=80)
     idx0 = int(np.where(np.array(lags) == 0)[0][0])
     corr0 = float(corrs[idx0])
 
@@ -87,7 +133,12 @@ def run_one(*, texts0, tip, mix_inj, params: RunParams, alpha: float, W: int):
     corp_snaps = result.corp_snapshots
     states = result.states
 
-    entropy_reports = compute_entropy_series(corp_snaps, tip, anchor_set_size=params.anchor_set_size, sample_every=1)
+    entropy_reports = compute_entropy_series(
+        corp_snaps,
+        tip,
+        anchor_set_size=params.anchor_set_size,
+        sample_every=1,
+    )
     H_joint = np.array([r.H_joint for r in entropy_reports], dtype=float)
     H_marg = np.array([r.H_marginal for r in entropy_reports], dtype=float)
     K = np.array([r.K for r in entropy_reports], dtype=float)
@@ -108,7 +159,7 @@ def run_one(*, texts0, tip, mix_inj, params: RunParams, alpha: float, W: int):
     pi = sliding_piF(states, W=W)
     Hj_sm = smooth(H_joint, W=W)
     m = min(len(pi), len(Hj_sm))
-    lags, corrs, best_lag, best_corr = lag_corr(pi[:m], Hj_sm[:m], max_lag=80)
+    lags, corrs, best_lag, best_corr = safe_lag_corr(pi[:m], Hj_sm[:m], max_lag=80)
 
     return {
         "states": states,
@@ -122,9 +173,13 @@ def run_one(*, texts0, tip, mix_inj, params: RunParams, alpha: float, W: int):
         "deltas_H": deltas_H,
         "models_MI": models_MI,
         "deltas_MI": deltas_MI,
-        "lag": {"best_lag": int(best_lag), "best_corr": float(best_corr)},
+        "lag": {
+            "best_lag": int(best_lag),
+            "best_corr": float(best_corr),
+        },
     }
-   
+
+
 def run_one_summary(
     *,
     texts0,
@@ -190,7 +245,7 @@ def run_one_summary(
     pi = pi[:m]
     Hj_sm = Hj_sm[:m]
 
-    lags, corrs, best_lag, best_corr = lag_corr(pi, Hj_sm, max_lag=80)
+    lags, corrs, best_lag, best_corr = safe_lag_corr(pi, Hj_sm, max_lag=80)
     idx0 = int(np.where(np.array(lags) == 0)[0][0])
     corr0 = float(corrs[idx0])
 


### PR DESCRIPTION
Summary

This PR fixes experiments/common_quench_metrics.py so batch trajectory generation can complete for corpora whose freeze series has zero variance.

The immediate blocker was Cp2 trajectory generation failing with:

ValueError: All-NaN slice encountered

The failure occurred when lag_corr(pi, Hj_sm, max_lag=80) produced an all-NaN correlation vector. For Cp2 at low-r / low-alpha, the run can remain entirely non-frozen:

piF_mean = 0.0
piF_tail = 0.0

In that regime, the sliding freeze series is constant, so lag correlation is undefined. That is a valid scientific outcome, not a failed trajectory.

What changed

This PR makes common_quench_metrics.py robust to degenerate but valid time series.

It preserves trajectory and index output even when lag correlation or regression diagnostics are undefined.

The patched behavior is:

corr0 = nan
best_corr = nan
best_lag = 0
delta_r2_freeze = nan
delta_r2_entropy = 0.0

for the observed Cp2 constant-freeze case.

The trajectory artifact is still written with finite core arrays:

F_raw
H_joint
K
pi
Hj_sm
lags
corrs

where corrs may be all-NaN to honestly represent undefined correlations.

Scientific interpretation

This does not change the quench dynamics or redefine the observables.

It only changes failure handling for mathematically undefined summary statistics.

A constant freeze field has no variance, so Pearson-style lag correlation is undefined. In compact notation:

\operatorname{Var}(\pi_F) = 0
\quad\Rightarrow\quad
\operatorname{corr}(\pi_F, H) \text{ is undefined.}

That should be recorded as nan, not promoted to a runtime exception.

Validation

Single Cp2 job now completes:

PYTHONPATH=src:experiments .venv/bin/python - <<'PY'
from experiments.exp_batch import run_one_job
meta, summary = run_one_job(
    ("Cp2", 0.10, 0.03, 300, 30, 0),
    "outputs/corpora/Cp2/campaigns/debug_v3"
)
print(meta)
print(summary)
PY

Observed summary:

piF_mean: 0.0
piF_tail: 0.0
H_joint_mean: 0.5925255054469006
var_H_joint: 0.2811385092611588
K_min: 1.0
K_max: 7.0
corr0: nan
delta_r2_freeze: nan
delta_r2_entropy: 0.0
best_lag: 0
best_corr: nan

Trajectory file was written successfully:

outputs/corpora/Cp2/campaigns/debug_v3/trajectories/traj_Cp2_r0.100_a0.030000_seed0.npz

Smoke batch also completes:

PYTHONPATH=src:experiments .venv/bin/python experiments/exp_batch.py \
  --corpus-key Cp2 \
  --campaign smoke_v2 \
  --max-workers 2 \
  --max-jobs 2

Observed outputs:

done: 2
failed: 0
index.csv written
trajectories written

Next step

After merging, start a fresh Cp2 full campaign, preferably as full_v2, rather than resuming the old full_v1 manifest that contains failed/running states from the previous crash behavior.