### PR TITLE
infra: add ChromaDB indexing and DuckDB artifact registry tools

### DIFF
--- a/tools/build_artifact_registry_duckdb.py
+++ b/tools/build_artifact_registry_duckdb.py
@@ -1,0 +1,489 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+from pathlib import Path
+
+import duckdb
+import pandas as pd
+
+
+ARTIFACT_SUFFIXES = {".csv", ".json", ".md", ".npz", ".npy"}
+
+
+def sha1_file(path: Path, max_bytes: int | None = None) -> str:
+    h = hashlib.sha1()
+    with path.open("rb") as f:
+        if max_bytes is None:
+            for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                h.update(chunk)
+        else:
+            h.update(f.read(max_bytes))
+    return h.hexdigest()
+
+
+def csv_shape_and_columns(path: Path) -> tuple[int | None, list[str]]:
+    try:
+        with path.open("r", encoding="utf-8", errors="replace", newline="") as f:
+            reader = csv.reader(f)
+            header = next(reader, [])
+            rows = sum(1 for _ in reader)
+        return rows, header
+    except Exception:
+        return None, []
+
+
+def infer_obs_id(path: Path) -> str | None:
+    for part in path.parts:
+        lower = part.lower()
+        if lower.startswith("obs") and len(lower) >= 6:
+            token = lower.split("_")[0]
+            if len(token) >= 6 and token[3:6].isdigit():
+                return f"OBS-{token[3:6]}"
+
+    name = path.name.lower()
+    if name.startswith("obs") and len(name) >= 6 and name[3:6].isdigit():
+        return f"OBS-{name[3:6]}"
+
+    return None
+
+
+def infer_campaign_from_path(path: Path) -> tuple[str | None, str | None, str]:
+    """
+    Return (corpus, campaign, layout).
+
+    Supported layouts:
+
+    New campaign layout:
+      outputs/corpora/<corpus>/campaigns/<campaign>/...
+
+    Legacy/root layout:
+      outputs/index.csv
+      outputs/trajectories/*.npz
+
+    Legacy corpus/campaign are assigned later from CLI args because they are not
+    encoded in the root paths themselves.
+    """
+    parts = list(path.parts)
+
+    try:
+        i = parts.index("corpora")
+        if parts[i + 2] == "campaigns":
+            return parts[i + 1], parts[i + 3], "campaign"
+    except Exception:
+        pass
+
+    if "trajectories" in parts or path.name == "index.csv":
+        # Could be legacy or campaign; campaign would have matched above.
+        return None, None, "legacy_or_unknown"
+
+    return None, None, "unknown"
+
+
+def should_scan_artifact(path: Path) -> bool:
+    if not path.is_file():
+        return False
+    if path.suffix not in ARTIFACT_SUFFIXES:
+        return False
+    if any(part in {".git", ".venv", "__pycache__", "node_modules"} for part in path.parts):
+        return False
+    return True
+
+
+def scan_artifacts(
+    root: Path,
+    *,
+    legacy_corpus: str | None,
+    legacy_campaign: str | None,
+) -> pd.DataFrame:
+    rows = []
+
+    for path in root.rglob("*"):
+        if not should_scan_artifact(path):
+            continue
+
+        corpus, campaign, layout = infer_campaign_from_path(path)
+
+        # Assign root-layout outputs/index.csv and outputs/trajectories to the
+        # explicitly declared legacy corpus/campaign.
+        if layout == "legacy_or_unknown":
+            try:
+                rel_to_root = path.relative_to(root)
+                if (
+                    rel_to_root.parts == ("index.csv",)
+                    or len(rel_to_root.parts) >= 2
+                    and rel_to_root.parts[0] == "trajectories"
+                ):
+                    corpus = legacy_corpus
+                    campaign = legacy_campaign
+                    layout = "legacy_root"
+            except Exception:
+                pass
+
+        csv_rows, cols = (None, [])
+        if path.suffix == ".csv":
+            csv_rows, cols = csv_shape_and_columns(path)
+
+        rows.append(
+            {
+                "path": str(path),
+                "suffix": path.suffix,
+                "size_bytes": path.stat().st_size,
+                "modified_at": path.stat().st_mtime,
+                "sha1_head": sha1_file(path, max_bytes=1024 * 1024),
+                "obs_id": infer_obs_id(path),
+                "corpus": corpus,
+                "campaign": campaign,
+                "layout": layout,
+                "rows": csv_rows,
+                "columns_json": json.dumps(cols),
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+def load_campaign_runs(outputs_root: Path) -> pd.DataFrame:
+    """
+    Load progress snapshots from new campaign layout.
+    """
+    rows = []
+
+    for progress in outputs_root.glob("corpora/*/campaigns/*/manifests/*_progress.json"):
+        try:
+            data = json.loads(progress.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+
+        root = Path(data.get("root", ""))
+        corpus = None
+        campaign = None
+
+        parts = list(root.parts)
+        try:
+            i = parts.index("corpora")
+            if parts[i + 2] == "campaigns":
+                corpus = parts[i + 1]
+                campaign = parts[i + 3]
+        except Exception:
+            pass
+
+        traj_dir = root / "trajectories"
+        trajectory_count = len(list(traj_dir.glob("*.npz"))) if traj_dir.exists() else 0
+
+        index_path = root / "index.csv"
+        index_rows = None
+        if index_path.exists():
+            index_rows, _ = csv_shape_and_columns(index_path)
+
+        rows.append(
+            {
+                "corpus": corpus,
+                "campaign": campaign,
+                "layout": "campaign",
+                "root": str(root),
+                "run_name": data.get("run_name"),
+                "host": data.get("host"),
+                "pid": data.get("pid"),
+                "updated_at": data.get("updated_at"),
+                "total": data.get("total"),
+                "done": data.get("done"),
+                "failed": data.get("failed"),
+                "running": data.get("running"),
+                "pending": data.get("pending"),
+                "percent": data.get("percent"),
+                "elapsed_sec": data.get("elapsed_sec"),
+                "throughput_jobs_per_min": data.get("throughput_jobs_per_min"),
+                "eta_sec": data.get("eta_sec"),
+                "last_completed": data.get("last_completed"),
+                "last_error": data.get("last_error"),
+                "trajectory_count": trajectory_count,
+                "index_rows": index_rows,
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+def load_legacy_campaign_run(
+    outputs_root: Path,
+    *,
+    legacy_corpus: str | None,
+    legacy_campaign: str | None,
+) -> pd.DataFrame:
+    """
+    Register root-layout legacy campaign:
+
+      outputs/index.csv
+      outputs/trajectories/*.npz
+
+    This supports older C/Cp canonical runs that predate the campaign namespace.
+    """
+    if not legacy_corpus or not legacy_campaign:
+        return pd.DataFrame()
+
+    index_path = outputs_root / "index.csv"
+    traj_dir = outputs_root / "trajectories"
+
+    if not index_path.exists() and not traj_dir.exists():
+        return pd.DataFrame()
+
+    index_rows = None
+    if index_path.exists():
+        index_rows, _ = csv_shape_and_columns(index_path)
+
+    trajectory_count = len(list(traj_dir.glob("*.npz"))) if traj_dir.exists() else 0
+
+    # Infer total/done from index rows where possible.
+    done = index_rows if index_rows is not None else trajectory_count
+    total = done
+
+    row = {
+        "corpus": legacy_corpus,
+        "campaign": legacy_campaign,
+        "layout": "legacy_root",
+        "root": str(outputs_root),
+        "run_name": f"{legacy_corpus}_{legacy_campaign}",
+        "host": None,
+        "pid": None,
+        "updated_at": None,
+        "total": total,
+        "done": done,
+        "failed": None,
+        "running": None,
+        "pending": None,
+        "percent": 1.0 if done is not None else None,
+        "elapsed_sec": None,
+        "throughput_jobs_per_min": None,
+        "eta_sec": None,
+        "last_completed": None,
+        "last_error": None,
+        "trajectory_count": trajectory_count,
+        "index_rows": index_rows,
+    }
+
+    return pd.DataFrame([row])
+
+
+def load_index_metrics_campaign_layout(outputs_root: Path) -> pd.DataFrame:
+    frames = []
+
+    for index_path in outputs_root.glob("corpora/*/campaigns/*/index.csv"):
+        try:
+            df = pd.read_csv(index_path)
+        except Exception:
+            continue
+
+        parts = list(index_path.parts)
+        corpus = None
+        campaign = None
+        try:
+            i = parts.index("corpora")
+            if parts[i + 2] == "campaigns":
+                corpus = parts[i + 1]
+                campaign = parts[i + 3]
+        except Exception:
+            pass
+
+        df.insert(0, "layout", "campaign")
+        df.insert(0, "campaign", campaign)
+        df.insert(0, "corpus_root", corpus)
+        df.insert(0, "index_path", str(index_path))
+        frames.append(df)
+
+    if not frames:
+        return pd.DataFrame()
+
+    return pd.concat(frames, ignore_index=True)
+
+
+def load_index_metrics_legacy_layout(
+    outputs_root: Path,
+    *,
+    legacy_corpus: str | None,
+    legacy_campaign: str | None,
+) -> pd.DataFrame:
+    if not legacy_corpus or not legacy_campaign:
+        return pd.DataFrame()
+
+    index_path = outputs_root / "index.csv"
+    if not index_path.exists():
+        return pd.DataFrame()
+
+    try:
+        df = pd.read_csv(index_path)
+    except Exception:
+        return pd.DataFrame()
+
+    # Do not overwrite the original corpus column if present. Add corpus_root
+    # and campaign as registry metadata.
+    df.insert(0, "layout", "legacy_root")
+    df.insert(0, "campaign", legacy_campaign)
+    df.insert(0, "corpus_root", legacy_corpus)
+    df.insert(0, "index_path", str(index_path))
+
+    return df
+
+
+def load_all_campaign_runs(
+    outputs_root: Path,
+    *,
+    legacy_corpus: str | None,
+    legacy_campaign: str | None,
+) -> pd.DataFrame:
+    frames = [
+        load_campaign_runs(outputs_root),
+        load_legacy_campaign_run(
+            outputs_root,
+            legacy_corpus=legacy_corpus,
+            legacy_campaign=legacy_campaign,
+        ),
+    ]
+    frames = [f for f in frames if not f.empty]
+    if not frames:
+        return pd.DataFrame()
+    return pd.concat(frames, ignore_index=True)
+
+
+def load_all_index_metrics(
+    outputs_root: Path,
+    *,
+    legacy_corpus: str | None,
+    legacy_campaign: str | None,
+) -> pd.DataFrame:
+    frames = [
+        load_index_metrics_campaign_layout(outputs_root),
+        load_index_metrics_legacy_layout(
+            outputs_root,
+            legacy_corpus=legacy_corpus,
+            legacy_campaign=legacy_campaign,
+        ),
+    ]
+    frames = [f for f in frames if not f.empty]
+    if not frames:
+        return pd.DataFrame()
+    return pd.concat(frames, ignore_index=True)
+
+
+def normalize_empty_frame(df: pd.DataFrame, columns: list[str]) -> pd.DataFrame:
+    if not df.empty:
+        return df
+    return pd.DataFrame(columns=columns)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--outputs-root", default="outputs")
+    ap.add_argument("--db", default="metadata/pam_artifacts.duckdb")
+    ap.add_argument(
+        "--legacy-corpus",
+        default=None,
+        help=(
+            "Corpus label for legacy root-layout artifacts at outputs/index.csv "
+            "and outputs/trajectories/*.npz, e.g. C or Cp."
+        ),
+    )
+    ap.add_argument(
+        "--legacy-campaign",
+        default="canonical_legacy",
+        help="Campaign label for legacy root-layout artifacts.",
+    )
+    args = ap.parse_args()
+
+    outputs_root = Path(args.outputs_root)
+    db_path = Path(args.db)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    artifact_df = scan_artifacts(
+        outputs_root,
+        legacy_corpus=args.legacy_corpus,
+        legacy_campaign=args.legacy_campaign if args.legacy_corpus else None,
+    )
+
+    campaigns_df = load_all_campaign_runs(
+        outputs_root,
+        legacy_corpus=args.legacy_corpus,
+        legacy_campaign=args.legacy_campaign if args.legacy_corpus else None,
+    )
+
+    index_df = load_all_index_metrics(
+        outputs_root,
+        legacy_corpus=args.legacy_corpus,
+        legacy_campaign=args.legacy_campaign if args.legacy_corpus else None,
+    )
+
+    artifact_df = normalize_empty_frame(
+        artifact_df,
+        [
+            "path",
+            "suffix",
+            "size_bytes",
+            "modified_at",
+            "sha1_head",
+            "obs_id",
+            "corpus",
+            "campaign",
+            "layout",
+            "rows",
+            "columns_json",
+        ],
+    )
+
+    campaigns_df = normalize_empty_frame(
+        campaigns_df,
+        [
+            "corpus",
+            "campaign",
+            "layout",
+            "root",
+            "run_name",
+            "host",
+            "pid",
+            "updated_at",
+            "total",
+            "done",
+            "failed",
+            "running",
+            "pending",
+            "percent",
+            "elapsed_sec",
+            "throughput_jobs_per_min",
+            "eta_sec",
+            "last_completed",
+            "last_error",
+            "trajectory_count",
+            "index_rows",
+        ],
+    )
+
+    con = duckdb.connect(str(db_path))
+    con.execute("create or replace table artifact_files as select * from artifact_df")
+    con.execute("create or replace table campaign_runs as select * from campaigns_df")
+    con.execute("create or replace table index_metrics as select * from index_df")
+
+    print("wrote", db_path)
+    print("artifact_files:", len(artifact_df))
+    print("campaign_runs:", len(campaigns_df))
+    print("index_metrics:", len(index_df))
+
+    if len(campaigns_df):
+        print()
+        print(
+            con.execute(
+                """
+                select corpus, campaign, layout, done, failed, pending,
+                       trajectory_count, index_rows
+                from campaign_runs
+                order by corpus, campaign, layout
+                """
+            )
+            .fetchdf()
+            .to_string(index=False)
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/index_chromadb_pam.py
+++ b/tools/index_chromadb_pam.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+
+import chromadb
+from chromadb.utils import embedding_functions
+
+
+INCLUDE_SUFFIXES = {".md", ".py", ".json"}
+EXCLUDE_PARTS = {
+    ".git", ".venv", "__pycache__", ".mypy_cache", ".pytest_cache",
+    "outputs", "node_modules",
+}
+
+
+def should_index(path: Path) -> bool:
+    if path.suffix not in INCLUDE_SUFFIXES:
+        return False
+    if any(part in EXCLUDE_PARTS for part in path.parts):
+        return False
+    if path.stat().st_size > 300_000:
+        return False
+    return True
+
+
+def chunk_text(text: str, max_chars: int = 2400, overlap: int = 300) -> list[str]:
+    text = text.replace("\r\n", "\n")
+    chunks = []
+    start = 0
+    while start < len(text):
+        end = min(len(text), start + max_chars)
+        chunk = text[start:end].strip()
+        if chunk:
+            chunks.append(chunk)
+        if end == len(text):
+            break
+        start = max(0, end - overlap)
+    return chunks
+
+
+def stable_id(path: Path, chunk_index: int, text: str) -> str:
+    h = hashlib.sha1()
+    h.update(str(path).encode("utf-8"))
+    h.update(str(chunk_index).encode("utf-8"))
+    h.update(text.encode("utf-8"))
+    return h.hexdigest()
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".")
+    ap.add_argument("--host", default="localhost")
+    ap.add_argument("--port", type=int, default=8000)
+    ap.add_argument("--collection", default="pam_docs_code_v1")
+    ap.add_argument("--reset", action="store_true")
+    args = ap.parse_args()
+
+    root = Path(args.root).resolve()
+
+    client = chromadb.HttpClient(host=args.host, port=args.port)
+
+    if args.reset:
+        try:
+            client.delete_collection(args.collection)
+        except Exception:
+            pass
+
+    embedder = embedding_functions.DefaultEmbeddingFunction()
+
+    collection = client.get_or_create_collection(
+        name=args.collection,
+        embedding_function=embedder,
+        metadata={"project": "pam-research", "kind": "docs_code"},
+    )
+
+    ids = []
+    docs = []
+    metas = []
+
+    files = [p for p in root.rglob("*") if p.is_file() and should_index(p)]
+    files.sort()
+
+    for path in files:
+        rel = path.relative_to(root)
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for i, chunk in enumerate(chunk_text(text)):
+            ids.append(stable_id(rel, i, chunk))
+            docs.append(chunk)
+            metas.append(
+                {
+                    "path": str(rel),
+                    "chunk_index": i,
+                    "suffix": path.suffix,
+                    "bytes": path.stat().st_size,
+                }
+            )
+
+            if len(ids) >= 100:
+                collection.upsert(ids=ids, documents=docs, metadatas=metas)
+                ids, docs, metas = [], [], []
+
+    if ids:
+        collection.upsert(ids=ids, documents=docs, metadatas=metas)
+
+    print("indexed files:", len(files))
+    print("collection count:", collection.count())
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/query_chromadb_pam.py
+++ b/tools/query_chromadb_pam.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+
+import chromadb
+from chromadb.utils import embedding_functions
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("query", nargs="+")
+    ap.add_argument("--host", default=os.environ.get("CHROMA_HOST", "localhost"))
+    ap.add_argument("--port", type=int, default=int(os.environ.get("CHROMA_PORT", "8000")))
+    ap.add_argument("--collection", default="pam_docs_code_v1")
+    ap.add_argument("--n", type=int, default=5)
+    ap.add_argument("--chars", type=int, default=900)
+    args = ap.parse_args()
+
+    query = " ".join(args.query)
+
+    client = chromadb.HttpClient(host=args.host, port=args.port)
+    collection = client.get_collection(
+        args.collection,
+        embedding_function=embedding_functions.DefaultEmbeddingFunction(),
+    )
+
+    res = collection.query(query_texts=[query], n_results=args.n)
+
+    print("QUERY:", query)
+    print("COLLECTION:", args.collection)
+
+    for i, (doc, meta, dist) in enumerate(
+        zip(res["documents"][0], res["metadatas"][0], res["distances"][0]),
+        start=1,
+    ):
+        print("\n" + "=" * 80)
+        print(f"{i}. distance={dist:.6g}")
+        print(f"path={meta.get('path')} chunk={meta.get('chunk_index')}")
+        print("-" * 80)
+        print(doc[: args.chars])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR adds the first local infrastructure tools for PAM research recall and artifact indexing.

It introduces:

- `tools/index_chromadb_pam.py` for indexing repo docs/code/metadata into a remote or local ChromaDB server.
- `tools/query_chromadb_pam.py` for lightweight semantic retrieval from the ChromaDB collection.
- `tools/build_artifact_registry_duckdb.py` for scanning PAM output artifacts, campaign indexes, manifests, and trajectory counts into a DuckDB registry.
- `.gitignore` updates for generated local registry/database artifacts.

## Motivation

The repository is now large enough that research recall and artifact tracking need dedicated support.

ChromaDB provides semantic retrieval over docs/code/provenance notes, while DuckDB provides structured inspection of outputs, campaign state, indexes, schemas, and artifact metadata.

## Scope

This PR adds tooling only. It does not add generated ChromaDB indexes, DuckDB databases, or registry exports to the repository.

## Supported layouts

The DuckDB registry tool supports:

- current campaign layout:
  `outputs/corpora/<corpus>/campaigns/<campaign>/...`
- legacy/root layout:
  `outputs/index.csv`
  `outputs/trajectories/*.npz`

This allows legacy C/Cp outputs and newer campaign outputs such as Cp2 `full_v2` to be indexed consistently.

## Guardrails

- Generated `.duckdb`, WAL, and registry export artifacts are ignored.
- Large raw outputs and trajectories are not committed.
- ChromaDB is used as a semantic recall layer, not as the source of truth.
- DuckDB is used as a local/derived artifact registry, not as a replacement for file-first artifacts.